### PR TITLE
Feature: Load config env after config files.

### DIFF
--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -24,9 +24,6 @@ module.exports = function (extendWithConfig) {
     // Load default configuration.
     new strategy.LoadFileConfigStrategy(path.join(__dirname, '/config.yml'), true),
 
-    // Load configuration from our environment.
-    new strategy.LoadEnvConfigStrategy('STORMPATH'),
-
     // Load API keys and configuration from home (.stormpath) folder
     new strategy.LoadAPIKeyConfigStrategy(stormpathPath + '/apiKey.properties'),
     new strategy.LoadFileConfigStrategy(stormpathPath + '/stormpath.json'),
@@ -36,6 +33,9 @@ module.exports = function (extendWithConfig) {
     new strategy.LoadAPIKeyConfigStrategy(currentPath + '/apiKey.properties'),
     new strategy.LoadFileConfigStrategy(currentPath + '/stormpath.json'),
     new strategy.LoadFileConfigStrategy(currentPath + '/stormpath.yml'),
+
+    // Load configuration from our environment.
+    new strategy.LoadEnvConfigStrategy('STORMPATH'),
 
     // Extend our configuration with the configuration we passed into the client.
     // Also, try and load our API key if it was specified in our config.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "mocha": "~1.17.0",
     "mocha-sinon": "~1.1.0",
     "nock": "~0.27.2",
-    "nodeenv": "^0.2.1",
     "sinon": "~1.7.3",
     "sinon-chai": "~2.4.0",
     "time-grunt": "~0.2.0",

--- a/test/common.js
+++ b/test/common.js
@@ -32,12 +32,13 @@ function clone(value) {
 function snapshotEnv() {
   var originalEnv = clone(process.env);
   return function restore() {
-    for (var key in process.env) {
+    var key;
+    for (key in process.env) {
       if (!(key in originalEnv)) {
         delete process.env[key];
       }
     }
-    for (var key in originalEnv) {
+    for (key in originalEnv) {
       process.env[key] = originalEnv[key];
     }
   };

--- a/test/common.js
+++ b/test/common.js
@@ -25,6 +25,17 @@ function random(){
   return '' + Math.random()*Date.now();
 }
 
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function snapshotEnv() {
+  var originalEnv = clone(process.env);
+  return function restore() {
+    process.env = originalEnv;
+  };
+}
+
 function assertAccessTokenResponse(response){
   assert.isDefined(response.accessTokenResponse);
   assert.isDefined(response.accessTokenResponse.access_token);
@@ -56,6 +67,7 @@ module.exports = {
   Stormpath: Stormpath,
   random: random,
   uuid: uuid,
+  snapshotEnv: snapshotEnv,
   assertPasswordGrantResponse: assertPasswordGrantResponse,
   assertAccessTokenResponse: assertAccessTokenResponse
 };

--- a/test/common.js
+++ b/test/common.js
@@ -32,7 +32,14 @@ function clone(value) {
 function snapshotEnv() {
   var originalEnv = clone(process.env);
   return function restore() {
-    process.env = originalEnv;
+    for (var key in process.env) {
+      if (!(key in originalEnv)) {
+        delete process.env[key];
+      }
+    }
+    for (var key in originalEnv) {
+      process.env[key] = originalEnv[key];
+    }
   };
 }
 

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -8,7 +8,6 @@ var FakeFS = require('fake-fs');
 var common = require('./common');
 var assert = common.assert;
 
-var stormpathConfig = require('stormpath-config');
 var configLoader = require('../lib/configLoader');
 
 describe('Configuration loader', function () {
@@ -70,8 +69,9 @@ describe('Configuration loader', function () {
     afterIt.push(restoreEnv);
 
     loader.load(function (err, config) {
-      assert.isNotNull(err);
+      assert.isUndefined(config);
 
+      assert.isNotNull(err);
       assert.equal(err.message, 'API key ID and secret is required.');
 
       done();

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -45,6 +45,12 @@ describe('Configuration loader', function () {
     });
   });
 
+  after(function () {
+    if (fakeFs) {
+      fakeFs.unpatch();
+    }
+  });
+
   // Cleanup functions that should run directly after all "it" tests.
   // This is because mocha does not offer this functionality at the moment.
   // I.e. mocha's after() is queued and executed after all tests have run.

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -114,9 +114,9 @@ describe('Configuration loader', function () {
 
     var restoreEnv = common.snapshotEnv();
 
-    process.env.STORMPATH_CLIENT_APIKEY_ID = uuid(),
-    process.env.STORMPATH_CLIENT_APIKEY_SECRET = uuid(),
-    process.env.STORMPATH_APPLICATION_HREF = 'http://api.stormpath.com/v1/applications/' + uuid(),
+    process.env.STORMPATH_CLIENT_APIKEY_ID = uuid();
+    process.env.STORMPATH_CLIENT_APIKEY_SECRET = uuid();
+    process.env.STORMPATH_APPLICATION_HREF = 'http://api.stormpath.com/v1/applications/' + uuid();
     process.env.STORMPATH_APPLICATION_NAME = uuid();
 
     after(restoreEnv);


### PR DESCRIPTION
Changes so that environment config is loaded after config files.

##### How to verify

Use an existing application that integrates with the `stormpath` module, and test that the Stormpath environment config (`STORMPATH_`) overrides Stormpath config set in files (`~/.stormpath/stormpath.json`, `~/.stormpath/apiKey.properties`, `./stormpath.json`, `~/.stormpath/apiKey.properties`). And that configuration passed directly to the client overrides that in the environment.

I.e. the config load order should now be:

1. File `~/.stormpath/apiKeys.properties`.
2. File `~/.stormpath/stormpath.json`.
3. File `(application path)/apiKeys.properties`.
4. File `(application path)/stormpath.json`.
5. Environment.
6. Config provided to integration (i.e. `stormpath.init(app, { /* here */ });`).

Fixes #225.