### PR TITLE
New token getter methods on AuthenticationResult

### DIFF
--- a/lib/authc/BasicApiAuthenticator.js
+++ b/lib/authc/BasicApiAuthenticator.js
@@ -4,7 +4,7 @@ var AuthenticationResult = require('../resource/AuthenticationResult');
 function BasicApiAuthenticator(application,authHeaderValue){
   var parts = new Buffer(authHeaderValue.replace(/Basic /i,''),'base64').toString('utf8').split(':');
   if(parts.length!==2){
-    return new ApiAuthRequestError('Invalid Authorization value');
+    return new ApiAuthRequestError('Invalid Authorization value',400);
   }
   this.application = application;
   this.id = parts[0];
@@ -23,7 +23,9 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
         (apiKey.status==='ENABLED') &&
         (apiKey.account.status==='ENABLED')
       ){
-        callback(null,new AuthenticationResult(apiKey,self.application.dataStore));
+        var authenticationResult = new AuthenticationResult(apiKey,self.application.dataStore);
+        authenticationResult.application = self.application;
+        callback(null,authenticationResult);
       }else{
         callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
       }

--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -10,7 +10,7 @@ function OAuthBasicExchangeAuthenticator(application,request,ttl,scopeFactory, r
   var parts = new Buffer(authValue,'base64').toString('utf8').split(':');
 
   if(parts.length!==2){
-    return new ApiAuthRequestError('Invalid Authorization value');
+    return new ApiAuthRequestError('Invalid Authorization value',400);
   }
   if(request.method!=='POST'){
     return new ApiAuthRequestError('Must use POST for token exchange, see http://tools.ietf.org/html/rfc6749#section-3.2');
@@ -39,6 +39,8 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
         (apiKey.account.status==='ENABLED')
       ){
         var result = new AuthenticationResult(apiKey,self.application.dataStore);
+        result.forApiKey = apiKey;
+        result.application = self.application;
         result.tokenResponse = self.buildTokenResponse(apiKey);
         callback(null,result);
       }else{

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -132,7 +132,20 @@ Application.prototype.authenticateAccount = function authenticateApplicationAcco
     loginAttempt.accountStore = accountStore;
   }
 
-  _this.dataStore.createResource(_this.loginAttempts.href, {expand: 'account'}, loginAttempt, AuthenticationResult, callback);
+  _this.dataStore.createResource(
+    _this.loginAttempts.href,
+    {expand: 'account'},
+    loginAttempt,
+    AuthenticationResult,
+    function(err,authenticationResult){
+      if(err){
+        callback(err);
+      }
+      else{
+        authenticationResult.application = _this;
+        callback(null,authenticationResult);
+      }
+  });
 };
 
 Application.prototype.sendPasswordResetEmail = function sendApplicationPasswordResetEmail(emailOrUsername, callback) {

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -345,6 +345,8 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
         authHeaderValue.replace(/Bearer /i,''),
         callback
       );
+    }else{
+      return callback(new ApiAuthRequestError('Invalid Authorization value',400));
     }
   }else if(accessToken){
     authenticator = new OauthAccessTokenAuthenticator(self, accessToken, callback);

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -29,8 +29,8 @@ AuthenticationResult.prototype.getJwt = function getJwt() {
   }).signWith('HS256',self.application.dataStore.requestExecutor.options.apiKey.secret).setTtl(3600);
 };
 
