### PR TITLE
Updated CacheManager to only create one connection to Redis

### DIFF
--- a/docs/app/views/client.md
+++ b/docs/app/views/client.md
@@ -208,25 +208,6 @@ var client = new stormpath.Client(options);
   </tbody>
 </table>
 
----
-
-
-<a name="customNonceStore"></a>
-### Custom Nonce Store
-
-If you are using the [ID Site Feature][] in your Stormpath implementation, the calls to
-[Application.createIdSiteUrl()](application#createIdSiteUrl) and [Application.handleIdSiteCallback()](application#handleIdSiteCallback)
-will make use of a nonce value to prevent replay attacks.  By default these nonces will be stored in a cache region in the client's data store.
-
-You may use your own Nonce Store by providing an interface object that we can use to communicate with it.  Your interface object must have these two methods:
-
-* `getNonce(nonceStringValue,callback)` - It will search your nonce store for the nonce value and then call the callback with with the `(err,value)` pattern, where `err` indicates a problem with the store and `value` is the found nonce or `null`
-* `putNonce(nonceStringValue,callback)` - It should place the nonce value in your nonce store and then call the callback with `(err)` where `err` is a store error or `null`
-
-You then pass this object to the stormpath client constructor as the `nonceStore` option.
-
----
-
 <a name="memory"></a>
 ### In Memory Cache
 
@@ -360,6 +341,15 @@ var cacheOptions = {
   tti: 300
 };
 
+// Or with an existing RedisClient connection:
+
+var cacheOptions = {
+  store: 'redis',
+  existingCache: <previously instantiated redis object>
+  ttl: 300,
+  tti: 300
+};
+
 var client = new stormpath.Client({
   apiKey: apiKey,
   cacheOptions: cacheOptions
@@ -383,7 +373,14 @@ var client = new stormpath.Client({
       <td><code>store</code></td>
       <td><code>string|function</code></td>
       <td>optional</td>
-      <td> Should be equal to string `'redis'` or reference to `RedisStore` constructor function.
+      <td> Should be equal to string `'redis'` or reference to `RedisStore` constructor function. Note - <b>required</b> with <code>existingCache</code>.
+      </td>
+    </tr>
+    <tr>
+      <td><code>existingCache</code></td>
+      <td><code>object</code></td>
+      <td>optional</td>
+      <td>An existing redis connection object created using the <a href="https://github.com/mranney/node_redis" target="_blank">node-redis</a> client. This parameter allows you to reuse an existing Redis connection from elsewhere in your application. <code>Connection</code> and <code>options</code> parameters will be ignored if this parameter is set. <code>Store</code> parameter must be set to `'redis'` if using this option.
       </td>
     </tr>
     <tr>
@@ -423,6 +420,23 @@ var client = new stormpath.Client({
     </tr>
   </tbody>
 </table>
+
+---
+
+
+<a name="customNonceStore"></a>
+### Custom Nonce Store
+
+If you are using the [ID Site Feature][] in your Stormpath implementation, the calls to
+[Application.createIdSiteUrl()](application#createIdSiteUrl) and [Application.handleIdSiteCallback()](application#handleIdSiteCallback)
+will make use of a nonce value to prevent replay attacks.  By default these nonces will be stored in a cache region in the client's data store.
+
+You may use your own Nonce Store by providing an interface object that we can use to communicate with it.  Your interface object must have these two methods:
+
+* `getNonce(nonceStringValue,callback)` - It will search your nonce store for the nonce value and then call the callback with with the `(err,value)` pattern, where `err` indicates a problem with the store and `value` is the found nonce or `null`
+* `putNonce(nonceStringValue,callback)` - It should place the nonce value in your nonce store and then call the callback with `(err)` where `err` is a store error or `null`
+
+You then pass this object to the stormpath client constructor as the `nonceStore` option.
 
 ---
 

--- a/lib/cache/CacheManager.js
+++ b/lib/cache/CacheManager.js
@@ -10,6 +10,7 @@ var Cache = require('./Cache');
 function CacheManager() {
   var self = this;
   self.caches = {};
+  self._existingStore = null;
 
   Object.defineProperty(self, 'stats', {
     get: function () {
@@ -22,7 +23,15 @@ function CacheManager() {
 }
 
 CacheManager.prototype.createCache = function (region,options) {
-  this.caches[region] = new Cache(options);
+    if (this._existingStore) {
+      this.caches[region] = this._existingStore;
+    } else {
+      var newCache = new Cache(options);
+      this.caches[region] = newCache;
+      if (newCache.store.constructor.name === 'RedisStore') {
+        this._existingStore = newCache;
+      }      
+    }
 };
 
 CacheManager.prototype.getCache = function (region) {

--- a/lib/cache/RedisStore.js
+++ b/lib/cache/RedisStore.js
@@ -13,7 +13,16 @@ var CacheEntry = require('./CacheEntry');
  */
 function RedisStore(opt){
   this._options = opt || {};
-  this.redis = RedisStore._createClient(opt);
+  if (opt.existingCache) {
+    if (opt.existingCache.constructor.name === 'RedisClient') {
+      this.redis = opt.existingCache;
+    } else {
+      throw new Error('Expecting an instance of RedisClient');
+    }
+  } else {
+    this.redis = RedisStore._createClient(opt);
+  }
+  this.redis = opt.existingCache || RedisStore._createClient(opt);
   this.redis.debug_mode = /redis/i.test(process.env.DEBUG);
 }
 

--- a/test/live/sp.cache.redisStore_live.js
+++ b/test/live/sp.cache.redisStore_live.js
@@ -2,14 +2,11 @@ var common = require('../common');
 var should = common.should;
 var random = common.random;
 
+var Redis = require('redis');
 var Cache = require('../../lib/cache/Cache');
 var RedisStore = require('../../lib/cache/RedisStore');
 
-describe('Cache module - live', function () {
-
-  describe('Redis cache store', function () {
-    var redisStore = new Cache(RedisStore);
-
+var redisActionTests = function(redisStore) {
     describe('set entry', function () {
       var key = 'key' + random();
       var val = 'val' + random();
@@ -107,6 +104,42 @@ describe('Cache module - live', function () {
         });
       });
     });
+};
 
+describe('Cache module - live', function () {
+
+  describe('Redis cache store', function () {
+    var redisStore = new Cache(RedisStore);
+
+    redisActionTests(redisStore);
+  });
+});
+
+describe('Cache module - live (existing redis instance)', function () {
+
+  describe('Redis cache store (existing instance)', function () {
+    var redis = Redis.createClient();
+    var options = {
+      store: RedisStore,
+      existingCache: redis
+    };
+    var incorrectOptions = {
+      store: RedisStore,
+      existingCache: 'not a redis instance'
+    };
+    var redisStore = new Cache(options);
+
+    redisActionTests(redisStore);
+
+    function createIncorrectRedisStore() {
+      var storeInstance = new Cache(incorrectOptions);
+      return storeInstance;  
+    }
+
+    it('should throw an error if passed an invalid redis instance', function (done) {
+      createIncorrectRedisStore.should.throw('Expecting an instance of RedisClient');
+      done();
+    });
+    
   });
 });


### PR DESCRIPTION
CacheHandler was creating a new Cache object (and connection) for all ten items in the CACHE_REGION array. If the cache is Redis, it seems unnecessary to create ten connections to the same instance, so I've modified CacheManager to point each region at the first Redis instance instead.