### PR TITLE
In Node SDK, when using .save function, when a callback is not specified, we should not error

### DIFF
--- a/lib/ds/DataStore.js
+++ b/lib/ds/DataStore.js
@@ -6,6 +6,7 @@ var RequestExecutor = require('./RequestExecutor');
 var Resource = require('../resource/Resource');
 var InstanceResource = require('../resource/InstanceResource');
 var instantiate = require('../resource/ResourceFactory').instantiate;
+var noop = function (){};
 
 //Caching
 var CacheHandler = require('../cache/CacheHandler');
@@ -296,6 +297,7 @@ DataStore.prototype.createResource = function createResource(/* parentHref, [que
   var ctor = (args.length > 0 && (args[args.length -1] instanceof Function)) ? args.pop() : InstanceResource;
   var data = args.pop();
   var query = (args.length > 0) ? args.pop() : null;
+  callback = callback || noop;
 
   if (!utils.isAssignableFrom(InstanceResource, ctor)) {
     throw new Error("If specifying a constructor function, it must be for class equal to or a subclass of InstanceResource.");
@@ -328,6 +330,7 @@ DataStore.prototype.saveResource = function saveResource(resource, callback) {
   var _this = this;
 
   var href = utils.valueOf(resource.href);
+  callback = callback || noop;
 
   var request = {uri: href, method: 'POST', body: resource};
 
@@ -346,11 +349,9 @@ DataStore.prototype.saveResource = function saveResource(resource, callback) {
 };
 
 DataStore.prototype.deleteResource = function deleteResource(resource, callback) {
-
   var _this = this;
-
   var href = utils.valueOf(resource.href);
-
+  callback = callback || noop;
   //remove from cache:
   _this.cacheHandler.remove(href, utils.noop);
 


### PR DESCRIPTION
updated: create, delete, save Resource methods in DataStore switched to soft mode (callback is optional parameter)
