### PR TITLE
Convenience Configuration

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -59,6 +59,26 @@ function Config(options){
     this.client.apiKey.secret = props.secret;
   }
 
+  // If a user enables a boolean configuration option named `website`, this
+  // means the user is building a website and we should automatically enable
+  // certain features in the library meant for users developing websites.  This
+  // is a simpler way of handling configuration than forcing users to specify
+  // all nested JSON configuration options themselves.
+  if (this.website) {
+    this.web.register.enabled = true;
+    this.web.login.enabled = true;
+    this.web.logout.enabled = true;
+  }
+
+  // If a user enables a boolean configuration option named `api`, this means
+  // the user is building an API service, and we should automatically enable
+  // certain features in the library meant for users developing API services --
+  // namely, our OAuth2 token endpoint (/oauth/token).  This allows users
+  // building APIs to easily provision OAuth2 tokens without specifying any
+  // nested JSON configuration options.
+  if (this.api) {
+    this.web.oauth2.enabled = true;
+  }
 }
 
 Config.prototype.getEnvVars = function(){

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -84,6 +84,39 @@ describe('Client', function () {
       done();
     });
 
+    it('should enable all web routes if the website config option is specified', function(done) {
+      var client = new Client({
+        client: {
+          apiKey: {
+            id: '1',
+            secret: '1'
+          }
+        },
+        website: true
+      });
+
+      assert(client.config.web.register.enabled);
+      assert(client.config.web.login.enabled);
+      assert(client.config.web.logout.enabled);
+
+      done();
+    });
+
+    it('should enable all oauth2 routes if the api config option is specified', function(done) {
+      var client = new Client({
+        client: {
+          apiKey: {
+            id: '1',
+            secret: '1'
+          }
+        },
+        api: true
+      });
+
+      assert(client.config.web.oauth2.enabled);
+      done();
+    });
+
     it('should emit a ready event with the client itself as the value', function(done) {
       var client = new Client({
         client: {


### PR DESCRIPTION
This commit modifies the configuration client to do a little bit of magic.

The idea is this: right now, it is quite tricky to enable the default stuff in Express for websites: login / logout / register.

You have to know about the configuration options, and specify an ugly nested config that is quite lengthy and eats a lot of space in your code.

What this PR does is allows users to simplify their configuration through 2 optional options: `website` and `api`.

If you say:

```
var client = new Client({
  website: true
});
```

Then you'll get the registration / login / logout functionality all enabled with our default settings (like the old express-stormpath behavior).

If you say:

```
var client = new Client({
  api: true
});
```

You'll get our oauth endpoint enabled by default, eg: `/oauth/token` -- this is ideal for users building any sort of API service.

@robertjd and I have discussed this previously and think it's a good idea.