### PR TITLE
fix: getAccount error causes undefined object error

### DIFF
--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -169,12 +169,16 @@ Application.prototype.getAccount = function getAccount(/* providerData, [options
 
   var w = function getAccountCallbackWrapper(callback){
     return function(err, account){
-      var isNew = account._isNew;
-      delete account._isNew;
-      callback(err, {
-        account: account,
-        created: isNew
-      });
+      if(err){
+        callback(err);
+      }else{
+        var isNew = account._isNew;
+        delete account._isNew;
+        callback(err, {
+          account: account,
+          created: isNew
+        });
+      }
     };
   };
 


### PR DESCRIPTION
previously we would try to read account, which is undefined if
there is an error
