### PR TITLE
Feature: Async scope factory

### DIFF
--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -15,9 +15,11 @@ function OAuthBasicExchangeAuthenticator(application,request,ttl,scopeFactory, r
   if(parts.length!==2){
     return new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400});
   }
+
   if(request.method!=='POST'){
     return new ApiAuthRequestError({userMessage: 'Must use POST for token exchange, see http://tools.ietf.org/html/rfc6749#section-3.2'});
   }
+
   this.id = parts[0];
   this.secret = parts[1];
   this.application = application;
@@ -26,8 +28,8 @@ function OAuthBasicExchangeAuthenticator(application,request,ttl,scopeFactory, r
   this.requestedScope = requestedScope;
 }
 
-OAuthBasicExchangeAuthenticator.prototype.defaultScopeFactory = function defaultScopeFactory() {
-  return '';
+OAuthBasicExchangeAuthenticator.prototype.defaultScopeFactory = function defaultScopeFactory(account, requestedScope, callback) {
+  callback(null, '');
 };
 
 OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(callback) {
@@ -42,10 +44,20 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
         (apiKey.account.status==='ENABLED')
       ){
         var result = new AuthenticationResult(apiKey,self.application.dataStore);
+
         result.forApiKey = apiKey;
         result.application = self.application;
-        result.tokenResponse = self.buildTokenResponse(apiKey);
-        callback(null,result);
+
+        self.buildTokenResponse(apiKey, function onTokenResponse(err, tokenResponse) {
+          if (err) {
+            callback(err);
+            return;
+          }
+
+          result.tokenResponse = tokenResponse;
+
+          callback(null, result);
+        });
       }else{
         callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}));
       }
@@ -53,19 +65,51 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
   });
 };
 
-OAuthBasicExchangeAuthenticator.prototype.buildTokenResponse = function buildTokenResponse(apiKey) {
+OAuthBasicExchangeAuthenticator.prototype.buildTokenResponse = function buildTokenResponse(apiKey, callback) {
   var self = this;
-  var scope = self.scopeFactory(apiKey.account,self.requestedScope);
-  // TODO v1.0.0 - remove string option for tokens, should be array only
-  return {
-    "access_token": self.buildAccesstoken(apiKey.account),
-    "token_type":"bearer",
-    "expires_in": self.ttl,
-    "scope": Array.isArray(scope) ? scope.join(' ') : scope
-  };
+
+  var account = apiKey.account;
+  var requestedScope = self.requestedScope;
+
+  function retrieveScopeFactoryResult(callback) {
+    var hasBeenCalled = false;
+
+    function callbackWithResult(err, scope) {
+      if (hasBeenCalled) {
+        throw new Error('Callback has already been called once. Assert that your scopeFactory doesn\'t return a result while also calling the callback.');
+      }
+
+      hasBeenCalled = true;
+
+      callback(err, scope);
+    }
+
+    var optionalResult = self.scopeFactory(account, requestedScope, callbackWithResult);
+
+    // For backward-compatibility: If we have a result then call the callback immediately,
+    // else expect it to be handled by the scopeFactory function.
+    if (optionalResult || optionalResult === '') {
+      callbackWithResult(null, optionalResult);
+    }
+  }
+
+  retrieveScopeFactoryResult(function onScopeResolved(err, scopeResult) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    // TODO v1.0.0 - remove string option for tokens, should be array only
+    callback(null, {
+      access_token: self.buildAccessToken(account, scopeResult),
+      token_type: 'bearer',
+      expires_in: self.ttl,
+      scope: Array.isArray(scopeResult) ? scopeResult.join(' ') : scopeResult
+    });
+  });
 };
 
