### PR TITLE
fix getAccessToken expires too quickly

### DIFF
--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -28,7 +28,7 @@ AuthenticationResult.prototype.getJwt = function getJwt() {
     sub: self.forApiKey ? self.forApiKey.id : self.account.href,
     jti: utils.uuid()
   },self.application.dataStore.requestExecutor.options.apiKey.secret)
-  .setExpiration(new Date().getTime() + 3600);
+  .setExpiration(new Date().getTime() + 3600 * 1000);
 };
 
 AuthenticationResult.prototype.getAccessToken = function getAccessToken(jwt) {
@@ -41,7 +41,7 @@ AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenR
   var resp = {
     'access_token': jwt.compact(),
     'token_type': 'Bearer',
-    'expires_in': jwt.ttl
+    'expires_in': jwt.exp
   };
   if(jwt.body.scope){
     resp.scope = jwt.body.scope;


### PR DESCRIPTION
closes #204 
A quick fix by setting `setExpiration()` value correctly