### PR TITLE
Fixing Broken CustomData Deletion

### DIFF
--- a/lib/resource/CustomData.js
+++ b/lib/resource/CustomData.js
@@ -84,8 +84,45 @@ CustomData.prototype.remove = function removeCustomDataField(fieldName){
 
 CustomData.prototype.save = function saveCustomData(cb){
   var self = this;
+  var resource;
+
+  // If the user deleted any properties, then before we save() the new data,
+  // we'll remove any deleted properties.
   self._deleteRemovedProperties(function(){
-    self.dataStore.saveResource(self._deleteReservedFields(), cb);
+
+    // At this point, we've finished deleting any properties the user has
+    // removed.  So we are at an interesting point -- two things could be true
+    // here:
+    //
+    //   - Either there is still data left to actually save(), or
+    //   - There is no data to save, as the user ONLY deleted stuff.
+    //
+    // In the event of #2, we MUST ABORT the save(), otherwise we'll get an
+    // error (as Stormpath will fail the API call if we try to save nothing).
+    //
+    // So what I'm doing below is this: explicitly avoiding a call to save() if
+    // there is no data remaining.
+    resource = self._deleteReservedFields();
+
+    // We need to remove all of the non-data properties from the resource
+    // before attempting to save() it.  Since this is a CustomData object, we
+    // have to remove all methods, as well as the href property.
+    async.forEachOf(resource, function(value, key, callback) {
+      if (key === 'href' || typeof value === 'function') {
+        delete resource[key];
+      }
+
+      callback();
+
+    // Once we've finished *purging* the resource object, we can then either
+    // skip the save(), or process it and continue.
+    }, function() {
+      if (Object.keys(resource).length > 0) {
+        return self.dataStore.saveResource(self._deleteReservedFields(), cb);
+      }
+
+      cb();
+    });
   });
 };
 

--- a/lib/resource/CustomData.js
+++ b/lib/resource/CustomData.js
@@ -107,22 +107,19 @@ CustomData.prototype.save = function saveCustomData(cb){
     // We need to remove all of the non-data properties from the resource
     // before attempting to save() it.  Since this is a CustomData object, we
     // have to remove all methods, as well as the href property.
-    async.forEachOf(resource, function(value, key, callback) {
-      if (key === 'href' || typeof value === 'function') {
+    Object.keys(resource).forEach(function(key) {
+      if (key === 'href' || typeof resource[key] === 'function') {
         delete resource[key];
       }
-
-      callback();
+    });
 
     // Once we've finished *purging* the resource object, we can then either
     // skip the save(), or process it and continue.
-    }, function() {
-      if (Object.keys(resource).length > 0) {
-        return self.dataStore.saveResource(self._deleteReservedFields(), cb);
-      }
+    if (Object.keys(resource).length > 0) {
+      return self.dataStore.saveResource(self._deleteReservedFields(), cb);
+    }
 
-      cb();
-    });
+    cb();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "request": "~2.40.0",
     "moment": "~2.8.3",
     "node-uuid": "~1.4.1",
-    "async": "~1.4.2",
+    "async": "~0.7.0",
     "redis": "~0.12.1",
     "memcached": "~0.2.8",
     "glob": "3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "request": "~2.40.0",
     "moment": "~2.8.3",
     "node-uuid": "~1.4.1",
-    "async": "~0.7.0",
+    "async": "~1.4.2",
     "redis": "~0.12.1",
     "memcached": "~0.2.8",
     "glob": "3",

--- a/test/it/account_it.js
+++ b/test/it/account_it.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var common = require('../common');
+var assert = require('assert');
+
 var helpers = require('./helpers');
-var assert = common.assert;
 
 var Account = require('../../lib/resource/Account');
 var CustomData = require('../../lib/resource/CustomData');
@@ -38,7 +38,7 @@ describe('Account', function() {
 
   it('should be create-able from a directory instance', function() {
     assert.equal(creationResult[0], null); // did not error
-    assert.instanceOf(account, Account);
+    assert(account instanceof Account);
   });
 
   describe('customData', function() {
@@ -57,7 +57,7 @@ describe('Account', function() {
       });
 
       it('should be get-able', function() {
-        assert.instanceOf(customData, CustomData);
+        assert(customData instanceof CustomData);
         assert.equal(customData.href, account.href + '/customData');
       });
 
@@ -106,7 +106,7 @@ describe('Account', function() {
       });
 
       it('should be get-able', function() {
-        assert.instanceOf(customData, CustomData);
+        assert(customData instanceof CustomData);
         assert.equal(customData.href, account.href + '/customData');
       });
 
@@ -161,7 +161,7 @@ describe('Account', function() {
       });
 
       it('should be get-able', function() {
-        assert.instanceOf(customData, CustomData);
+        assert(customData instanceof CustomData);
         assert.equal(customData.href, account.href + '/customData');
       });
 

--- a/test/it/account_it.js
+++ b/test/it/account_it.js
@@ -1,173 +1,194 @@
+'use strict';
 
 var common = require('../common');
 var helpers = require('./helpers');
 var assert = common.assert;
 
-var CustomData = require('../../lib/resource/CustomData');
 var Account = require('../../lib/resource/Account');
+var CustomData = require('../../lib/resource/CustomData');
 
-describe('Account',function(){
-
+describe('Account', function() {
   var client, directory, account, creationResult;
 
-  before(function(done){
-    helpers.getClient(function(_client){
+  before(function(done) {
+    helpers.getClient(function(_client) {
       client = _client;
-      client.createDirectory(
-        {name: helpers.uniqId()},
-        function(err, _directory) {
-          directory = _directory;
-          directory.createAccount(
-            helpers.fakeAccount(),
-            function(err,_account){
-              account = _account;
-              creationResult = [err,_account];
-              done();
-            }
-          );
-        }
-      );
+
+      client.createDirectory({ name: helpers.uniqId() }, function(err, _directory) {
+        directory = _directory;
+
+        directory.createAccount(helpers.fakeAccount(), function(err,_account) {
+          account = _account;
+          creationResult = [err, _account];
+          done();
+        });
+      });
     });
   });
 
-  after(function(done){
-    account.delete(function(err){
-      if(err){
-        throw err;
-      }else{
-        directory.delete(done);
+  after(function(done) {
+    account.delete(function(err) {
+      if (err) {
+        return done(err);
       }
+
+      directory.delete(done);
     });
   });
 
-  it('should be create-able from a directory instance',function(){
-    assert.equal(creationResult[0],null); // did not error
-    assert.instanceOf(account,Account);
+  it('should be create-able from a directory instance', function() {
+    assert.equal(creationResult[0], null); // did not error
+    assert.instanceOf(account, Account);
   });
 
-  describe('custom data',function(){
-
-    describe('via customData.get',function(){
+  describe('customData', function() {
+    describe('via customData.get', function() {
       var customData;
 
-      before(function(done){
-        account.customData.get(function(err,_customData){
-          if(err){ throw err; }
-          customData = _customData;
-          done();
-        });
-      });
-
-      it('should be get-able',function(){
-        assert.instanceOf(customData,CustomData);
-        assert.equal(customData.href,account.href+'/customData');
-      });
-
-      describe('when saved and re-fetched',function(){
-        var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
-        before(function(done){
-          customData[propertyName] = propertyValue;
-          customData.save(function(err){
-            if(err){ throw err; }
-            account.customData.get(function(err,customData){
-              if(err){ throw err; }
-              customDataAfterGet = customData;
-              done();
-            });
-          });
-        });
-        it('should have the new property persisted',function(){
-          assert.equal(customDataAfterGet[propertyName],propertyValue);
-        });
-      });
-    });
-
-    describe('via getCustomData',function(){
-      var customData;
-
-      before(function(done){
-        account.getCustomData(function(err,_customData){
-          if(err){ throw err; }
-          customData = _customData;
-          done();
-        });
-      });
-
-      it('should be get-able',function(){
-        assert.instanceOf(customData,CustomData);
-        assert.equal(customData.href,account.href+'/customData');
-      });
-
-      describe('when saved and re-fetched',function(){
-        var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
-        before(function(done){
-          customData[propertyName] = propertyValue;
-          customData.save(function(err){
-            if(err){ throw err; }
-            account.getCustomData(function(err,customData){
-              if(err){ throw err; }
-              customDataAfterGet = customData;
-              done();
-            });
-          });
-        });
-        it('should have the new property persisted',function(){
-          assert.equal(customDataAfterGet[propertyName],propertyValue);
-        });
-      });
-    });
-
-    describe('via resource expansion',function(){
-
-      function getExpandedAccount(cb){
-        client.getAccount(
-          account.href,
-          { expand: 'customData' },
-          function(err, account){
-            if(err){ throw err; }
-            cb(account);
+      before(function(done) {
+        account.customData.get(function(err, _customData) {
+          if (err) {
+            return done(err);
           }
-        );
+
+          customData = _customData;
+          done();
+        });
+      });
+
+      it('should be get-able', function() {
+        assert.instanceOf(customData, CustomData);
+        assert.equal(customData.href, account.href + '/customData');
+      });
+
+      describe('when saved and re-fetched', function() {
+        var customDataAfterGet;
+        var propertyName = helpers.uniqId();
+        var propertyValue = helpers.uniqId();
+
+        before(function(done) {
+          customData[propertyName] = propertyValue;
+
+          customData.save(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            account.customData.get(function(err, customData) {
+              if (err) {
+                return done(err);
+              }
+
+              customDataAfterGet = customData;
+              done();
+            });
+          });
+        });
+
+        it('should have the new property persisted', function() {
+          assert.equal(customDataAfterGet[propertyName], propertyValue);
+        });
+      });
+    });
+
+    describe('via getCustomData', function() {
+      var customData;
+
+      before(function(done) {
+        account.getCustomData(function(err, _customData) {
+          if (err) {
+            return done(err);
+          }
+
+          customData = _customData;
+          done();
+        });
+      });
+
+      it('should be get-able', function() {
+        assert.instanceOf(customData, CustomData);
+        assert.equal(customData.href, account.href + '/customData');
+      });
+
+      describe('when saved and re-fetched', function() {
+        var customDataAfterGet;
+        var propertyName = helpers.uniqId();
+        var propertyValue = helpers.uniqId();
+
+        before(function(done) {
+          customData[propertyName] = propertyValue;
+
+          customData.save(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            account.getCustomData(function(err, customData) {
+              if (err) {
+                return done(err);
+              }
+
+              customDataAfterGet = customData;
+              done();
+            });
+          });
+        });
+
+        it('should have the new property persisted', function() {
+          assert.equal(customDataAfterGet[propertyName], propertyValue);
+        });
+      });
+    });
+
+    describe('via resource expansion', function() {
+      function getExpandedAccount(cb) {
+        client.getAccount(account.href, { expand: 'customData' }, function(err, account) {
+          if (err) {
+            throw err;
+          }
+
+          cb(account);
+        });
       }
 
       var customData;
 
-      before(function(done){
-        getExpandedAccount(function(account){
+      before(function(done) {
+        getExpandedAccount(function(account) {
           customData = account.customData;
           done();
         });
       });
 
-      it('should be get-able',function(){
-        assert.instanceOf(customData,CustomData);
-        assert.equal(customData.href,account.href+'/customData');
+      it('should be get-able', function() {
+        assert.instanceOf(customData, CustomData);
+        assert.equal(customData.href, account.href + '/customData');
       });
 
-      describe('when saved and re-fetched',function(){
+      describe('when saved and re-fetched', function() {
         var customDataAfterGet;
         var propertyName = helpers.uniqId();
         var propertyValue = helpers.uniqId();
-        before(function(done){
+
+        before(function(done) {
           customData[propertyName] = propertyValue;
-          customData.save(function(err){
-            if(err){ throw err; }
-            getExpandedAccount(function(account){
+
+          customData.save(function(err) {
+            if (err) {
+              return done(err);
+            }
+
+            getExpandedAccount(function(account) {
               customDataAfterGet = account.customData;
               done();
             });
           });
         });
-        it('should have the new property persisted',function(){
-          assert.equal(customDataAfterGet[propertyName],propertyValue);
+
+        it('should have the new property persisted', function() {
+          assert.equal(customDataAfterGet[propertyName], propertyValue);
         });
       });
     });
   });
-
-
 });

--- a/test/it/account_it.js
+++ b/test/it/account_it.js
@@ -88,6 +88,13 @@ describe('Account', function() {
         it('should have the new property persisted', function() {
           assert.equal(customDataAfterGet[propertyName], propertyValue);
         });
+
+        it('should allow all added keys to be deleted', function(done) {
+          customDataAfterGet.remove(propertyName);
+          customDataAfterGet.save(function(err) {
+            done(err);
+          });
+        });
       });
     });
 


### PR DESCRIPTION
Previously (see: #177), users were unable to remove *all* customData fields due to the way our saving mechanism works.

This PR fixes this behavior, and adds tests to verify it.