-OAuthBasicExchangeAuthenticator.prototype.buildAccesstoken = function buildAccesstoken(account) {
+OAuthBasicExchangeAuthenticator.prototype.buildAccessToken = function buildAccessToken(account, scope) {
   var self = this;
   var now = nowEpochSeconds();
 
@@ -75,8 +119,6 @@ OAuthBasicExchangeAuthenticator.prototype.buildAccesstoken = function buildAcces
     iat: now,
     exp: now + self.ttl
   };
-
-  var scope = self.scopeFactory(account,self.requestedScope);
 
   if(scope){
     // TODO v1.0.0 - remove string option, should be array only

--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -15,9 +15,11 @@ function OAuthBasicExchangeAuthenticator(application,request,ttl,scopeFactory, r
   if(parts.length!==2){
     return new ApiAuthRequestError('Invalid Authorization value',400);
   }
+
   if(request.method!=='POST'){
     return new ApiAuthRequestError('Must use POST for token exchange, see http://tools.ietf.org/html/rfc6749#section-3.2');
   }
+
   this.id = parts[0];
   this.secret = parts[1];
   this.application = application;
@@ -26,8 +28,8 @@ function OAuthBasicExchangeAuthenticator(application,request,ttl,scopeFactory, r
   this.requestedScope = requestedScope;
 }
 
-OAuthBasicExchangeAuthenticator.prototype.defaultScopeFactory = function defaultScopeFactory() {
-  return '';
+OAuthBasicExchangeAuthenticator.prototype.defaultScopeFactory = function defaultScopeFactory(account, requestedScope, callback) {
+  callback(null, '');
 };
 
 OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(callback) {
@@ -42,10 +44,20 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
         (apiKey.account.status==='ENABLED')
       ){
         var result = new AuthenticationResult(apiKey,self.application.dataStore);
+
         result.forApiKey = apiKey;
         result.application = self.application;
-        result.tokenResponse = self.buildTokenResponse(apiKey);
-        callback(null,result);
+
+        self.buildTokenResponse(apiKey, function onTokenResponse(err, tokenResponse) {
+          if (err) {
+            callback(err);
+            return;
+          }
+
+          result.tokenResponse = tokenResponse;
+
+          callback(null, result);
+        });
       }else{
         callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
       }
@@ -53,19 +65,51 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
   });
 };
 
-OAuthBasicExchangeAuthenticator.prototype.buildTokenResponse = function buildTokenResponse(apiKey) {
+OAuthBasicExchangeAuthenticator.prototype.buildTokenResponse = function buildTokenResponse(apiKey, callback) {
   var self = this;
-  var scope = self.scopeFactory(apiKey.account,self.requestedScope);
-  // TODO v1.0.0 - remove string option for tokens, should be array only
-  return {
-    "access_token": self.buildAccesstoken(apiKey.account),
-    "token_type":"bearer",
-    "expires_in": self.ttl,
-    "scope": Array.isArray(scope) ? scope.join(' ') : scope
-  };
+
+  var account = apiKey.account;
+  var requestedScope = self.requestedScope;
+
+  function retrieveScopeFactoryResult(callback) {
+    var hasBeenCalled = false;
+
+    function callbackWithResult(err, scope) {
+      if (hasBeenCalled) {
+        throw new Error('Callback has already been called once. Assert that your scopeFactory doesn\'t return a result while also calling the callback.');
+      }
+
+      hasBeenCalled = true;
+
+      callback(err, scope);
+    }
+
+    var optionalResult = self.scopeFactory(account, requestedScope, callbackWithResult);
+
+    // For backward-compatibility: If we have a result then call the callback immediately,
+    // else expect it to be handled by the scopeFactory function.
+    if (optionalResult || optionalResult === '') {
+      callbackWithResult(null, optionalResult);
+    }
+  }
+
+  retrieveScopeFactoryResult(function onScopeResolved(err, scopeResult) {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    // TODO v1.0.0 - remove string option for tokens, should be array only
+    callback(null, {
+      access_token: self.buildAccessToken(account, scopeResult),
+      token_type: 'bearer',
+      expires_in: self.ttl,
+      scope: Array.isArray(scopeResult) ? scopeResult.join(' ') : scopeResult
+    });
+  });
 };
 
-OAuthBasicExchangeAuthenticator.prototype.buildAccesstoken = function buildAccesstoken(account) {
+OAuthBasicExchangeAuthenticator.prototype.buildAccessToken = function buildAccessToken(account, scope) {
   var self = this;
   var now = nowEpochSeconds();
 
@@ -75,8 +119,6 @@ OAuthBasicExchangeAuthenticator.prototype.buildAccesstoken = function buildAcces
     iat: now,
     exp: now + self.ttl
   };
-
-  var scope = self.scopeFactory(account,self.requestedScope);
 
   if(scope){
     // TODO v1.0.0 - remove string option, should be array only

--- a/quickstart.js
+++ b/quickstart.js
@@ -11,9 +11,6 @@
 
 var stormpath = require('stormpath');
 
-var homeDir = process.env[(process.platform === 'win32' ? 'USERPROFILE' : 'HOME')];
-var apiKeyFilePath = homeDir + '/.stormpath/apiKey.properties';
-
 //helper function to prevent any data collisions in the tenant while running the quickstart:
 function unique(aString) {
   return aString + '-' + require('node-uuid').v4().toString();
@@ -25,16 +22,11 @@ var client, application, account, group = null;
 var accountEmail = unique('jlpicard') + '@mailinator.com';
 
 // ==================================================
-// Step 1 - Load the API Key file and create a Client
+// Step 1 - Create a client and wait for it to ready
 // ==================================================
-stormpath.loadApiKey(apiKeyFilePath, function (err, apiKey) {
-  if (err) throw err;
+var client = new stormpath.Client();
 
-  client = new stormpath.Client({apiKey: apiKey});
-
-  //client is available, kick off the quickstart steps:
-  createApplication();
-});
+client.on('ready', createApplication);
 
 // ==================================================
 // Step 2 - Register an application with Stormpath

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -652,7 +652,7 @@ describe('Application.authenticateApiRequest',function(){
 
           decodedAccessToken = nJwt.verify(
             result[1].tokenResponse.access_token,
-            client._dataStore.requestExecutor.options.apiKey.secret,
+            client._dataStore.requestExecutor.options.client.apiKey.secret,
             'HS256'
           );
 

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -615,31 +615,6 @@ describe('Application.authenticateApiRequest',function(){
         });
       });
 
-      it('should return an error if called multiple times', function(done) {
-        var mochaErrorListener = process.listeners('uncaughtException').pop();
-
-        process.removeListener('uncaughtException', mochaErrorListener);
-
-        process.nextTick(function () {
-          process.listeners('uncaughtException').push(mochaErrorListener);
-        });
-
-        process.once('uncaughtException', function (err) {
-          assert.equal(err.message, 'Callback has already been called once. Assert that your scopeFactory doesn\'t return a result while also calling the callback.');
-          done();
-        });
-
-        app.authenticateApiRequest({
-          request: requestObject,
-          scopeFactory: function(account, requestedScope, callback){
-            callback(null, '123');
-            return ['123'];
-          }
-        },function(err){
-          assert.isNull(err);
-        });
-      });
-
       it('should call the scope factory with the requested scope', function(done) {
         app.authenticateApiRequest({
           request: requestObject,

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -249,6 +249,7 @@ describe('Application.authenticateApiRequest',function(){
   describe('with a previously issued access token',function(){
     var customScope = 'custom-scope';
     var accessToken;
+
     before(function(done){
       var requestObject = {
         headers: {
@@ -270,6 +271,7 @@ describe('Application.authenticateApiRequest',function(){
         done();
       });
     });
+
     describe('using Bearer authorization',function(){
       describe('and access_token is passed as Authorization: Bearer <token>',function(){
         var result;
@@ -300,6 +302,7 @@ describe('Application.authenticateApiRequest',function(){
           assert.equal(result[1].grantedScopes[0],customScope);
         });
       });
+
       describe('and access_token is tampered with',function(){
         var result;
         before(function(done){
@@ -545,21 +548,22 @@ describe('Application.authenticateApiRequest',function(){
   });
 
   describe('with a scope factory',function(){
-
     var result;
+    var requestObject;
     var requestedScope = 'scope-a scope-b';
     var givenScope = ['given-scope-a given-scope-b'];
     var scopeFactoryArgs;
     var decodedAccessToken;
 
     before(function(done){
-      var requestObject = {
+      requestObject = {
         headers: {
           'authorization': 'Basic ' + new Buffer([apiKey.id,apiKey.secret].join(':')).toString('base64')
         },
         method: 'POST',
         url: '/some/resource?grant_type=client_credentials&scope='+requestedScope
       };
+
       app.authenticateApiRequest({
         request: requestObject,
         scopeFactory: function(account,requestedScope){
@@ -596,6 +600,70 @@ describe('Application.authenticateApiRequest',function(){
       assert.equal(result[1].tokenResponse.scope,givenScope.join(' '));
     });
 
+    describe('that is given a callback', function () {
+      it('should return an error if given one', function(done) {
+        var expectedError = new Error('expected_error');
+
+        app.authenticateApiRequest({
+          request: requestObject,
+          scopeFactory: function(account, requestedScope, callback){
+            callback(expectedError);
+          }
+        },function(err){
+          assert.equal(err, expectedError);
+          done();
+        });
+      });
+
+      it('should return an error if called multiple times', function(done) {
+        var mochaErrorListener = process.listeners('uncaughtException').pop();
+
+        process.removeListener('uncaughtException', mochaErrorListener);
+
+        process.nextTick(function () {
+          process.listeners('uncaughtException').push(mochaErrorListener);
+        });
+
+        process.once('uncaughtException', function (err) {
+          assert.equal(err.message, 'Callback has already been called once. Assert that your scopeFactory doesn\'t return a result while also calling the callback.');
+          done();
+        });
+
+        app.authenticateApiRequest({
+          request: requestObject,
+          scopeFactory: function(account, requestedScope, callback){
+            callback(null, '123');
+            return ['123'];
+          }
+        },function(err){
+          assert.isNull(err);
+        });
+      });
+
+      it('should call the scope factory with the requested scope', function(done) {
+        app.authenticateApiRequest({
+          request: requestObject,
+          scopeFactory: function(account, requestedScope, callback){
+            scopeFactoryArgs = [account, requestedScope];
+            callback(null, givenScope);
+          }
+        },function(err, value){
+          result = [err, value];
+
+          decodedAccessToken = nJwt.verify(
+            result[1].tokenResponse.access_token,
+            client._dataStore.requestExecutor.options.apiKey.secret,
+            'HS256'
+          );
+
+          var requestedScopes = requestedScope.split(' ');
+          assert.equal(scopeFactoryArgs[1][0], requestedScopes[0]);
+          assert.equal(scopeFactoryArgs[1][1], requestedScopes[1]);
+
+          done();
+        });
+      });
+    });
   });
 
   describe('with a custom ttl',function(){


### PR DESCRIPTION
Adds the ability for a OAuthBasicExchangeAuthenticator scope factory to resolve scopes asynchronously.

Previously it was only possible for scopes to be resolved synchronously by the scope factory. As shown below:

``` js
app.authenticateApiRequest({
  scopeFactory: function(account, requestedScope){
    return ['myscope'];
  }
}, onResult);
```

But now it's also possible to do so by calling the optional callback argument. As shown below:

``` js
app.authenticateApiRequest({
  scopeFactory: function(account, requestedScope, callback){
    callback(null, ['myscope']);
  }
}, onResult);
```

**Note:** If the scope factory returns a value (not undefined) then it is assumed that this is the scope result. Else it is assumed that the scope result will be provided through the provided callback. The reason that both cases are supported is because of backward compatibility.

Closes #171.
