### PR TITLE
fixing error status codes for authenticateApiRequest

### DIFF
--- a/lib/authc/BasicApiAuthenticator.js
+++ b/lib/authc/BasicApiAuthenticator.js
@@ -16,7 +16,7 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
 
   self.application.getApiKey(self.id,function(err,apiKey){
     if(err){
-      callback(err);
+      callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
     }else{
       if(
         (apiKey.secret===self.secret) &&
@@ -25,7 +25,7 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
       ){
         callback(null,new AuthenticationResult(apiKey,self.application.dataStore));
       }else{
-        callback(new ApiAuthRequestError('Invalid Credentials'));
+        callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
       }
     }
   });

--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -31,7 +31,7 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
   var self = this;
   self.application.getApiKey(self.id,function(err,apiKey){
     if(err){
-      callback(err);
+      callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
     }else{
       if(
         (apiKey.secret===self.secret) &&
@@ -42,7 +42,7 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
         result.tokenResponse = self.buildTokenResponse(apiKey);
         callback(null,result);
       }else{
-        callback(new ApiAuthRequestError('Invalid Credentials'));
+        callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
       }
     }
   });

--- a/lib/authc/OauthAccessTokenAuthenticator.js
+++ b/lib/authc/OauthAccessTokenAuthenticator.js
@@ -10,7 +10,7 @@ function getJwt(token,secret){
     jwtObject = jwt.decode(token, secret);
   }
   catch(e){
-    return new ApiAuthRequestError('Cannot decode JWT: ' + e.message);
+    return new ApiAuthRequestError('access_token is invalid',401);
   }
   return jwtObject;
 }
@@ -23,7 +23,7 @@ function validateJwt(jwtObject){
     }
   }
   if(nowEpochSeconds()>jwtObject.exp){
-    return new ApiAuthRequestError('Token has expired');
+    return new ApiAuthRequestError('Token has expired', 401);
   }
   if(jwtObject.scope && typeof jwtObject.scope !== 'string'){
     return new ApiAuthRequestError('scope must be a string');
@@ -60,7 +60,7 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
   var self = this;
   self.application.getApiKey(self.apiKey,function(err,apiKey){
     if(err){
-      callback(err);
+      callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
     }else if(
       (apiKey.status==='ENABLED') &&
       (apiKey.account.status==='ENABLED')
@@ -74,7 +74,7 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
 
       callback(null,new AuthenticationResult(apiKey,self.application.dataStore));
     }else{
-      callback(new ApiAuthRequestError('Invalid Client Id'));
+      callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
     }
   });
 };

--- a/lib/error/ApiAuthRequestError.js
+++ b/lib/error/ApiAuthRequestError.js
@@ -1,11 +1,11 @@
 var utils  = require('../utils');
 
-function ApiAuthRequestError(message){
+function ApiAuthRequestError(message, statusCode){
   Error.call(this);
   Error.captureStackTrace(this, this.constructor);
   this.name='ApiAuthRequestError';
-  this.message = message;
-  this.statusCode = 400;
+  this.userMessage = this.message = message;
+  this.statusCode = statusCode || 400;
 }
 utils.inherits(ApiAuthRequestError, Error);
 

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -247,7 +247,9 @@ Application.prototype.getApiKey = function getApiKey(apiKeyId, options, callback
     }else if(result && result.items && result.items.length === 1 ){
       cb(null,result.items[0]);
     }else{
-      cb(new Error('ApiKey not found'));
+      var error = new Error('ApiKey not found');
+      error.status = 404;
+      cb(error);
     }
   });
 };

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -41,7 +41,7 @@ describe('Application.authenticateApiRequest',function(){
     });
   });
 
