### PR TITLE
Feature: Speed-up tests by caching client

### DIFF
--- a/test/it/client_it.js
+++ b/test/it/client_it.js
@@ -16,19 +16,16 @@ describe('Client', function() {
   describe('creation', function() {
     it('should not throw', function(done) {
       assert.doesNotThrow(function () {
-        helpers.loadApiKey(function(apiKey) {
-          var client = new stormpath.Client({
-            apiKey: apiKey,
-            skipRemoteConfig: true
-          });
+        var client = new stormpath.Client({
+          skipRemoteConfig: true
+        });
 
-          client.on('error', function (err) {
-            throw err;
-          });
+        client.on('error', function (err) {
+          throw err;
+        });
 
-          client.on('ready', function () {
-            done();
-          });
+        client.on('ready', function () {
+          done();
         });
       });
     });


### PR DESCRIPTION
Execute tests faster by only instantiating one client when using the `helper.getClient()` helper method.