### PR TITLE
remove requirement that api auth requests be GET or POST

### DIFF
--- a/lib/authc/AuthRequestParser.js
+++ b/lib/authc/AuthRequestParser.js
@@ -12,9 +12,6 @@ function AuthRequestParser(request,locationsToSearch){
   if(typeof request.method !== 'string'){
     throw new ApiAuthRequestError('request must have a method property');
   }
-  // if((request.method !== 'GET')&&(request.method !== 'POST')){
-  //   throw new ApiAuthRequestError('request method must be GET or POST');
-  // }
   var req = request;
   var searchBody = locationsToSearch.indexOf('body') > -1;
   var searchHeader = locationsToSearch.indexOf('header') > -1;


### PR DESCRIPTION
this is not necessary though we do still require that oauth exchange
requests use POST, per the spec
