### PR TITLE
Fixing oauth error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # stormpath-sdk-node Change Log
 
+### 0.13.5
+
+**Not Yet Released**
+
+-Fixed OAuth error responses to include the error code `invalid_client`, where appropriate
+
 ### 0.13.4
 
 - Refactor: DataStore and RequestExecutor now uses `options.client.apiKey` instead of `options.apiKey`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 **Not Yet Released**
 
--Fixed OAuth error responses to include the error code `invalid_client`, where appropriate
+- Fixed OAuth error responses to include the error code `invalid_client`, where appropriate.
 
 ### 0.13.4
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 # Upgrade Guide
 
+### Version 0.13.4 -> Version 0.13.5
+
+No changes needed
+
 ### Version 0.13.3 -> Version 0.13.4
 
 No changes needed

--- a/lib/authc/AuthRequestParser.js
+++ b/lib/authc/AuthRequestParser.js
@@ -7,19 +7,19 @@ var ApiAuthRequestError = require('../error/ApiAuthRequestError');
 function AuthRequestParser(request,locationsToSearch){
 
   if(typeof request !=='object'){
-    throw new ApiAuthRequestError('request must be an object');
+    throw new ApiAuthRequestError({userMessage: 'request must be an object'});
   }
   if(typeof request.url !== 'string'){
-    throw new ApiAuthRequestError('request must have a url string');
+    throw new ApiAuthRequestError({userMessage: 'request must have a url string'});
   }
   if(typeof request.headers !== 'object'){
-    throw new ApiAuthRequestError('request must have a headers object');
+    throw new ApiAuthRequestError({userMessage: 'request must have a headers object'});
   }
   if(typeof request.method !== 'string'){
-    throw new ApiAuthRequestError('request must have a method property');
+    throw new ApiAuthRequestError({userMessage: 'request must have a method property'});
   }
   if(typeof locationsToSearch !== 'object') {
-    throw new ApiAuthRequestError('locationsToSearch must be an array');
+    throw new ApiAuthRequestError({userMessage: 'locationsToSearch must be an array'});
   }
 
   var req = request;

--- a/lib/authc/BasicApiAuthenticator.js
+++ b/lib/authc/BasicApiAuthenticator.js
@@ -6,7 +6,7 @@ var AuthenticationResult = require('../resource/AuthenticationResult');
 function BasicApiAuthenticator(application,authHeaderValue){
   var parts = new Buffer(authHeaderValue.replace(/Basic /i,''),'base64').toString('utf8').split(':');
   if(parts.length!==2){
-    return new ApiAuthRequestError('Invalid Authorization value',400);
+    return new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400});
   }
   this.application = application;
   this.id = parts[0];
@@ -18,7 +18,7 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
 
   self.application.getApiKey(self.id,function(err,apiKey){
     if(err){
-      callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
+      callback(err.status===404 ? new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client',  statusCode: 401}) : err);
     }else{
       if(
         (apiKey.secret===self.secret) &&
@@ -29,7 +29,7 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
         authenticationResult.application = self.application;
         callback(null,authenticationResult);
       }else{
-        callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
+        callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client',  statusCode: 401}));
       }
     }
   });

--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -13,10 +13,10 @@ function OAuthBasicExchangeAuthenticator(application,request,ttl,scopeFactory, r
   var parts = new Buffer(authValue,'base64').toString('utf8').split(':');
 
   if(parts.length!==2){
-    return new ApiAuthRequestError('Invalid Authorization value',400);
+    return new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400});
   }
   if(request.method!=='POST'){
-    return new ApiAuthRequestError('Must use POST for token exchange, see http://tools.ietf.org/html/rfc6749#section-3.2');
+    return new ApiAuthRequestError({userMessage: 'Must use POST for token exchange, see http://tools.ietf.org/html/rfc6749#section-3.2'});
   }
   this.id = parts[0];
   this.secret = parts[1];
