### PR TITLE
Removing remote strategy loading

### DIFF
--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -1,22 +1,11 @@
 var path = require('path');
 
-var Client = require('./Client');
 var stormpathConfig = require('stormpath-config');
 var strategy = stormpathConfig.strategy;
 
 // Set the paths the we want to load configuration files from
 var currentPath = process.cwd();
 var stormpathPath = '~/.stormpath';
-
-// Factory method to create a client using a configuration only.
-// The configuration provided to this factory is the final configuration.
-function ClientFactory (config) {
-  return new Client(
-    new stormpathConfig.Loader([
-      new strategy.ExtendConfigStrategy(config)
-    ])
-  );
-}
 
 // Create a default client config loader.
 module.exports = function (extendWithConfig) {
@@ -51,9 +40,7 @@ module.exports = function (extendWithConfig) {
     new strategy.EnrichClientConfigStrategy(),
 
     // Validate config so that we know that we have an API key and can continue...
-    new strategy.ValidateClientConfigStrategy(),
+    new strategy.ValidateClientConfigStrategy()
 
-    // Enrich our config with application data from the Stormpath API.
-    new strategy.EnrichClientFromRemoteConfigStrategy(ClientFactory)
   ]);
 };

--- a/test/it/client_it.js
+++ b/test/it/client_it.js
@@ -16,9 +16,7 @@ describe('Client', function() {
   describe('creation', function() {
     it('should not throw', function(done) {
       assert.doesNotThrow(function () {
-        var client = new stormpath.Client({
-          skipRemoteConfig: true
-        });
+        var client = new stormpath.Client();
 
         client.on('error', function (err) {
           throw err;

--- a/test/it/helpers.js
+++ b/test/it/helpers.js
@@ -16,9 +16,7 @@ function getClient(cb) {
     return cb(loadedClient);
   }
 
-  var client = new stormpath.Client({
-    skipRemoteConfig: true
-  });
+  var client = new stormpath.Client();
 
   client.on('error', function (err) {
     throw err;

--- a/test/it/password_policy_it.js
+++ b/test/it/password_policy_it.js
@@ -9,7 +9,7 @@ describe('PasswordPolicy', function() {
     var client, directory;
 
     before(function (done) {
-      client = new Client({ skipRemoteConfig: true });
+      client = new Client();
 
       client.on('error', function (err) {
         done(err);

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -15,7 +15,6 @@ var Application = require('../lib/resource/Application');
 var DataStore = require('../lib/ds/DataStore');
 
 function makeTestClient (options) {
-  options.skipRemoteConfig = true;
   return new Client(options);
 }
 

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -53,9 +53,7 @@ describe('Configuration loader', function () {
   }
 
   beforeEach(function () {
-    loader = configLoader({
-      skipRemoteConfig: true
-    });
+    loader = configLoader();
   });
 
   after(function () {
@@ -117,7 +115,6 @@ describe('Configuration loader', function () {
     };
 
     loader = configLoader({
-      skipRemoteConfig: true,
       apiKey: dummyApiKey
     });
 
@@ -233,7 +230,6 @@ describe('Configuration loader', function () {
     setupFakeFs();
 
     var customConfig = {
-      skipRemoteConfig: true,
       apiKey: {
         id: uuid(),
         secret: uuid()
@@ -401,7 +397,6 @@ describe('Configuration loader', function () {
     setupFakeFs();
 
     var customConfig = {
-      skipRemoteConfig: true,
       client: {
         apiKey: {
           id: uuid(),


### PR DESCRIPTION
@typerandom can you sanity check this for me?

`stormpath-config@0.0.13` affects master in this repo, in that you cannot create a client without specifying application configuration.  This is not what we want from the Node SDK, as you don't always want to be working with an application - that requirement is delegated to the framework integration (which does require an application).

Here is the related change in the express library:

https://github.com/stormpath/express-stormpath/commit/3df9ab26afc815550a709f33dcad329b7380bd41