### PR TITLE
Removed two unnecessary cache roundtrips after a getAccount() call

### DIFF
--- a/lib/cache/Cache.js
+++ b/lib/cache/Cache.js
@@ -64,8 +64,10 @@ Cache.prototype.get = function (key, cb) {
     self.stats.hit();
     // what point to touch entry if we not updating cache store
     // will work for memory store but will not for redis store
-    entry.touch();
-    self.store.set(key, entry, function(){});
+    if (self.ttl !== self.tti) {
+      entry.touch();
+      self.store.set(key, entry, function(){});
+    }
     return cb(null, entry.value);
   });
 };

--- a/lib/ds/DataStore.js
+++ b/lib/ds/DataStore.js
@@ -59,8 +59,7 @@ function isResourceCtor(obj) {
   return obj && (obj instanceof Function) && utils.isAssignableFrom(Resource, obj);
 }
 
-DataStore.prototype._wrapGetResourceResponse =
-  function wrapGetResourceResponse(err, data, InstanceCtor, query, cb) {
+DataStore.prototype._wrapGetResourceResponse = function wrapGetResourceResponse(err, source, data, InstanceCtor, query, cb) {
   var _this = this;
   if (err) {
     return cb(err, null);
@@ -84,7 +83,9 @@ DataStore.prototype._wrapGetResourceResponse =
       cb(err,instance);
     });
   }else if(data && data.href){
-    _this.cacheHandler.put(data.href, instance, utils.noop);
+    if (source === 'request') {
+      _this.cacheHandler.put(data.href, instance, utils.noop);  
+    }
     return cb(null, instance);
   }else{
     return cb(null, instance);
@@ -274,7 +275,7 @@ DataStore.prototype.exec = function executeRequest(callback){
 
   function doRequest(){
     _this.requestExecutor.execute(request, function onGetResourceRequestResult(err, body) {
-      _this._wrapGetResourceResponse(err, body, ctor, query, callback);
+      _this._wrapGetResourceResponse(err, 'request', body, ctor, query, callback);
     });
   }
   if (
@@ -292,7 +293,7 @@ DataStore.prototype.exec = function executeRequest(callback){
 
   _this.cacheHandler.get(cacheKey, function onCacheResult(err, entry) {
     if (err || entry) {
-      _this._wrapGetResourceResponse(err, entry, ctor, query, callback);
+      _this._wrapGetResourceResponse(err, 'cache', entry, ctor, query, callback);
       return;
     }
 


### PR DESCRIPTION
The getAccount() call was resulting in two seemingly unnecessary cache roundtrips - the first where cache.ttl === cache tti (no need for a cache set operation to update the lastAccessedAt attribute in that case as ttl expiry would cover tti expiry), secondly in DataStore.prototype._wrapGetResourceResponse where data had been received from the cache rather than a request and therefore did not need to be immediately (re)cached.
