### PR TITLE
fixes for Tenant.verifyAccountEmail

### DIFF
--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -50,7 +50,13 @@ Tenant.prototype.verifyAccountEmail = function verifyAccountEmail(token, callbac
   var self = this;
   var href = "/accounts/emailVerificationTokens/" + token;
 
-  return self.dataStore.createResource(href, null /* no request body */, require('./Account'), callback);
+  return self.dataStore.createResource(href, null, null, function(err,result){
+    if(err){
+      callback(err);
+    }else{
+      self.dataStore.getResource(result.href,{nocache:true},require('./Account'),callback);
+    }
+  });
 };
 
 module.exports = Tenant;


### PR DESCRIPTION
Fixes #28 by:
- getting the account after we verify the token
- specifying a nocache query param to bypass the cache in the datastore
