### PR TITLE
Fix 0.8 tests by using npm 1.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - '0.10'
   - '0.8'
 before_install:
-  npm install -g npm@'>=1.4.3'
+  npm install -g npm@'=1.4.3'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 node_js:
   - '0.10'
   - '0.8'
-
+before_install:
+  npm install -g npm@'>=1.4.3'
 


### PR DESCRIPTION
npm 1.4.3 is able to resolve any dependencies that use the carent symbol

Higher versions of npm use modules which are not compatible with node 0.8

See:

https://github.com/travis-ci/travis-ci/issues/2076

https://github.com/Floby/node-libspotify/issues/21