### PR TITLE
Fix: Cache eviction of customData when calling account.save()

### DIFF
--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -100,8 +100,8 @@ Account.prototype.save = function saveAccount(){
   // If customData, then inject our own callback and invalidate the
   // customData resource cache when the account finishes saving.
   if (self.customData) {
-    var originalCallback = args.length > 0 && typeof args[args.length - 1] === 'function' ?
-      args.pop() : function nop() {};
+    var lastArg = args.length > 0 ? args[args.length - 1] : null;
+    var originalCallback = typeof lastArg === 'function' ? args.pop() : function nop() {};
 
     args.push(function newCallback() {
       self.dataStore._evict(self.customData.href, originalCallback);

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -94,7 +94,20 @@ Account.prototype.getApiKeys = function getApiKeys(options,callback) {
 
 Account.prototype.save = function saveAccount(){
   var self = this;
-  var args = arguments;
+
+  var args = Array.prototype.slice.call(arguments);
+
+  // If customData, then inject our own callback and invalidate the
+  // customData resource cache when the account finishes saving.
+  if (self.customData) {
+    var originalCallback = args.length > 0 && typeof args[args.length - 1] === 'function' ?
+      args.pop() : function nop() {};
+
+    args.push(function newCallback() {
+      self.dataStore._evict(self.customData.href, originalCallback);
+    });
+  }
+
   self._applyCustomDataUpdatesIfNecessary(function(){
     Account.super_.prototype.save.apply(self, args);
   });


### PR DESCRIPTION
Invalidate customData when setting customData on an account and then calling `account.save()`.

Previously the customData resource would be updated, but the cache would still be stale.

Closes https://github.com/stormpath/express-stormpath/issues/156