### PR TITLE
Fix: Backward-compatible apiKey

### DIFF
--- a/lib/config.yml
+++ b/lib/config.yml
@@ -1,4 +1,10 @@
 ---
+# 'apiKey' might feel redundant since 'client.apiKey' is what is being used.
+# But for backward-compability we need to have this here.
+apiKey:
+  file: null
+  id: null
+  secret: null
 client:
   apiKey:
     file: null

--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -35,7 +35,12 @@ module.exports = function (extendWithConfig) {
     new strategy.LoadFileConfigStrategy(currentPath + '/stormpath.yml'),
 
     // Load configuration from our environment.
-    new strategy.LoadEnvConfigStrategy('STORMPATH'),
+    new strategy.LoadEnvConfigStrategy('STORMPATH', {
+      // Aliases used to support legacy API key.
+      STORMPATH_APIKEY_ID: 'STORMPATH_API_KEY_ID',
+      STORMPATH_APIKEY_SECRET: 'STORMPATH_API_KEY_SECRET',
+      STORMPATH_APIKEY_FILE: 'STORMPATH_API_KEY_FILE'
+    }),
 
     // Extend our configuration with the configuration we passed into the client.
     // Also, try and load our API key if it was specified in our config.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "properties-parser": "~0.2.3",
     "redis": "~2.2.3",
     "request": "~2.40.0",
-    "stormpath-config": "0.0.9",
+    "stormpath-config": "0.0.12",
     "underscore": "~1.5.2",
     "underscore.string": "~3.2.2"
   },

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -145,8 +145,8 @@ describe('Client', function () {
 
       client.on('ready', function () {
         resetEnvVars();
-        assert.equal(client.config.apiKey.id,'1');
-        assert.equal(client.config.apiKey.secret,'2');
+        assert.equal(client.config.client.apiKey.id,'1');
+        assert.equal(client.config.client.apiKey.secret,'2');
         done();
       });
     });


### PR DESCRIPTION
Fixes backward-compatibility support for the `apiKey` config.

##### How to verify

1. Add a `STORMPATH_APIKEY_ID` or `STORMPATH_APIKEY_SECRET` environment variable.
2. Assert that the environment config is being picked up when initializing the SDK.
3. Add a `{ apiKey: { id: 'your id', secret: 'your secret' }}` client config. I.e. `new stormpath.Client({/* here */})`.
4. Assert that the user config is being picked up when initializing the SDK.