### PR TITLE
Docs: How to provide organization nameKey to authenticationRequest()

### DIFF
--- a/docs/app/views/application.md
+++ b/docs/app/views/application.md
@@ -49,7 +49,7 @@ application.authenticateAccount(authcRequest, function(err, result) {
       <td>`authenticationRequest`</td>
       <td>`object`</td>
       <td>required</td>
-      <td>Object with two required name/value pairs: `username` and `password` and one optional `accountStore`.  `username` can be either a username or email address. `password` is the _raw_ password submitted directly by your application user.  Stormpath hashes and encrypts this value securely automatically - you don't have to do anything special before submitting to Stormpath. If you desire to target a specific `accountStore`, then provide reference to the `accountStore` in options.</td>
+      <td>Object with two required name/value pairs: `username` and `password` and one optional `accountStore`.  `username` can be either a username or email address. `password` is the _raw_ password submitted directly by your application user.  Stormpath hashes and encrypts this value securely automatically - you don't have to do anything special before submitting to Stormpath. If you desire to target a specific `accountStore`, then provide reference to the `accountStore` in options. If `accountStore` is provided as a string an account store HREF is expected, otherwise it expects an object describing the account store link, e.g. `{ nameKey: 'organizaiton nameKey' }`.</td>
     </tr>
     <tr>
       <td>`callback`</td>

--- a/docs/app/views/application.md
+++ b/docs/app/views/application.md
@@ -49,7 +49,7 @@ application.authenticateAccount(authcRequest, function(err, result) {
       <td>`authenticationRequest`</td>
       <td>`object`</td>
       <td>required</td>
-      <td>Object with two required name/value pairs: `username` and `password` and one optional `accountStore`.  `username` can be either a username or email address. `password` is the _raw_ password submitted directly by your application user.  Stormpath hashes and encrypts this value securely automatically - you don't have to do anything special before submitting to Stormpath. If you desire to target a specific `accountStore`, then provide reference to the `accountStore` in options. If `accountStore` is provided as a string an account store HREF is expected, otherwise it expects an object describing the account store link, e.g. `{ nameKey: 'organizaiton nameKey' }`.</td>
+      <td>Object with two required name/value pairs: `username` and `password` and one optional `accountStore`.  `username` can be either a username or email address. `password` is the _raw_ password submitted directly by your application user.  Stormpath hashes and encrypts this value securely automatically - you don't have to do anything special before submitting to Stormpath. If you desire to target a specific `accountStore`, then provide reference to the `accountStore` in options. If `accountStore` is provided as a string an account store HREF is expected, otherwise it expects an object that identifies the account store, e.g. `{ nameKey: 'organizaiton nameKey' }`.</td>
     </tr>
     <tr>
       <td>`callback`</td>


### PR DESCRIPTION
Adds docs that describe how to provide an organization nameKey to the Application.authenticationRequest() method.

Feedback welcome.

Closes #201.