-  describe('with Authorization: Basic <key>:<secret>',function(){
+  describe('with Authorization: Basic <key>:<secret> (1)',function(){
 
     describe('with valid credentials',function(){
 
@@ -93,6 +93,7 @@ describe('Application.authenticateApiRequest',function(){
 
       it('should err',function(){
         assert.instanceOf(result[0],Error);
+        assert.equal(result[0].statusCode,401);
       });
 
       it('should not return an instance of AuthenticationResult',function(){
@@ -164,6 +165,7 @@ describe('Application.authenticateApiRequest',function(){
         describe('the authentication result',function(){
           it('should err',function(){
             assert.instanceOf(result[0],Error);
+            assert.equal(result[0].statusCode,400);
           });
 
           it('should not return an instance of AuthenticationResult',function(){
@@ -213,6 +215,35 @@ describe('Application.authenticateApiRequest',function(){
       });
     });
 
+  });
+
+  describe('with an invalid jwt value',function(){
+    var result;
+    before(function(done){
+
+      var requestObject = {
+        headers: {
+          'authorization': 'Bearer ' + 'this-is-not-a-valid-jwt-value'
+        },
+        method: 'GET',
+        url: '/some/resource'
+      };
+      app.authenticateApiRequest({
+        request: requestObject
+      },function(err,value){
+        result = [err,value];
+        done();
+      });
+    });
+    it('should err',function(){
+      assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,401);
+      assert.equal(result[0].message,'access_token is invalid');
+    });
+
+    it('should not return an instance of AuthenticationResult',function(){
+      assert.isUndefined(result[1]);
+    });
   });
 
   describe('with a previously issued access token',function(){
@@ -272,7 +303,11 @@ describe('Application.authenticateApiRequest',function(){
       describe('and access_token is tampered with',function(){
         var result;
         before(function(done){
-          var tamperedToken = accessToken.replace(/e/,'b');
+
+          var decodedAccessToken = jwt.decode(accessToken,
+            client._dataStore.requestExecutor.options.apiKey.secret,'HS256');
+          decodedAccessToken.scope += ' things-i-cant-have';
+          var tamperedToken = jwt.encode(decodedAccessToken,'not the same key','HS256');
           var requestObject = {
             headers: {
               'authorization': 'Bearer ' + tamperedToken
@@ -289,6 +324,8 @@ describe('Application.authenticateApiRequest',function(){
         });
         it('should err',function(){
           assert.instanceOf(result[0],Error);
+          assert.equal(result[0].statusCode,401);
+          assert.equal(result[0].message,'access_token is invalid');
         });
 
         it('should not return an instance of AuthenticationResult',function(){
@@ -341,6 +378,7 @@ describe('Application.authenticateApiRequest',function(){
         });
         it('should err',function(){
           assert.instanceOf(result[0],Error);
+          assert.equal(result[0].statusCode,400);
         });
 
         it('should not return an instance of AuthenticationResult',function(){
@@ -419,6 +457,8 @@ describe('Application.authenticateApiRequest',function(){
     });
     it('should err',function(){
       assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,401);
+      assert.equal(result[0].message,'Token has expired');
     });
 
     it('should not return an instance of AuthenticationResult',function(){
@@ -444,6 +484,7 @@ describe('Application.authenticateApiRequest',function(){
     });
     it('should err',function(){
       assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,400);
     });
 
     it('should not return an instance of AuthenticationResult',function(){
@@ -470,6 +511,7 @@ describe('Application.authenticateApiRequest',function(){
     });
     it('should err',function(){
       assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,400);
     });
 
     it('should not return an instance of AuthenticationResult',function(){
@@ -494,6 +536,7 @@ describe('Application.authenticateApiRequest',function(){
     });
     it('should err',function(){
       assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,400);
     });
 
     it('should not return an instance of AuthenticationResult',function(){
@@ -618,6 +661,7 @@ describe('Application.authenticateApiRequest',function(){
 
     it('should err',function(){
       assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,401);
     });
 
     it('should not return an instance of AuthenticationResult',function(){
@@ -663,6 +707,7 @@ describe('Application.authenticateApiRequest',function(){
 
     it('should err',function(){
       assert.instanceOf(result[0],Error);
+      assert.equal(result[0].statusCode,401);
     });
 
     it('should not return an instance of AuthenticationResult',function(){


### PR DESCRIPTION
previously we were issuing 400 for all errors that came out of this
method

now we are returning 401 for any error that indicates a problem
with the supplied credentials or token