@@ -34,7 +34,7 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
   var self = this;
   self.application.getApiKey(self.id,function(err,apiKey){
     if(err){
-      callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
+      callback(err.status===404 ? new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}) : err);
     }else{
       if(
         (apiKey.secret===self.secret) &&
@@ -47,7 +47,7 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
         result.tokenResponse = self.buildTokenResponse(apiKey);
         callback(null,result);
       }else{
-        callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
+        callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}));
       }
     }
   });

--- a/lib/authc/OauthAccessTokenAuthenticator.js
+++ b/lib/authc/OauthAccessTokenAuthenticator.js
@@ -14,7 +14,7 @@ function getJwt(token, secret){
     jwtObject = jwt.decode(token, secret);
   }
   catch(e){
-    return new ApiAuthRequestError('access_token is invalid',401);
+    return new ApiAuthRequestError({userMessage: 'access_token is invalid',statusCode: 401});
   }
   return jwtObject;
 }
@@ -23,14 +23,14 @@ function validateJwt(jwtObject){
   var requiredFields = [['iat',Number],['exp',Number],['sub',String]];
   for(var i=0,m=requiredFields.length;i<m;i++){
     if(!jwtObject[requiredFields[i][0]]||jwtObject[requiredFields[i][0]].constructor!==requiredFields[i][1]){
-      return new ApiAuthRequestError('Missing or invalid jwt parameter: ' + requiredFields[i][0]);
+      return new ApiAuthRequestError({userMessage: 'Missing or invalid jwt parameter: ' + requiredFields[i][0]});
     }
   }
   if(nowEpochSeconds()>jwtObject.exp){
-    return new ApiAuthRequestError('Token has expired', 401);
+    return new ApiAuthRequestError({userMessage: 'Token has expired', statusCode: 401});
   }
   if(jwtObject.scope && typeof jwtObject.scope !== 'string'){
-    return new ApiAuthRequestError('scope must be a string');
+    return new ApiAuthRequestError({userMessage: 'scope must be a string'});
   }
   return null;
 }
@@ -66,7 +66,7 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
   if(subject.match(/accounts/)){
     self.application.dataStore.getResource(subject,null,require('../resource/Account'),function(err,account){
       if(err){
-        callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
+        callback(err.status===404 ? new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}) : err);
       }else if(account.status==='ENABLED'){
         var data = {
           token: self.token,
@@ -80,13 +80,13 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
 
         callback(null,new AuthenticationResult(data,self.application.dataStore));
       }else{
-        callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
+        callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}));
       }
     });
   }else{
     self.application.getApiKey(self.apiKey,function(err,apiKey){
       if(err){
-        callback(err.status===404 ? new ApiAuthRequestError('Invalid Client Credentials', 401) : err);
+        callback(err.status===404 ? new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}) : err);
       }else if(
         (apiKey.status==='ENABLED') &&
         (apiKey.account.status==='ENABLED')
@@ -100,7 +100,7 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
 
         callback(null,new AuthenticationResult(apiKey,self.application.dataStore));
       }else{
-        callback(new ApiAuthRequestError('Invalid Client Credentials', 401));
+        callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401 }));
       }
     });
   }

--- a/lib/error/ApiAuthRequestError.js
+++ b/lib/error/ApiAuthRequestError.js
@@ -8,9 +8,7 @@ function ApiAuthRequestError(errorData){
   this.name='ApiAuthRequestError';
   this.userMessage = this.message = errorData.userMessage;
   this.statusCode = errorData.statusCode || 400;
-  if(errorData.error){
-    this.error = errorData.error;
-  }
+  this.error = errorData.error;
 }
 utils.inherits(ApiAuthRequestError, Error);
 

--- a/lib/error/ApiAuthRequestError.js
+++ b/lib/error/ApiAuthRequestError.js
@@ -2,12 +2,15 @@
 
 var utils  = require('../utils');
 
