### PR TITLE
Fix: Leaking test applications

### DIFF
--- a/test/it/helpers.js
+++ b/test/it/helpers.js
@@ -1,6 +1,14 @@
+var path = require('path');
+var moment = require('moment');
+
+var pkg = require('../../package.json');
 var common = require('../common');
+
 var uuid = common.uuid;
 var stormpath = common.Stormpath;
+
+var hasCleanupRun = false;
+var testRunId = uuid.v4().split('-')[0];
 
 function loadApiKey(cb) {
   var id = process.env.STORMPATH_CLIENT_APIKEY_ID;
@@ -55,6 +63,62 @@ function fakeAccount(){
 }
 
 /**
+ * Get the friendly (printable) name of the calling file.
+ *
+ * @function
+ *
+ * @returns string - The name of the calling file.
+ */
+function getFriendlyCallerName() {
+  var err = new Error();
+
+  var originalPrepareStackTrace = Error.prepareStackTrace;
+
+  Error.prepareStackTrace = function (err, stack) {
+    return stack;
+  };
+
+  try {
+    var currentfile = err.stack.shift().getFileName();
+
+    while (err.stack.length) {
+      var callerfile = err.stack.shift().getFileName();
+
+      if(currentfile !== callerfile) {
+        return path.basename(callerfile).replace('.js', '');
+      }
+    }
+  } catch (err) {
+  }
+
+  Error.prepareStackTrace = originalPrepareStackTrace;
+
+  return 'unknown';
+}
+
+/**
+ * Deletes Stormpath applications that have are older than 5 minutes.
+ *
+ * @function
+ *
+ * @param {Function} callback - A callback to run when done.
+ */
+function cleanupOldApplications(callback) {
+  var fiveMinutesAgo = moment().subtract(5, 'minutes');
+  getClient(function (client) {
+    client.getApplications(function (err, applications) {
+      applications.each(function (application, next) {
+        if (application.name.indexOf(pkg.name + ':') === 0 && moment(application.createdAt).isBefore(fiveMinutesAgo)) {
+          application.delete(next);
+        } else {
+          next();
+        }
+      }, callback);
+    });
+  });
+}
+
+/**
  * Create a new Stormpath Application for usage in tests.
  *
  * @function
@@ -62,21 +126,27 @@ function fakeAccount(){
  * @param {Function} callback - A callback to run when done.
  */
 function createApplication(callback) {
-  var prefix = uuid.v4();
-  var appData = { name: prefix };
-  var opts = { createDirectory: true };
+  if (hasCleanupRun) {
+    var appData = { name: pkg.name + ':' + getFriendlyCallerName() + ':' + testRunId + ':' + uuid.v4() };
+    var opts = { createDirectory: true };
 
-  getClient(function(client){
-    client.createApplication(appData, opts, callback);
-  });
+    getClient(function(client){
+      client.createApplication(appData, opts, callback);
+    });
+  } else {
+    cleanupOldApplications(function () {
+      hasCleanupRun = true;
+      createApplication(callback);
+    });
+  }
 }
-
 
 function fakeDirectory(){
   return {
     name: uniqId()
   };
 }
+
 /**
  * Fetches the default account store for a given application
  *


### PR DESCRIPTION
Fixes the issue with leaking test applications by running a cleanup (of applications older than 5min) before any applications are created using the test helper `helper.createApplication()`.