### PR TITLE
Refactor: Remove redundant self

### DIFF
--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -110,14 +110,13 @@ OAuthBasicExchangeAuthenticator.prototype.buildTokenResponse = function buildTok
 };
 
 OAuthBasicExchangeAuthenticator.prototype.buildAccessToken = function buildAccessToken(account, scope) {
-  var self = this;
   var now = nowEpochSeconds();
 
   var _jwt = {
-    sub: self.id,
-    iss: self.application.href,
+    sub: this.id,
+    iss: this.application.href,
     iat: now,
-    exp: now + self.ttl
+    exp: now + this.ttl
   };
 
   if(scope){
@@ -125,7 +124,7 @@ OAuthBasicExchangeAuthenticator.prototype.buildAccessToken = function buildAcces
     _jwt.scope = Array.isArray(scope) ? scope.join(' ') : scope;
   }
 
-  return self._token = jwt.encode(_jwt, self.application.dataStore.requestExecutor.options.client.apiKey.secret, 'HS256');
+  return this._token = jwt.encode(_jwt, this.application.dataStore.requestExecutor.options.client.apiKey.secret, 'HS256');
 };
 
 module.exports = OAuthBasicExchangeAuthenticator;

--- a/lib/authc/Sauthc1RequestAuthenticator.js
+++ b/lib/authc/Sauthc1RequestAuthenticator.js
@@ -26,9 +26,7 @@ utils.inherits(Sauthc1RequestAuthenticator, RequestAuthenticator);
 
 //TODO: finish this implementation:
 Sauthc1RequestAuthenticator.prototype.authenticate = function sauthc1Authenticate(req) {
-
-  var self = this;
-  var apiKey = self.apiKey;
+  var apiKey = this.apiKey;
 
   function isDefaultPort(parsedUrl) {
     var protocol = parsedUrl.protocol;

--- a/lib/cache/CacheEntry.js
+++ b/lib/cache/CacheEntry.js
@@ -14,13 +14,12 @@ var moment = require('moment');
  * @constructor
  */
 function CacheEntry(value, createdAt, lastAccessedAt){
-  var self = this;
-  self.value = value;
-  self.createdAt = createdAt || Date.now();
-  self.lastAccessedAt = lastAccessedAt || self.createdAt;
+  this.value = value;
+  this.createdAt = createdAt || Date.now();
+  this.lastAccessedAt = lastAccessedAt || this.createdAt;
 
-  if (typeof self.createdAt !== 'number' ||
-    typeof self.lastAccessedAt !== 'number'){
+  if (typeof this.createdAt !== 'number' ||
+    typeof this.lastAccessedAt !== 'number'){
     throw new Error('Expecting date in timestamp format or use CacheEntry.parse method instead');
   }
 }

--- a/lib/cache/CacheStats.js
+++ b/lib/cache/CacheStats.js
@@ -6,14 +6,11 @@
  * @constructor
  */
 function CacheStats() {
-
-  var self = this;
-
-  self.puts = 0;
-  self.hits = 0;
-  self.misses = 0;
-  self.expirations = 0;
-  self.size = 0;
+  this.puts = 0;
+  this.hits = 0;
+  this.misses = 0;
+  this.expirations = 0;
+  this.size = 0;
 }
 
 /**

--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -61,7 +61,6 @@ RequestExecutor.prototype.qualify = function qualify(uri){
  * @param callback the callback to invoke when the request returns
  */
 RequestExecutor.prototype.execute = function executeRequest(req, callback) {
-  var self = this;
   if (!req) {
     throw new Error('Request argument is required.');
   }
@@ -75,7 +74,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
   if (req.method) { //defaults to GET
     options.method = req.method;
   }
-  options.uri = self.qualify(req.uri);
+  options.uri = this.qualify(req.uri);
   if (req.query) {
     options.qs = req.query;
   }

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -25,17 +25,17 @@ function OAuthPasswordGrantRequestAuthenticator(application) {
   return this;
 }
 OAuthPasswordGrantRequestAuthenticator.prototype.authenticate = function authenticate(data,callback) {
-  var self = this;
+  var application = this.application;
   if(arguments.length !==2 ){
     throw new Error('Must call authenticate with (data,callback)');
   }else{
-    var href = this.application.href + '/oauth/token';
+    var href = application.href + '/oauth/token';
     data.grant_type='password';
-    this.application.dataStore.createResource(href,{form:data},function(err,data){
+    application.dataStore.createResource(href,{form:data},function(err,data){
       if(err){
         return callback(err);
       }
-      callback(null,new OAuthPasswordGrantAuthenticationResult(self.application,data));
+      callback(null,new OAuthPasswordGrantAuthenticationResult(application,data));
     });
   }
 };

--- a/lib/oauth/refresh-grant.js
+++ b/lib/oauth/refresh-grant.js
@@ -25,22 +25,22 @@ function OAuthRefreshTokenGrantAuthenticator(application) {
   return this;
 }
 OAuthRefreshTokenGrantAuthenticator.prototype.authenticate = function authenticate(data,callback) {
-  var self = this;
+  var application = this.application;
   if(arguments.length !==2 ){
     throw new Error('Must call authenticate with (data,callback)');
   }else if (!data.refresh_token){
     throw new Error('data does not have refresh_token property');
   }else{
-    var href = this.application.href + '/oauth/token';
+    var href = application.href + '/oauth/token';
     var formData = {
       grant_type: 'refresh_token',
       refresh_token: data.refresh_token
     };
-    this.application.dataStore.createResource(href,{form:formData},function(err,data){
+    application.dataStore.createResource(href,{form:formData},function(err,data){
       if(err){
         return callback(err);
       }
-      callback(null,new OAuthRefreshTokenGrantAuthenticationResult(self.application,data));
+      callback(null,new OAuthRefreshTokenGrantAuthenticationResult(application,data));
     });
   }
 };

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -12,43 +12,38 @@ function Account(data) {
 utils.inherits(Account, DirectoryChildResource);
 
 Account.prototype.getAccessTokens = function getAccessTokens(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accessTokens.href, options, require('./AccessToken'), callback);
+  return this.dataStore.getResource(this.accessTokens.href, options, require('./AccessToken'), callback);
 };
 
 Account.prototype.getRefreshTokens = function getRefreshTokens(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.refreshTokens.href, options, require('./RefreshToken'), callback);
+  return this.dataStore.getResource(this.refreshTokens.href, options, require('./RefreshToken'), callback);
 };
 
 Account.prototype.getGroups = function getAccountGroups(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.groups.href, options, require('./Group'), callback);
+  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
 };
 
 Account.prototype.getGroupMemberships = function getGroupMemberships(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.groupMemberships.href, options, require('./GroupMembership'), callback);
+  return this.dataStore.getResource(this.groupMemberships.href, options, require('./GroupMembership'), callback);
 };
 
 Account.prototype.addToGroup = function addAccountToGroup(/* groupOrGroupHref, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var group = args.shift();
   var callback = args.pop();
@@ -60,36 +55,33 @@ Account.prototype.addToGroup = function addAccountToGroup(/* groupOrGroupHref, [
     };
   }
 
-  return self._createGroupMembership(self, group, options, callback);
+  return this._createGroupMembership(this, group, options, callback);
 };
 
 Account.prototype.getProviderData = function getProviderData(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  if (!self.providerData){
+  if (!this.providerData){
     return callback();
   }
 
-  return self.dataStore.getResource(self.providerData.href, options, require('./ProviderData'), callback);
+  return this.dataStore.getResource(this.providerData.href, options, require('./ProviderData'), callback);
 };
 
 Account.prototype.createApiKey = function createApiKey(options,callback) {
-  var self = this;
   var cb = typeof options === 'function' ? options : callback;
-  var opts = _.extend({},self.dataStore.apiKeyEncryptionOptions,typeof options === 'object' ? options : {});
+  var opts = _.extend({},this.dataStore.apiKeyEncryptionOptions,typeof options === 'object' ? options : {});
 
-  return self.dataStore.createResource(self.apiKeys.href, opts, null, require('./ApiKey'), cb);
+  return this.dataStore.createResource(this.apiKeys.href, opts, null, require('./ApiKey'), cb);
 };
 
 Account.prototype.getApiKeys = function getApiKeys(options,callback) {
-  var self = this;
   var cb = typeof options === 'function' ? options : callback;
-  var opts = _.extend({},self.dataStore.apiKeyEncryptionOptions,typeof options === 'object' ? options : {});
+  var opts = _.extend({},this.dataStore.apiKeyEncryptionOptions,typeof options === 'object' ? options : {});
 
-  return self.dataStore.getResource(self.apiKeys.href, opts, require('./ApiKey'), cb);
+  return this.dataStore.getResource(this.apiKeys.href, opts, require('./ApiKey'), cb);
 };
 
 Account.prototype.save = function saveAccount(){

--- a/lib/resource/AccountStoreMapping.js
+++ b/lib/resource/AccountStoreMapping.js
@@ -40,20 +40,18 @@ AccountStoreMapping.prototype.getApplication = function getApplication(/* [optio
     should be removed
     @TODO Version 1.0
   */
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.application.href, options, require('./Application'), callback);
+  return this.dataStore.getResource(this.application.href, options, require('./Application'), callback);
 };
 AccountStoreMapping.prototype.getAccountStore = function getAccountStore(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accountStore.href, options, AccountStoreClassFactory, callback);
+  return this.dataStore.getResource(this.accountStore.href, options, AccountStoreClassFactory, callback);
 };
 
 AccountStoreMapping.prototype.setApplication = function setAccountStoreMappingApplication(application) {

--- a/lib/resource/ApiKey.js
+++ b/lib/resource/ApiKey.js
@@ -11,12 +11,11 @@ function ApiKey() {
 utils.inherits(ApiKey, InstanceResource);
 
 ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {
-  var self = this;
-  var salt = self.apiKeyMetaData.encryptionKeySalt;
-  var iterations = self.apiKeyMetaData.encryptionKeyIterations;
-  var keyLengthBits = self.apiKeyMetaData.encryptionKeySize;
-  var password = new Buffer(self.dataStore.requestExecutor.options.client.apiKey.secret);
-  var encryptedSecret = new Buffer(self.secret,'base64');
+  var salt = this.apiKeyMetaData.encryptionKeySalt;
+  var iterations = this.apiKeyMetaData.encryptionKeyIterations;
+  var keyLengthBits = this.apiKeyMetaData.encryptionKeySize;
+  var password = new Buffer(this.dataStore.requestExecutor.options.client.apiKey.secret);
+  var encryptedSecret = new Buffer(this.secret,'base64');
   var iv = encryptedSecret.slice(0,16);
   var rawEncryptedValue = encryptedSecret.slice(16);
   crypto.pbkdf2(password,new Buffer(salt,'base64'),iterations,(keyLengthBits/8),function(err,key){

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -24,11 +24,10 @@ function Application() {
 utils.inherits(Application, InstanceResource);
 
 Application.prototype.createIdSiteUrl = function createIdSiteUrl(_options) {
-  var self = this;
   var options = typeof _options === "object" ? _options : {};
-  var p = url.parse(self.href);
+  var p = url.parse(this.href);
   var base = p.protocol + '//' + p.host;
-  var apiKey = self.dataStore.requestExecutor.options.client.apiKey;
+  var apiKey = this.dataStore.requestExecutor.options.client.apiKey;
   var nonce = uuid();
   var state = options.state || '';
 
@@ -40,7 +39,7 @@ Application.prototype.createIdSiteUrl = function createIdSiteUrl(_options) {
     jti: nonce,
     iat: new Date().getTime()/1000,
     iss: apiKey.id,
-    sub: self.href,
+    sub: this.href,
     state: encodeURIComponent(state),
     path: options.path || '/',
     cb_uri: options.callbackUri
@@ -77,8 +76,6 @@ Application.prototype._decodeJwt = function _decodeJwt(str,secret){
 };
 
 Application.prototype.handleIdSiteCallback = function handleIdSiteCallback(responseUri,callback) {
-  var self = this;
-
   if(typeof responseUri !== 'string'){
     throw new Error('handleIdSiteCallback must be called with an uri string');
   }
@@ -87,10 +84,12 @@ Application.prototype.handleIdSiteCallback = function handleIdSiteCallback(respo
 
   var params = (url.parse(responseUri,true).query) || {};
   var token = params.jwtResponse || '';
-  var secret = self.dataStore.requestExecutor.options.client.apiKey.secret;
-  var apiKeyId = self.dataStore.requestExecutor.options.client.apiKey.id;
 
-  var responseJwt = self._decodeJwt(token,secret);
+  var dataStore = this.dataStore;
+  var secret = dataStore.requestExecutor.options.client.apiKey.secret;
+  var apiKeyId = dataStore.requestExecutor.options.client.apiKey.id;
+
+  var responseJwt = this._decodeJwt(token,secret);
 
   if(responseJwt instanceof Error){
     return cb(responseJwt);
@@ -111,15 +110,15 @@ Application.prototype.handleIdSiteCallback = function handleIdSiteCallback(respo
   var nonce = responseJwt.body.irt;
   var accountHref = responseJwt.body.sub;
 
-  self.dataStore.nonceStore.getNonce(nonce,function(err,value){
+  dataStore.nonceStore.getNonce(nonce,function(err,value){
     if(err){
       cb(err);
     }else if(value){
       cb(new Error(errorMessages.ID_SITE_JWT_ALREADY_USED));
     }else{
-      self.dataStore.nonceStore.putNonce(nonce,utils.noop);
+      dataStore.nonceStore.putNonce(nonce,utils.noop);
 
-      self.dataStore.getResource(accountHref,Account,function(err,account){
+      dataStore.getResource(accountHref,Account,function(err,account){
         if(err){
           cb(err);
         }else{
@@ -170,44 +169,38 @@ Application.prototype.authenticateAccount = function authenticateApplicationAcco
 };
 
 Application.prototype.sendPasswordResetEmail = function sendApplicationPasswordResetEmail(emailOrUsernameOrOptions, callback) {
-  var self = this;
   var options = typeof emailOrUsernameOrOptions === 'string' ? {
     email: emailOrUsernameOrOptions
   } : emailOrUsernameOrOptions;
-  return self.dataStore.createResource(self.passwordResetTokens.href, options, callback);
+  return this.dataStore.createResource(this.passwordResetTokens.href, options, callback);
 };
 
 Application.prototype.resendVerificationEmail = function resendVerificationEmail(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
-  return self.dataStore.createResource(self.verificationEmails.href, options, callback);
+  return this.dataStore.createResource(this.verificationEmails.href, options, callback);
 };
 
 Application.prototype.verifyPasswordResetToken = function verifyApplicationPasswordResetToken(token, callback) {
-  var self = this;
-  var href = self.passwordResetTokens.href + "/" + token;
-  return self.dataStore.getResource(href, callback);
+  var href = this.passwordResetTokens.href + "/" + token;
+  return this.dataStore.getResource(href, callback);
 };
 
 Application.prototype.resetPassword = function resetApplicationPassword(token, password, callback) {
-  var self = this;
-  var href = self.passwordResetTokens.href + "/" + token;
-  return self.dataStore.createResource(href, {expand: 'account'}, { password: password }, callback);
+  var href = this.passwordResetTokens.href + "/" + token;
+  return this.dataStore.createResource(href, {expand: 'account'}, { password: password }, callback);
 };
 
 Application.prototype.getAccounts = function getApplicationAccounts(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accounts.href, options, require('./Account'), callback);
+  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
 };
 
 Application.prototype.getAccount = function getAccount(/* providerData, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var providerData = args.shift();
   var callback = args.pop();
@@ -234,69 +227,64 @@ Application.prototype.getAccount = function getAccount(/* providerData, [options
     };
   };
 
-  return self.dataStore.createResource(self.accounts.href, options, providerData, require('./Account'), w(callback));
+  return this.dataStore.createResource(this.accounts.href, options, providerData, require('./Account'), w(callback));
 };
 
 Application.prototype.createAccount = function createApplicationAccount(/* account, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var account = args.shift();
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.createResource(self.accounts.href, options, account, require('./Account'), callback);
+  return this.dataStore.createResource(this.accounts.href, options, account, require('./Account'), callback);
 };
 
 Application.prototype.getGroups = function getApplicationGroups(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.groups.href, options, require('./Group'), callback);
+  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
 };
 
 Application.prototype.createGroup = function createApplicationGroup(/* group, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var group = args.shift();
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.createResource(self.groups.href, options, group, require('./Group'), callback);
+  return this.dataStore.createResource(this.groups.href, options, group, require('./Group'), callback);
 };
 
 Application.prototype.getOAuthPolicy = function getOAuthPolicy(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.oAuthPolicy.href, options, require('./InstanceResource'), callback);
+  return this.dataStore.getResource(this.oAuthPolicy.href, options, require('./InstanceResource'), callback);
 };
 
 Application.prototype.getTenant = function getApplicationTenant(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.tenant.href, options, require('./Tenant'), callback);
+  return this.dataStore.getResource(this.tenant.href, options, require('./Tenant'), callback);
 };
 
 Application.prototype.getApiKey = function getApiKey(apiKeyId, options, callback) {
-  var self = this;
   var argCount = Array.prototype.slice.call(arguments).length;
   var cb = argCount === 3 ? callback : options;
 
-  var opts = _.extend({},self.dataStore.apiKeyEncryptionOptions,argCount === 3 ? options : {id:apiKeyId});
+  var dataStore = this.dataStore;
+  var opts = _.extend({},dataStore.apiKeyEncryptionOptions,argCount === 3 ? options : {id:apiKeyId});
 
-  return self.dataStore.getResource(self.apiKeys.href, opts, require('./ApiKey'), function(err,result){
+  return dataStore.getResource(this.apiKeys.href, opts, require('./ApiKey'), function(err,result){
     if(err){
       cb(err);
     }else if(result instanceof require('./ApiKey')){
       // this happens if we found it in the cache.  manually 'expand' the account
-      self.dataStore.getResource(result.account.href,function(err,account){
+      dataStore.getResource(result.account.href,function(err,account){
         if(err){ cb(err); }else{
           result.account = account;
           cb(null,result);
@@ -314,8 +302,6 @@ Application.prototype.getApiKey = function getApiKey(apiKeyId, options, callback
 };
 
 Application.prototype.authenticateApiRequest = function authenticateApiRequest(options,callback) {
-  var self = this;
-
   if(typeof options!=='object'){
     throw new ApiAuthRequestError({userMessage: 'options must be an object' });
   }
@@ -341,8 +327,6 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
 
   var ttl = options.ttl;
 
-  var application = self;
-
   var req = options.request;
 
   var scopeFactory = typeof options.scopeFactory === 'function' ? options.scopeFactory : null;
@@ -365,7 +349,7 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
     if(authHeaderValue.match(/Basic/i)){
       if(grantType){
         authenticator = new OAuthBasicExchangeAuthenticator(
-          application,
+          this,
           req,
           ttl,
           scopeFactory,
@@ -373,13 +357,13 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
         );
       }else{
         authenticator = new BasicApiAuthenticator(
-          application,
+          this,
           authHeaderValue
         );
       }
     }else if(authHeaderValue.match(/Bearer/i)){
       authenticator = new OauthAccessTokenAuthenticator(
-        self,
+        this,
         authHeaderValue.replace(/Bearer /i,''),
         callback
       );
@@ -387,7 +371,7 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
       return callback(new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400}));
     }
   }else if(accessToken){
-    authenticator = new OauthAccessTokenAuthenticator(self, accessToken, callback);
+    authenticator = new OauthAccessTokenAuthenticator(this, accessToken, callback);
   }
 
   if(!authenticator){
@@ -403,32 +387,30 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
 };
 
 Application.prototype.getAccountStoreMappings = function getAccountStoreMappings(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accountStoreMappings.href, options, ApplicationAccountStoreMapping, callback);
+  return this.dataStore.getResource(this.accountStoreMappings.href, options, ApplicationAccountStoreMapping, callback);
 };
 
 Application.prototype.getDefaultAccountStore = function getDefaultAccountStore(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  if (!self.defaultAccountStoreMapping) {
+  if (!this.defaultAccountStoreMapping) {
     return callback();
   }
 
-  return self.dataStore.getResource(self.defaultAccountStoreMapping.href, options, ApplicationAccountStoreMapping, callback);
+  return this.dataStore.getResource(this.defaultAccountStoreMapping.href, options, ApplicationAccountStoreMapping, callback);
 };
 
 Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(store, callback) {
   var self = this;
   store = 'string' === typeof store ? {href: store} : store;
 
-  self.getAccountStoreMappings(function (err, res) {
+  this.getAccountStoreMappings(function (err, res) {
     if (err) {
       return callback(err);
     }
@@ -445,6 +427,7 @@ Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(s
     var mapping = new ApplicationAccountStoreMapping({ isDefaultAccountStore: true })
       .setApplication(self)
       .setAccountStore(store);
+
     return self.dataStore.createResource('/accountStoreMappings', null, mapping, ApplicationAccountStoreMapping, clearCache);
   }
 
@@ -464,23 +447,22 @@ Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(s
 };
 
 Application.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  if (!self.defaultGroupStoreMapping) {
+  if (!this.defaultGroupStoreMapping) {
     return callback();
   }
 
-  return self.dataStore.getResource(self.defaultGroupStoreMapping.href, options, ApplicationAccountStoreMapping, callback);
+  return this.dataStore.getResource(this.defaultGroupStoreMapping.href, options, ApplicationAccountStoreMapping, callback);
 };
 
 Application.prototype.setDefaultGroupStore = function setDefaultGroupStore(store, callback) {
   var self = this;
   store = 'string' === typeof store ? {href: store} : store;
 
-  self.getAccountStoreMappings(function (err, res) {
+  this.getAccountStoreMappings(function (err, res) {
     if (err) {
       return callback(err);
     }
@@ -516,11 +498,10 @@ Application.prototype.setDefaultGroupStore = function setDefaultGroupStore(store
 };
 
 Application.prototype.createAccountStoreMapping = function createAccountStoreMapping(mapping, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var options = (args.length > 2) ? args[1] : null;
 
-  mapping = new ApplicationAccountStoreMapping(mapping).setApplication(self);
+  mapping = new ApplicationAccountStoreMapping(mapping).setApplication(this);
 
   return this.dataStore.createResource('/accountStoreMappings', options, mapping, ApplicationAccountStoreMapping, callback);
 };
@@ -543,12 +524,11 @@ Application.prototype.addAccountStore = function addAccountStore(store, callback
 };
 
 Application.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.customData.href, options, require('./CustomData'), callback);
+  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
 };
 
 module.exports = Application;

--- a/lib/resource/ApplicationAccountStoreMapping.js
+++ b/lib/resource/ApplicationAccountStoreMapping.js
@@ -10,12 +10,11 @@ function ApplicationAccountStoreMapping() {
 utils.inherits(ApplicationAccountStoreMapping, AccountStoreMapping);
 
 ApplicationAccountStoreMapping.prototype.getApplication = function getApplication(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.application.href, options, require('./Application'), callback);
+  return this.dataStore.getResource(this.application.href, options, require('./Application'), callback);
 };
 
 ApplicationAccountStoreMapping.prototype.setApplication = function setApplication(application) {

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -13,21 +13,19 @@ function AuthenticationResult() {
 utils.inherits(AuthenticationResult, InstanceResource);
 
 AuthenticationResult.prototype.getAccount = function getAuthenticationResultAccount(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.account.href, options, require('./Account'), callback);
+  return this.dataStore.getResource(this.account.href, options, require('./Account'), callback);
 };
 
 AuthenticationResult.prototype.getJwt = function getJwt() {
-  var self = this;
   return nJwt.create({
-    iss: self.application.href,
-    sub: self.forApiKey ? self.forApiKey.id : self.account.href,
+    iss: this.application.href,
+    sub: this.forApiKey ? this.forApiKey.id : this.account.href,
     jti: utils.uuid()
-  },self.application.dataStore.requestExecutor.options.client.apiKey.secret)
+  },this.application.dataStore.requestExecutor.options.client.apiKey.secret)
   .setExpiration(new Date().getTime() + (3600*1000));
 };
 

--- a/lib/resource/Directory.js
+++ b/lib/resource/Directory.js
@@ -9,90 +9,81 @@ function Directory() {
 utils.inherits(Directory, InstanceResource);
 
 Directory.prototype.getAccounts = function getDirectoryAccounts(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accounts.href, options, require('./Account'), callback);
+  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
 };
 
 Directory.prototype.getAccountCreationPolicy = function getAccountCreationPolicy(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accountCreationPolicy.href, options, require('./InstanceResource'), callback);
+  return this.dataStore.getResource(this.accountCreationPolicy.href, options, require('./InstanceResource'), callback);
 };
 
 Directory.prototype.getPasswordPolicy = function getPasswordPolicy(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.passwordPolicy.href, options, require('./PasswordPolicy'), callback);
+  return this.dataStore.getResource(this.passwordPolicy.href, options, require('./PasswordPolicy'), callback);
 };
 
 Directory.prototype.createAccount = function createDirectoryAccount(/* account, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var account = args.shift();
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.createResource(self.accounts.href, options, account, require('./Account'), callback);
+  return this.dataStore.createResource(this.accounts.href, options, account, require('./Account'), callback);
 };
 
 Directory.prototype.getGroups = function getDirectoryGroups(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.groups.href, options, require('./Group'), callback);
+  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
 };
 
 Directory.prototype.createGroup = function createDirectoryGroup(/* group, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var group = args.shift();
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.createResource(self.groups.href, options, group, require('./Group'), callback);
+  return this.dataStore.createResource(this.groups.href, options, group, require('./Group'), callback);
 };
 
 Directory.prototype.getTenant = function getDirectoryTenant(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.tenant.href, options, require('./Tenant'), callback);
+  return this.dataStore.getResource(this.tenant.href, options, require('./Tenant'), callback);
 };
 
 Directory.prototype.getProvider = function getProvider(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  if (!self.provider){
+  if (!this.provider){
     return callback();
   }
 
-  return self.dataStore.getResource(self.provider.href, options, require('./Provider'), callback);
+  return this.dataStore.getResource(this.provider.href, options, require('./Provider'), callback);
 };
 
 Directory.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.customData.href, options, require('./CustomData'), callback);
+  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
 };
 
 module.exports = Directory;

--- a/lib/resource/DirectoryChildResource.js
+++ b/lib/resource/DirectoryChildResource.js
@@ -9,25 +9,22 @@ function DirectoryChildResource() {
 utils.inherits(DirectoryChildResource, InstanceResource);
 
 DirectoryChildResource.prototype._applyCustomDataUpdatesIfNecessary = function applyCustomDataUpdatesIfNecessary(cb){
-  var self = this;
-  if (!self.customData){
+  if (!this.customData){
     return cb();
   }
 
-  if (self.customData._hasReservedFields()){
-    self.customData = self.customData._deleteReservedFields();
+  if (this.customData._hasReservedFields()){
+    this.customData = this.customData._deleteReservedFields();
   }
 
-  if (self.customData._hasRemovedProperties()){
-    return self.customData._deleteRemovedProperties(cb);
+  if (this.customData._hasRemovedProperties()){
+    return this.customData._deleteRemovedProperties(cb);
   }
 
   return cb();
 };
 
 DirectoryChildResource.prototype._createGroupMembership = function createGroupMembership(account, group, options, callback) {
-  var self = this;
-
   var href = '/groupMemberships';
 
   var membership = {
@@ -39,34 +36,31 @@ DirectoryChildResource.prototype._createGroupMembership = function createGroupMe
     }
   };
 
-  return self.dataStore.createResource(href, options, membership, require('./GroupMembership'), callback);
+  return this.dataStore.createResource(href, options, membership, require('./GroupMembership'), callback);
 };
 
 DirectoryChildResource.prototype.getDirectory = function getDirectoryChildResourceDirectory(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.directory.href, options, require('./Directory'), callback);
+  return this.dataStore.getResource(this.directory.href, options, require('./Directory'), callback);
 };
 
 DirectoryChildResource.prototype.getTenant = function getDirectoryChildResourceTenant(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.tenant.href, options, require('./Tenant'), callback);
+  return this.dataStore.getResource(this.tenant.href, options, require('./Tenant'), callback);
 };
 
 DirectoryChildResource.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.customData.href, options, require('./CustomData'), callback);
+  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
 };
 
 module.exports = DirectoryChildResource;

--- a/lib/resource/Group.js
+++ b/lib/resource/Group.js
@@ -9,7 +9,6 @@ function Group() {
 utils.inherits(Group, DirectoryChildResource);
 
 Group.prototype.addAccount = function addGroupAccount(/* accountOrAccountHref, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var account = args.shift();
   var callback = args.pop();
@@ -21,25 +20,23 @@ Group.prototype.addAccount = function addGroupAccount(/* accountOrAccountHref, [
     };
   }
 
-  return self._createGroupMembership(account, self, options, callback);
+  return this._createGroupMembership(account, this, options, callback);
 };
 
 Group.prototype.getAccounts = function getGroupAccounts(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accounts.href, options, require('./Account'), callback);
+  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
 };
 
 Group.prototype.getAccountMemberships = function getGroupAccountMemberships(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accountMemberships.href, options, require('./GroupMembership'), callback);
+  return this.dataStore.getResource(this.accountMemberships.href, options, require('./GroupMembership'), callback);
 };
 
 Group.prototype.save = function saveAccount(){

--- a/lib/resource/GroupMembership.js
+++ b/lib/resource/GroupMembership.js
@@ -9,21 +9,19 @@ function GroupMembership() {
 utils.inherits(GroupMembership, InstanceResource);
 
 GroupMembership.prototype.getAccount = function getGroupMembershipAccount(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.account.href, options, require('./Account'), callback);
+  return this.dataStore.getResource(this.account.href, options, require('./Account'), callback);
 };
 
 GroupMembership.prototype.getGroup = function getGroupMembershipGroup(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.group.href, options, require('./Group'), callback);
+  return this.dataStore.getResource(this.group.href, options, require('./Group'), callback);
 };
 
 module.exports = GroupMembership;

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -13,19 +13,17 @@ function Organization() {
 utils.inherits(Organization, require('./InstanceResource'));
 
 Organization.prototype.getAccountStoreMappings = function getAccountStoreMappings(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accountStoreMappings.href, options, OrganizationAccountStoreMapping, callback);
+  return this.dataStore.getResource(this.accountStoreMappings.href, options, OrganizationAccountStoreMapping, callback);
 };
 
 Organization.prototype.createAccountStoreMapping = function createAccountStoreMapping(mapping, callback) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var options = (args.length > 2) ? args[1] : null;
-  mapping = new OrganizationAccountStoreMapping(mapping).setOrganization(self);
+  mapping = new OrganizationAccountStoreMapping(mapping).setOrganization(this);
   return this.dataStore.createResource('/organizationAccountStoreMappings', options, mapping, OrganizationAccountStoreMapping, callback);
 };
 

--- a/lib/resource/OrganizationAccountStoreMapping.js
+++ b/lib/resource/OrganizationAccountStoreMapping.js
@@ -9,12 +9,11 @@ function OrganizationAccountStoreMapping() {
 utils.inherits(OrganizationAccountStoreMapping, AccountStoreMapping);
 
 OrganizationAccountStoreMapping.prototype.getOrganization = function getOrganization(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.organization.href, options, require('./Organization'), callback);
+  return this.dataStore.getResource(this.organization.href, options, require('./Organization'), callback);
 };
 
 OrganizationAccountStoreMapping.prototype.setOrganization = function setOrganization(organization) {

--- a/lib/resource/PasswordPolicy.js
+++ b/lib/resource/PasswordPolicy.js
@@ -10,12 +10,11 @@ function PasswordPolicy() {
 utils.inherits(PasswordPolicy, InstanceResource);
 
 PasswordPolicy.prototype.getStrength = function() {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.strength.href, options, require('./Strength'), callback);
+  return this.dataStore.getResource(this.strength.href, options, require('./Strength'), callback);
 };
 
 module.exports = PasswordPolicy;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -11,73 +11,65 @@ function Tenant() {
 utils.inherits(Tenant, InstanceResource);
 
 Tenant.prototype.getAccounts = function getTenantAccounts(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.accounts.href, options, require('./Account'), callback);
+  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
 };
 
 Tenant.prototype.getGroups = function getTenantGroups(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.groups.href, options, require('./Group'), callback);
+  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
 };
 
 Tenant.prototype.getApplications = function getTenantApplications(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.applications.href, options, require('./Application'), callback);
+  return this.dataStore.getResource(this.applications.href, options, require('./Application'), callback);
 };
 
 Tenant.prototype.getOrganizations = function getTenantOrganizations(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.organizations.href, options, require('./Organization'), callback);
+  return this.dataStore.getResource(this.organizations.href, options, require('./Organization'), callback);
 };
 
 
 Tenant.prototype.createApplication = function createTenantApplication(/* app, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var app = args.shift();
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  self.dataStore.createResource('/applications', options, app, require('./Application'), callback);
+  this.dataStore.createResource('/applications', options, app, require('./Application'), callback);
 };
 
 Tenant.prototype.createOrganization = function createTenantOrganization(/* app, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var app = args.shift();
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  self.dataStore.createResource('/organizations', options, app, require('./Organization'), callback);
+  this.dataStore.createResource('/organizations', options, app, require('./Organization'), callback);
 };
 
 Tenant.prototype.getDirectories = function getTenantDirectories(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.directories.href, options, require('./Directory'), callback);
+  return this.dataStore.getResource(this.directories.href, options, require('./Directory'), callback);
 };
 
 Tenant.prototype.createDirectory = function createTenantDirectory(/* dir, [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var dir = args.shift();
   var callback = args.pop();
@@ -87,30 +79,29 @@ Tenant.prototype.createDirectory = function createTenantDirectory(/* dir, [optio
     options = _.extend(options || {}, {expand:'provider'});
   }
 
-  self.dataStore.createResource('/directories', options, dir, require('./Directory'), callback);
+  this.dataStore.createResource('/directories', options, dir, require('./Directory'), callback);
 };
 
 Tenant.prototype.verifyAccountEmail = function verifyAccountEmail(token, callback) {
-  var self = this;
+  var dataStore = this;
   var href = "/accounts/emailVerificationTokens/" + token;
 
-  return self.dataStore.createResource(href, null, null, function(err,result){
+  return dataStore.createResource(href, null, null, function(err,result){
     if(err){
       callback(err);
     }else{
-      self.dataStore.getResource(result.href,{nocache:true},require('./Account'),callback);
+      dataStore.getResource(result.href,{nocache:true},require('./Account'),callback);
     }
   });
 };
 
 
 Tenant.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var self = this;
   var args = Array.prototype.slice.call(arguments);
   var callback = args.pop();
   var options = (args.length > 0) ? args.shift() : null;
 
-  return self.dataStore.getResource(self.customData.href, options, require('./CustomData'), callback);
+  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
 };
 
 module.exports = Tenant;


### PR DESCRIPTION
Removes the redundant places where `var self = this;` has been used.

This PR is is a part of several refactors with goal to clean up the codebase from redundant code.