### PR TITLE
Add "inner" property to wrapped native errors

### DIFF
--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -84,6 +84,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
   request(options, function onRequestResult(err, response, body) {
     if (err) {
       var wrapper = new Error('Unable to execute http request ' + req + ': ' + err.message);
+      wrapper.inner = err;
       return callback(wrapper, null);
     }
 

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -71,6 +71,7 @@ describe('ds:', function () {
 
         reqExec.execute({uri: uri}, cbSpy);
       });
+
       it('should return resource error in case of incorrect request', function (done) {
         var cbSpy;
         var uri = 'https://api.stormpath.com/v1/test';
@@ -78,6 +79,25 @@ describe('ds:', function () {
         nock(uri).get('/v1/test').reply(400, res);
         function cb(err, body) {
           err.should.be.an.instanceof(ResourceError);
+          expect(body).to.be.null;
+          cbSpy.should.have.been.calledOnce;
+          done();
+        }
+        cbSpy = sinon.spy(cb);
+
+        reqExec.execute({uri: uri, method:'GET'}, cbSpy);
+      });
+
+      it('should include the original request error in case of request error', function (done) {
+        var cbSpy;
+        // This triggers one of the possible http request errors
+        var uri = 'http://doesntexist/v1/test';
+
+        function cb(err, body) {
+          err.should.be.an.instanceof(Error);
+          err.should.have.property('inner')
+            .that.is.an.instanceof(Error)
+            .and.property('code', 'ENOTFOUND');
           expect(body).to.be.null;
           cbSpy.should.have.been.calledOnce;
           done();


### PR DESCRIPTION
When using the sdk, it sometimes happen that the request executor fails
for reason that are not API related. This fix adds the original request
error to the wrappedError to help the code to respond to it.

The wrapped error now contains a property "inner" that has the original error