-AuthenticationResult.prototype.getAccessToken = function getAccessToken() {
-  return this.getJwt().compact();
+AuthenticationResult.prototype.getAccessToken = function getAccessToken(jwt) {
+  return (jwt || this.getJwt()).compact();
 };
 
 AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenResponse(jwt) {

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -7,6 +7,7 @@ var jwt = require('njwt');
 function AuthenticationResult() {
   AuthenticationResult.super_.apply(this, arguments);
   Object.defineProperty(this, 'application', {enumerable:false,writable:true});
+  Object.defineProperty(this, 'forApiKey', {enumerable:false,writable:true});
 }
 utils.inherits(AuthenticationResult, InstanceResource);
 
@@ -23,7 +24,7 @@ AuthenticationResult.prototype.getJwt = function getJwt() {
   var self = this;
   return jwt.Jwt({
     iss: self.application.href,
-    sub: self.account.href,
+    sub: self.forApiKey ? self.forApiKey.id : self.account.href,
   }).signWith('HS256',self.application.dataStore.requestExecutor.options.apiKey.secret).setTtl(3600);
 };
 
@@ -31,13 +32,12 @@ AuthenticationResult.prototype.getAccessToken = function getAccessToken() {
   return this.getJwt().compact();
 };
 
-AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenResponse() {
-  var jwt = this.getJwt();
+AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenResponse(jwt) {
+  jwt = jwt || this.getJwt();
   var resp = {
     'access_token': jwt.compact(),
     'token_type': 'Bearer',
-    'expires_in': jwt.ttl,
-    'scope': this.scope
+    'expires_in': jwt.ttl
   };
   if(jwt.body.scope){
     resp.scope = jwt.body.scope;

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -2,7 +2,7 @@
 
 var utils = require('../utils');
 var InstanceResource = require('./InstanceResource');
-var jwt = require('njwt');
+var nJwt = require('njwt');
 
 function AuthenticationResult() {
   AuthenticationResult.super_.apply(this, arguments);
@@ -22,7 +22,7 @@ AuthenticationResult.prototype.getAccount = function getAuthenticationResultAcco
 
 AuthenticationResult.prototype.getJwt = function getJwt() {
   var self = this;
-  return jwt.Jwt({
+  return nJwt.Jwt({
     iss: self.application.href,
     sub: self.forApiKey ? self.forApiKey.id : self.account.href,
     jti: utils.uuid()
@@ -34,6 +34,7 @@ AuthenticationResult.prototype.getAccessToken = function getAccessToken() {
 };
 
 AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenResponse(jwt) {
+
   jwt = jwt || this.getJwt();
   var resp = {
     'access_token': jwt.compact(),

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -25,6 +25,7 @@ AuthenticationResult.prototype.getJwt = function getJwt() {
   return jwt.Jwt({
     iss: self.application.href,
     sub: self.forApiKey ? self.forApiKey.id : self.account.href,
+    jti: utils.uuid()
   }).signWith('HS256',self.application.dataStore.requestExecutor.options.apiKey.secret).setTtl(3600);
 };
 

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -2,9 +2,11 @@
 
 var utils = require('../utils');
 var InstanceResource = require('./InstanceResource');
+var jwt = require('njwt');
 
 function AuthenticationResult() {
   AuthenticationResult.super_.apply(this, arguments);
+  Object.defineProperty(this, 'application', {enumerable:false,writable:true});
 }
 utils.inherits(AuthenticationResult, InstanceResource);
 
@@ -15,6 +17,32 @@ AuthenticationResult.prototype.getAccount = function getAuthenticationResultAcco
   var options = (args.length > 0) ? args.shift() : null;
 
   return self.dataStore.getResource(self.account.href, options, require('./Account'), callback);
+};
+
+AuthenticationResult.prototype.getJwt = function getJwt() {
+  var self = this;
+  return jwt.Jwt({
+    iss: self.application.href,
+    sub: self.account.href,
+  }).signWith('HS256',self.application.dataStore.requestExecutor.options.apiKey.secret).setTtl(3600);
+};
+
+AuthenticationResult.prototype.getAccessToken = function getAccessToken() {
+  return this.getJwt().compact();
+};
+
+AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenResponse() {
+  var jwt = this.getJwt();
+  var resp = {
+    'access_token': jwt.compact(),
+    'token_type': 'Bearer',
+    'expires_in': jwt.ttl,
+    'scope': this.scope
+  };
+  if(jwt.body.scope){
+    resp.scope = jwt.body.scope;
+  }
+  return resp;
 };
 
 module.exports = AuthenticationResult;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "memcached": "~0.2.8",
     "glob": "3",
     "jwt-simple": "~0.2.0",
-    "njwt": "0.0.0"
+    "njwt": "0.0.1"
   },
   "devDependencies": {
     "grunt": "~0.4.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "redis": "~0.12.1",
     "memcached": "~0.2.8",
     "glob": "3",
-    "jwt-simple": "~0.2.0"
+    "jwt-simple": "~0.2.0",
+    "njwt": "0.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.2",

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -378,7 +378,7 @@ describe('Application.authenticateApiRequest',function(){
         });
         it('should err',function(){
           assert.instanceOf(result[0],Error);
-          assert.equal(result[0].statusCode,400);
+          assert.equal(result[0].statusCode,401);
         });
 
         it('should not return an instance of AuthenticationResult',function(){
@@ -536,7 +536,7 @@ describe('Application.authenticateApiRequest',function(){
     });
     it('should err',function(){
       assert.instanceOf(result[0],Error);
-      assert.equal(result[0].statusCode,400);
+      assert.equal(result[0].statusCode,401);
     });
 
     it('should not return an instance of AuthenticationResult',function(){

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -382,7 +382,7 @@ describe('Resources: ', function () {
           createResourceStub = sandbox
             .stub(dataStore, 'createResource', function () {
               var cb = Array.prototype.slice.call(arguments).pop();
-              cb();
+              cb(null, new AuthenticationResult());
             });
           cbSpy = sandbox.spy();
 
@@ -414,11 +414,11 @@ describe('Resources: ', function () {
           // call without optional param
           createResourceStub.should.have.been
             .calledWith(app.loginAttempts.href, {expand: 'account'}, expectedLoginAttempt1,
-            AuthenticationResult, cbSpy);
+            AuthenticationResult);
           // call with optional param
           createResourceStub.should.have.been
             .calledWith(app.loginAttempts.href, {expand: 'account'}, expectedLoginAttempt2,
-            AuthenticationResult, cbSpy);
+            AuthenticationResult);
         });
       });
 


### PR DESCRIPTION
Adding these new methods to `AuthenticationResult`:

`getJwt()` - returns a `Jwt` instance with a pre-configured body that is set to the appropriate defaults.  Also sets the signing key to the api key secret.

`getAccessToken([jwt])` - calls `jwt.compact()` on the given `jwt`, or a default `jwt` constructed by `getJwt()`

`getAccessToken([jwt])` - constructs an oauth-compatible response body from the given `jwt`, or a default `jwt` constructed with `getJwt()`

This PR also adjusts some status codes to be correct