-function ApiAuthRequestError(message, statusCode){
+function ApiAuthRequestError(errorData){
   Error.call(this);
   Error.captureStackTrace(this, this.constructor);
   this.name='ApiAuthRequestError';
-  this.userMessage = this.message = message;
-  this.statusCode = statusCode || 400;
+  this.userMessage = this.message = errorData.userMessage;
+  this.statusCode = errorData.statusCode || 400;
+  if(errorData.error){
+    this.error = errorData.error;
+  }
 }
 utils.inherits(ApiAuthRequestError, Error);
 

--- a/lib/error/ResourceError.js
+++ b/lib/error/ResourceError.js
@@ -13,6 +13,10 @@ function ResourceError(responseBody) {
   this.message = 'HTTP ' + this.status +
     ', Stormpath ' + this.code + ' (' + this.moreInfo + '): ' +
     this.developerMessage;
+
+  if (responseBody.error) {
+    this.error = responseBody.error;
+  }
 }
 utils.inherits(ResourceError, Error);
 

--- a/lib/jwt/jwt-authenticator.js
+++ b/lib/jwt/jwt-authenticator.js
@@ -29,7 +29,7 @@ JwtAuthenticator.prototype.withCookie = function withCookie(cookieName){
 };
 
 JwtAuthenticator.prototype.unauthenticated = function unauthenticated(){
-  return new ApiAuthRequestError('Unauthorized', 401);
+  return new ApiAuthRequestError({userMessage:'Unauthorized', statusCode: 401});
 };
 
 JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){

--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -65,7 +65,7 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
 };
 
 OAuthAuthenticator.prototype.unauthenticated = function unauthenticated(){
-  return new ApiAuthRequestError('Unauthorized', 401);
+  return new ApiAuthRequestError({userMessage: 'Unauthorized', statusCode: 401});
 };
 
 module.exports = OAuthAuthenticator;

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -317,15 +317,15 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
   var self = this;
 
   if(typeof options!=='object'){
-    throw new ApiAuthRequestError('options must be an object');
+    throw new ApiAuthRequestError({userMessage: 'options must be an object' });
   }
 
   if(typeof options.request!=='object'){
-    throw new ApiAuthRequestError('options.request must be an object');
+    throw new ApiAuthRequestError({userMessage: 'options.request must be an object' });
   }
 
   if(options.ttl && (typeof options.ttl!=='number')){
-    throw new ApiAuthRequestError('ttl must be a number');
+    throw new ApiAuthRequestError({userMessage: 'ttl must be a number'});
   }
   var validAccessTokenRequestLocations = ['header','body','url'];
   var defaultAccessTokenRequestLocations = ['header','body'];
@@ -356,7 +356,7 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
   var grantType = parser.grantType;
 
   if(grantType && grantType!=='client_credentials'){
-    return callback(new ApiAuthRequestError('Unsupported grant_type'));
+    return callback(new ApiAuthRequestError({userMessage: 'Unsupported grant_type'}));
   }
 
   var authenticator;
@@ -384,14 +384,14 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
         callback
       );
     }else{
-      return callback(new ApiAuthRequestError('Invalid Authorization value',400));
+      return callback(new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400}));
     }
   }else if(accessToken){
     authenticator = new OauthAccessTokenAuthenticator(self, accessToken, callback);
   }
 
   if(!authenticator){
-    return callback(new ApiAuthRequestError('Must provide access_token.',401));
+    return callback(new ApiAuthRequestError({userMessage: 'Must provide access_token.', statusCode: 401}));
   }
 
   if(authenticator instanceof Error){

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -4,7 +4,7 @@ var helpers = require('./helpers');
 var assert = common.assert;
 
 var AuthenticationResult = require('../../lib/resource/AuthenticationResult');
-var AuthenticationResult = require('../../lib/resource/AuthenticationResult');
+
 describe('Application.authenticateApiRequest',function(){
 
   var app, account, apiKey, client;


### PR DESCRIPTION
We need to send `invalid_client` for situations where client authentication fails.