### PR TITLE
Updated CacheManager to only create one connection for Redis

### DIFF
--- a/lib/cache/CacheManager.js
+++ b/lib/cache/CacheManager.js
@@ -9,6 +9,7 @@ var Cache = require('./Cache');
  */
 function CacheManager() {
   var self = this;
+  self._redisStore = null;
   self.caches = {};
 
   Object.defineProperty(self, 'stats', {
@@ -21,8 +22,13 @@ function CacheManager() {
   });
 }
 
-CacheManager.prototype.createCache = function (region,options) {
-  this.caches[region] = new Cache(options);
+CacheManager.prototype.createCache = function (region, options) {
+    if (options.store.name === 'RedisStore') {
+      this._redisStore = this._redisStore || new Cache(options);
+      this.caches[region] = this._redisStore;
+    } else {
+      this.caches[region] = new Cache(options);
+    }
 };
 
 CacheManager.prototype.getCache = function (region) {


### PR DESCRIPTION
The CacheManager was creating a new Redis connection for every entry in the CACHE_REGION array. In the context of a Redis setup it would seem to make more sense to have a single connection. 
