### PR TITLE
Refactor: Remove redundant dynamic args mapping

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1,11 +1,10 @@
 'use strict';
 
-var util = require('util');
 var async = require('async');
 var events = require('events');
-
 var stormpathConfig = require('stormpath-config');
 
+var utils = require('./utils');
 var DataStore = require('./ds/DataStore');
 var ObjectCallProxy = require('./proxy/ObjectCallProxy');
 
@@ -71,8 +70,8 @@ function Client(config) {
 
 // By inheriting from `events.EventEmitter`, we're making our Client object a
 // true EventEmitter -- allowing us to fire off events.
-util.inherits(Client, Object);
-util.inherits(Client, events.EventEmitter);
+utils.inherits(Client, Object);
+utils.inherits(Client, events.EventEmitter);
 
 /**
  * @callback onListenerCallback
@@ -118,12 +117,8 @@ Client.prototype.on = function() {
  *  response.
  */
 Client.prototype.getAccessToken = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/AccessToken'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/AccessToken'), args.callback);
 };
 
 /**
@@ -134,12 +129,8 @@ Client.prototype.getAccessToken = function() {
  *  response.
  */
 Client.prototype.getRefreshToken = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/RefreshToken'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/RefreshToken'), args.callback);
 };
 
 /**
@@ -151,25 +142,25 @@ Client.prototype.getRefreshToken = function() {
  */
 Client.prototype.getCurrentTenant = function() {
   var self = this;
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   // First, we'll check to see if we've already cached the current tenant (since
   // a Tenant never changes once a Client has been initialized).  This prevents
   // us from making unnecessary repeat API requests if this method is called
   // multiple times.
   if (self._currentTenant) {
-    return callback(null, self._currentTenant);
+    return args.callback(null, self._currentTenant);
   }
 
-  self._dataStore.getResource('/tenants/current', options, require('./resource/Tenant'), function(err, tenant) {
+  self._dataStore.getResource('/tenants/current', args.options, require('./resource/Tenant'), function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
     self._currentTenant = tenant;
-    return callback(null, tenant);
+
+    return args.callback(null, tenant);
   });
 };
 
@@ -241,16 +232,14 @@ Client.prototype.createResource = function() {
  *  response.
  */
 Client.prototype.getApplications = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.getApplications(options, callback);
+    return tenant.getApplications(args.options, args.callback);
   });
 };
 
@@ -269,17 +258,14 @@ Client.prototype.getApplications = function() {
  *  response.
  */
 Client.prototype.createApplication = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var app = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['app', 'options', 'callback']);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.createApplication(app, options, callback);
+    return tenant.createApplication(args.app, args.options, args.callback);
   });
 };
 
@@ -298,20 +284,17 @@ Client.prototype.createApplication = function() {
  *  response.
  */
 Client.prototype.createApplications = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var apps = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['apps', 'options', 'callback']);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    async.map(apps, function(app, cb) {
-      return tenant.createApplication(app, options, cb);
+    async.map(args.apps, function(app, cb) {
+      return tenant.createApplication(app, args.options, cb);
     }, function(err, applications) {
-      return callback(err, applications);
+      return args.callback(err, applications);
     });
   });
 };
@@ -330,16 +313,14 @@ Client.prototype.createApplications = function() {
  *  response.
  */
 Client.prototype.getAccounts = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.getAccounts(options, callback);
+    return tenant.getAccounts(args.options, args.callback);
   });
 };
 
@@ -357,16 +338,14 @@ Client.prototype.getAccounts = function() {
  *  response.
  */
 Client.prototype.getGroups = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.getGroups(options, callback);
+    return tenant.getGroups(args.options, args.callback);
   });
 };
 
@@ -384,16 +363,14 @@ Client.prototype.getGroups = function() {
  *  response.
  */
 Client.prototype.getDirectories = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.getDirectories(options, callback);
+    return tenant.getDirectories(args.options, args.callback);
   });
 };
 
@@ -412,17 +389,14 @@ Client.prototype.getDirectories = function() {
  *  response.
  */
 Client.prototype.createDirectory = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var dir = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['dir', 'options', 'callback']);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.createDirectory(dir, options, callback);
+    return tenant.createDirectory(args.dir, args.options, args.callback);
   });
 };
 
@@ -441,20 +415,17 @@ Client.prototype.createDirectory = function() {
  *  response.
  */
 Client.prototype.createDirectories = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var dirs = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['dirs', 'options', 'callback']);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    async.map(dirs, function(dir, cb) {
-      return tenant.createDirectory(dir, options, cb);
+    async.map(args.dirs, function(dir, cb) {
+      return tenant.createDirectory(dir, args.options, cb);
     }, function(err, directories) {
-      return callback(err, directories);
+      return args.callback(err, directories);
     });
   });
 };
@@ -468,17 +439,14 @@ Client.prototype.createDirectories = function() {
  *  response.
  */
 Client.prototype.createOrganization = function createOrganization() {
-  var args = Array.prototype.slice.call(arguments);
-  var data = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['data', 'options', 'callback']);
 
   this.getCurrentTenant(function(err, tenant) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
-    return tenant.createOrganization(data, options, callback);
+    return tenant.createOrganization(args.data, args.options, args.callback);
   });
 };
 
@@ -497,12 +465,8 @@ Client.prototype.createOrganization = function createOrganization() {
  *  response.
  */
 Client.prototype.getAccount = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/Account'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/Account'), args.callback);
 };
 
 /**
@@ -520,12 +484,8 @@ Client.prototype.getAccount = function() {
  *  response.
  */
 Client.prototype.getApplication = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/Application'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/Application'), args.callback);
 };
 
 /**
@@ -543,12 +503,8 @@ Client.prototype.getApplication = function() {
  *  response.
  */
 Client.prototype.getDirectory = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/Directory'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/Directory'), args.callback);
 };
 
 /**
@@ -566,12 +522,8 @@ Client.prototype.getDirectory = function() {
  *  response.
  */
 Client.prototype.getGroup = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/Group'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/Group'), args.callback);
 };
 
 /**
@@ -589,33 +541,23 @@ Client.prototype.getGroup = function() {
  *  response.
  */
 Client.prototype.getGroupMembership = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/GroupMembership'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/GroupMembership'), args.callback);
 };
 
 Client.prototype.getOrganization = function getOrganization() {
-  var args = Array.prototype.slice.call(arguments);
-  var href = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.getResource(href, options, require('./resource/Organization'), callback);
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/Organization'), args.callback);
 };
 
 Client.prototype.getOrganizations = function getOrganizations(/* [options,] callback */) {
-  var self = this;
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-  return self.getCurrentTenant(function onGetCurrentTenantForGroups(err, tenant) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.getCurrentTenant(function onGetCurrentTenantForGroups(err, tenant) {
     if (err) {
-      return callback(err, null);
+      return args.callback(err, null);
     }
-    return tenant.getOrganizations(options, callback);
+    return tenant.getOrganizations(args.options, args.callback);
   });
 };
 

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -12,65 +12,48 @@ function Account(data) {
 utils.inherits(Account, DirectoryChildResource);
 
 Account.prototype.getAccessTokens = function getAccessTokens(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accessTokens.href, options, require('./AccessToken'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accessTokens.href, args.options, require('./AccessToken'), args.callback);
 };
 
 Account.prototype.getRefreshTokens = function getRefreshTokens(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.refreshTokens.href, options, require('./RefreshToken'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.refreshTokens.href, args.options, require('./RefreshToken'), args.callback);
 };
 
 Account.prototype.getGroups = function getAccountGroups(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.groups.href, args.options, require('./Group'), args.callback);
 };
 
 Account.prototype.getGroupMemberships = function getGroupMemberships(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.groupMemberships.href, options, require('./GroupMembership'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.groupMemberships.href, args.options, require('./GroupMembership'), args.callback);
 };
 
 Account.prototype.addToGroup = function addAccountToGroup(/* groupOrGroupHref, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var group = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['group', 'options', 'callback'], true);
 
-  if (typeof group === 'string') {
-    group = {
-      href: group
+  if (typeof args.group === 'string') {
+    args.group = {
+      href: args.group
     };
   }
 
-  return this._createGroupMembership(this, group, options, callback);
+  return this._createGroupMembership(this, args.group, args.options, args.callback);
 };
 
 Account.prototype.getProviderData = function getProviderData(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   if (!this.providerData){
-    return callback();
+    return args.callback();
   }
 
-  return this.dataStore.getResource(this.providerData.href, options, require('./ProviderData'), callback);
+  return this.dataStore.getResource(this.providerData.href, args.options, require('./ProviderData'), args.callback);
 };
 
-Account.prototype.createApiKey = function createApiKey(options,callback) {
+Account.prototype.createApiKey = function createApiKey(options, callback) {
   var cb = typeof options === 'function' ? options : callback;
   var opts = _.extend({},this.dataStore.apiKeyEncryptionOptions,typeof options === 'object' ? options : {});
 

--- a/lib/resource/AccountStoreMapping.js
+++ b/lib/resource/AccountStoreMapping.js
@@ -1,10 +1,12 @@
 'use strict';
+
 var utils = require('../utils');
 var InstanceResource = require('./InstanceResource');
 
 function AccountStoreMapping() {
   AccountStoreMapping.super_.apply(this, arguments);
 }
+
 utils.inherits(AccountStoreMapping, InstanceResource);
 
 function AccountStoreClassFactory(data, dataStore) {
@@ -40,18 +42,14 @@ AccountStoreMapping.prototype.getApplication = function getApplication(/* [optio
     should be removed
     @TODO Version 1.0
   */
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
-  return this.dataStore.getResource(this.application.href, options, require('./Application'), callback);
+  return this.dataStore.getResource(this.application.href, args.options, require('./Application'), args.callback);
 };
-AccountStoreMapping.prototype.getAccountStore = function getAccountStore(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
 
-  return this.dataStore.getResource(this.accountStore.href, options, AccountStoreClassFactory, callback);
+AccountStoreMapping.prototype.getAccountStore = function getAccountStore(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accountStore.href, args.options, AccountStoreClassFactory, args.callback);
 };
 
 AccountStoreMapping.prototype.setApplication = function setAccountStoreMappingApplication(application) {

--- a/lib/resource/ApiKey.js
+++ b/lib/resource/ApiKey.js
@@ -8,6 +8,7 @@ var utils = require('../utils');
 function ApiKey() {
   ApiKey.super_.apply(this, arguments);
 }
+
 utils.inherits(ApiKey, InstanceResource);
 
 ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -191,12 +191,8 @@ Application.prototype.resetPassword = function resetApplicationPassword(token, p
 };
 
 Application.prototype.getSamlPolicy = function getSamlPolicy(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.samlPolicy.href, options, require('./SamlPolicy'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.samlPolicy.href, args.options, require('./SamlPolicy'), args.callback);
 };
 
 Application.prototype.getAccounts = function getApplicationAccounts(/* [options,] callback */) {

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -176,10 +176,8 @@ Application.prototype.sendPasswordResetEmail = function sendApplicationPasswordR
 };
 
 Application.prototype.resendVerificationEmail = function resendVerificationEmail(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-  return this.dataStore.createResource(this.verificationEmails.href, options, callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.createResource(this.verificationEmails.href, args.options, args.callback);
 };
 
 Application.prototype.verifyPasswordResetToken = function verifyApplicationPasswordResetToken(token, callback) {
@@ -202,28 +200,24 @@ Application.prototype.getSamlPolicy = function getSamlPolicy(/* [options,] callb
 };
 
 Application.prototype.getAccounts = function getApplicationAccounts(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accounts.href, args.options, require('./Account'), args.callback);
 };
 
 Application.prototype.getAccount = function getAccount(/* providerData, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var providerData = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['providerData', 'options', 'callback']);
 
-  if (!callback || !providerData || !providerData.providerData) {
+  if (!args.callback || !args.providerData || !args.providerData.providerData) {
     throw new Error('Incorrect usage. Usage: Application.getAccount(providerData, [options], callback);');
   }
 
-  if (typeof providerData.providerData !== 'object' || typeof providerData.providerData.providerId !== 'string' || (typeof providerData.providerData.code !== 'string' && typeof providerData.providerData.accessToken !== 'string')) {
+  var providerData = args.providerData.providerData;
+
+  if (typeof providerData !== 'object' || typeof providerData.providerId !== 'string' || (typeof providerData.code !== 'string' && typeof providerData.accessToken !== 'string')) {
     throw new Error('This method is used to create or access social accounts only. Did you mean to call Client.getAccount(href)?');
   }
 
-  var w = function getAccountCallbackWrapper(cb) {
+  function wrapCallback(cb) {
     return function(err, account) {
       if (err) {
         return cb(err);
@@ -234,51 +228,34 @@ Application.prototype.getAccount = function getAccount(/* providerData, [options
 
       cb(err, { account: account, created: isNew });
     };
-  };
+  }
 
-  return this.dataStore.createResource(this.accounts.href, options, providerData, require('./Account'), w(callback));
+  return this.dataStore.createResource(this.accounts.href, args.options, args.providerData, require('./Account'), wrapCallback(args.callback));
 };
 
 Application.prototype.createAccount = function createApplicationAccount(/* account, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var account = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.createResource(this.accounts.href, options, account, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['account', 'options', 'callback']);
+  return this.dataStore.createResource(this.accounts.href, args.options, args.account, require('./Account'), args.callback);
 };
 
 Application.prototype.getGroups = function getApplicationGroups(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.groups.href, args.options, require('./Group'), args.callback);
 };
 
 Application.prototype.createGroup = function createApplicationGroup(/* group, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var group = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.createResource(this.groups.href, options, group, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['group', 'options', 'callback']);
+  return this.dataStore.createResource(this.groups.href, args.options, args.group, require('./Group'), args.callback);
 };
 
 Application.prototype.getOAuthPolicy = function getOAuthPolicy(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.oAuthPolicy.href, options, require('./InstanceResource'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.oAuthPolicy.href, args.options, require('./InstanceResource'), args.callback);
 };
 
 Application.prototype.getTenant = function getApplicationTenant(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.tenant.href, options, require('./Tenant'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.tenant.href, args.options, require('./Tenant'), args.callback);
 };
 
 Application.prototype.getApiKey = function getApiKey(apiKeyId, options, callback) {
@@ -396,23 +373,18 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
 };
 
 Application.prototype.getAccountStoreMappings = function getAccountStoreMappings(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accountStoreMappings.href, options, ApplicationAccountStoreMapping, callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accountStoreMappings.href, args.options, ApplicationAccountStoreMapping, args.callback);
 };
 
 Application.prototype.getDefaultAccountStore = function getDefaultAccountStore(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   if (!this.defaultAccountStoreMapping) {
-    return callback();
+    return args.callback();
   }
 
-  return this.dataStore.getResource(this.defaultAccountStoreMapping.href, options, ApplicationAccountStoreMapping, callback);
+  return this.dataStore.getResource(this.defaultAccountStoreMapping.href, args.options, ApplicationAccountStoreMapping, args.callback);
 };
 
 Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(store, callback) {
@@ -456,15 +428,13 @@ Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(s
 };
 
 Application.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   if (!this.defaultGroupStoreMapping) {
-    return callback();
+    return args.callback();
   }
 
-  return this.dataStore.getResource(this.defaultGroupStoreMapping.href, options, ApplicationAccountStoreMapping, callback);
+  return this.dataStore.getResource(this.defaultGroupStoreMapping.href, args.options, ApplicationAccountStoreMapping, args.callback);
 };
 
 Application.prototype.setDefaultGroupStore = function setDefaultGroupStore(store, callback) {
@@ -508,7 +478,7 @@ Application.prototype.setDefaultGroupStore = function setDefaultGroupStore(store
 
 Application.prototype.createAccountStoreMapping = function createAccountStoreMapping(mapping, callback) {
   var args = Array.prototype.slice.call(arguments);
-  var options = (args.length > 2) ? args[1] : null;
+  var options = (args.length > 2) ? args[1] : null; // TODO: Refactor this. Don't get the reasoning of this atm.
 
   mapping = new ApplicationAccountStoreMapping(mapping).setApplication(this);
 
@@ -528,16 +498,12 @@ Application.prototype.createAccountStoreMappings = function createAccountStoreMa
 
 Application.prototype.addAccountStore = function addAccountStore(store, callback) {
   var mapping = new ApplicationAccountStoreMapping().setAccountStore(store).setApplication(this);
-
   return this.dataStore.createResource('/accountStoreMappings', null, mapping, ApplicationAccountStoreMapping, callback);
 };
 
 Application.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
 module.exports = Application;

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -472,13 +472,12 @@ Application.prototype.setDefaultGroupStore = function setDefaultGroupStore(store
   }
 };
 
-Application.prototype.createAccountStoreMapping = function createAccountStoreMapping(mapping, callback) {
-  var args = Array.prototype.slice.call(arguments);
-  var options = (args.length > 2) ? args[1] : null; // TODO: Refactor this. Don't get the reasoning of this atm.
+Application.prototype.createAccountStoreMapping = function createAccountStoreMapping(/* mapping, [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['mapping', 'options', 'callback']);
 
-  mapping = new ApplicationAccountStoreMapping(mapping).setApplication(this);
+  args.mapping = new ApplicationAccountStoreMapping(args.mapping).setApplication(this);
 
-  return this.dataStore.createResource('/accountStoreMappings', options, mapping, ApplicationAccountStoreMapping, callback);
+  return this.dataStore.createResource('/accountStoreMappings', args.options, args.mapping, ApplicationAccountStoreMapping, args.callback);
 };
 
 Application.prototype.createAccountStoreMappings = function createAccountStoreMappings(mappings,callback){

--- a/lib/resource/ApplicationAccountStoreMapping.js
+++ b/lib/resource/ApplicationAccountStoreMapping.js
@@ -1,6 +1,6 @@
 'use strict';
-var utils = require('../utils');
 
+var utils = require('../utils');
 var AccountStoreMapping = require('./AccountStoreMapping');
 
 function ApplicationAccountStoreMapping() {
@@ -10,11 +10,8 @@ function ApplicationAccountStoreMapping() {
 utils.inherits(ApplicationAccountStoreMapping, AccountStoreMapping);
 
 ApplicationAccountStoreMapping.prototype.getApplication = function getApplication(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.application.href, options, require('./Application'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.application.href, args.options, require('./Application'), args.callback);
 };
 
 ApplicationAccountStoreMapping.prototype.setApplication = function setApplication(application) {

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -15,11 +15,8 @@ function AuthenticationResult() {
 utils.inherits(AuthenticationResult, InstanceResource);
 
 AuthenticationResult.prototype.getAccount = function getAuthenticationResultAccount(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.account.href, options, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.account.href, args.options, require('./Account'), args.callback);
 };
 
 AuthenticationResult.prototype.getJwt = function getJwt() {

--- a/lib/resource/Directory.js
+++ b/lib/resource/Directory.js
@@ -67,21 +67,13 @@ Directory.prototype.getProvider = function getProvider(/* [options,] callback */
 };
 
 Directory.prototype.getOrganizations = function getOrganizations(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.organizations.href, options, require('./Organization'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.organizations.href, args.options, require('./Organization'), args.callback);
 };
 
 Directory.prototype.getOrganizationMappings = function getOrganizationMappings(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.organizationMappings.href, options, require('./OrganizationAccountStoreMapping'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.organizationMappings.href, args.options, require('./OrganizationAccountStoreMapping'), args.callback);
 };
 
 Directory.prototype.getCustomData = function getCustomData(/* [options,] callback */) {

--- a/lib/resource/Directory.js
+++ b/lib/resource/Directory.js
@@ -6,75 +6,49 @@ var utils = require('../utils');
 function Directory() {
   Directory.super_.apply(this, arguments);
 }
+
 utils.inherits(Directory, InstanceResource);
 
 Directory.prototype.getAccounts = function getDirectoryAccounts(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accounts.href, args.options, require('./Account'), args.callback);
 };
 
 Directory.prototype.getAccountCreationPolicy = function getAccountCreationPolicy(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accountCreationPolicy.href, options, require('./InstanceResource'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accountCreationPolicy.href, args.options, require('./InstanceResource'), args.callback);
 };
 
 Directory.prototype.getPasswordPolicy = function getPasswordPolicy(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.passwordPolicy.href, options, require('./PasswordPolicy'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.passwordPolicy.href, args.options, require('./PasswordPolicy'), args.callback);
 };
 
 Directory.prototype.createAccount = function createDirectoryAccount(/* account, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var account = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.createResource(this.accounts.href, options, account, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['account', 'options', 'callback']);
+  return this.dataStore.createResource(this.accounts.href, args.options, args.account, require('./Account'), args.callback);
 };
 
 Directory.prototype.getGroups = function getDirectoryGroups(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.groups.href, args.options, require('./Group'), args.callback);
 };
 
 Directory.prototype.createGroup = function createDirectoryGroup(/* group, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var group = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.createResource(this.groups.href, options, group, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['group', 'options', 'callback']);
+  return this.dataStore.createResource(this.groups.href, args.options, args.group, require('./Group'), args.callback);
 };
 
 Directory.prototype.getTenant = function getDirectoryTenant(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.tenant.href, options, require('./Tenant'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.tenant.href, args.options, require('./Tenant'), args.callback);
 };
 
 Directory.prototype.getProvider = function getProvider(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   if (!this.provider){
-    return callback();
+    return args.callback();
   }
 
   function providerFactory(provider, dataStore) {
@@ -89,7 +63,7 @@ Directory.prototype.getProvider = function getProvider(/* [options,] callback */
     return new ProviderType(provider, dataStore);
   }
 
-  return this.dataStore.getResource(this.provider.href, options, providerFactory, callback);
+  return this.dataStore.getResource(this.provider.href, args.options, providerFactory, args.callback);
 };
 
 Directory.prototype.getOrganizations = function getOrganizations(/* [options,] callback */) {
@@ -111,11 +85,8 @@ Directory.prototype.getOrganizationMappings = function getOrganizationMappings(/
 };
 
 Directory.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
 module.exports = Directory;

--- a/lib/resource/DirectoryChildResource.js
+++ b/lib/resource/DirectoryChildResource.js
@@ -40,27 +40,18 @@ DirectoryChildResource.prototype._createGroupMembership = function createGroupMe
 };
 
 DirectoryChildResource.prototype.getDirectory = function getDirectoryChildResourceDirectory(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.directory.href, options, require('./Directory'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.directory.href, args.options, require('./Directory'), args.callback);
 };
 
 DirectoryChildResource.prototype.getTenant = function getDirectoryChildResourceTenant(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.tenant.href, options, require('./Tenant'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.tenant.href, args.options, require('./Tenant'), args.callback);
 };
 
 DirectoryChildResource.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
 module.exports = DirectoryChildResource;

--- a/lib/resource/Group.js
+++ b/lib/resource/Group.js
@@ -6,37 +6,29 @@ var utils = require('../utils');
 function Group() {
   Group.super_.apply(this, arguments);
 }
+
 utils.inherits(Group, DirectoryChildResource);
 
 Group.prototype.addAccount = function addGroupAccount(/* accountOrAccountHref, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var account = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['account', 'options', 'callback']);
 
-  if (typeof account === 'string') {
-    account = {
-      href: account
+  if (typeof args.account === 'string') {
+    args.account = {
+      href: args.account
     };
   }
 
-  return this._createGroupMembership(account, this, options, callback);
+  return this._createGroupMembership(args.account, this, args.options, args.callback);
 };
 
 Group.prototype.getAccounts = function getGroupAccounts(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accounts.href, args.options, require('./Account'), args.callback);
 };
 
 Group.prototype.getAccountMemberships = function getGroupAccountMemberships(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accountMemberships.href, options, require('./GroupMembership'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accountMemberships.href, args.options, require('./GroupMembership'), args.callback);
 };
 
 Group.prototype.save = function saveAccount(){

--- a/lib/resource/GroupMembership.js
+++ b/lib/resource/GroupMembership.js
@@ -9,19 +9,13 @@ function GroupMembership() {
 utils.inherits(GroupMembership, InstanceResource);
 
 GroupMembership.prototype.getAccount = function getGroupMembershipAccount(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.account.href, options, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.account.href, args.options, require('./Account'), args.callback);
 };
 
 GroupMembership.prototype.getGroup = function getGroupMembershipGroup(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.group.href, options, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.group.href, args.options, require('./Group'), args.callback);
 };
 
 module.exports = GroupMembership;

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -12,16 +12,13 @@ function Organization() {
 utils.inherits(Organization, require('./InstanceResource'));
 
 Organization.prototype.getAccountStoreMappings = function getAccountStoreMappings(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accountStoreMappings.href, options, OrganizationAccountStoreMapping, callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accountStoreMappings.href, args.options, OrganizationAccountStoreMapping, args.callback);
 };
 
 Organization.prototype.createAccountStoreMapping = function createAccountStoreMapping(mapping, callback) {
   var args = Array.prototype.slice.call(arguments);
-  var options = (args.length > 2) ? args[1] : null;
+  var options = (args.length > 2) ? args[1] : null; // TODO: Refactor this... Doesn't make sense.
   mapping = new OrganizationAccountStoreMapping(mapping).setOrganization(this);
   return this.dataStore.createResource('/organizationAccountStoreMappings', options, mapping, OrganizationAccountStoreMapping, callback);
 };

--- a/lib/resource/OrganizationAccountStoreMapping.js
+++ b/lib/resource/OrganizationAccountStoreMapping.js
@@ -1,19 +1,17 @@
 'use strict';
-var utils = require('../utils');
 
+var utils = require('../utils');
 var AccountStoreMapping = require('./AccountStoreMapping');
 
 function OrganizationAccountStoreMapping() {
   OrganizationAccountStoreMapping.super_.apply(this, arguments);
 }
+
 utils.inherits(OrganizationAccountStoreMapping, AccountStoreMapping);
 
 OrganizationAccountStoreMapping.prototype.getOrganization = function getOrganization(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.organization.href, options, require('./Organization'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.organization.href, args.options, require('./Organization'), args.callback);
 };
 
 OrganizationAccountStoreMapping.prototype.setOrganization = function setOrganization(organization) {

--- a/lib/resource/PasswordPolicy.js
+++ b/lib/resource/PasswordPolicy.js
@@ -10,11 +10,8 @@ function PasswordPolicy() {
 utils.inherits(PasswordPolicy, InstanceResource);
 
 PasswordPolicy.prototype.getStrength = function() {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.strength.href, options, require('./Strength'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.strength.href, args.options, require('./Strength'), args.callback);
 };
 
 module.exports = PasswordPolicy;

--- a/lib/resource/SamlPolicy.js
+++ b/lib/resource/SamlPolicy.js
@@ -10,12 +10,8 @@ function SamlPolicy() {
 utils.inherits(SamlPolicy, InstanceResource);
 
 SamlPolicy.prototype.getServiceProvider = function getServiceProvider(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.serviceProvider.href, options, require('./SamlServiceProvider'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.serviceProvider.href, args.options, require('./SamlServiceProvider'), args.callback);
 };
 
 module.exports = SamlPolicy;

--- a/lib/resource/SamlProvider.js
+++ b/lib/resource/SamlProvider.js
@@ -10,21 +10,13 @@ function SamlProvider() {
 utils.inherits(SamlProvider, InstanceResource);
 
 SamlProvider.prototype.getAttributeStatementMappingRules = function getAttributeStatementMappingRules(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.attributeStatementMappingRules.href, options, require('./SamlAttributeStatementMappingRules'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.attributeStatementMappingRules.href, args.options, require('./SamlAttributeStatementMappingRules'), args.callback);
 };
 
 SamlProvider.prototype.getServiceProviderMetadata = function getServiceProviderMetadata(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.serviceProviderMetadata.href, options, require('./SamlServiceProviderMetadata'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.serviceProviderMetadata.href, args.options, require('./SamlServiceProviderMetadata'), args.callback);
 };
 
 module.exports = SamlProvider;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -1,85 +1,58 @@
 'use strict';
 
 var _ = require('underscore');
-
 var InstanceResource = require('./InstanceResource');
 var utils = require('../utils');
 
 function Tenant() {
   Tenant.super_.apply(this, arguments);
 }
+
 utils.inherits(Tenant, InstanceResource);
 
 Tenant.prototype.getAccounts = function getTenantAccounts(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.accounts.href, options, require('./Account'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.accounts.href, args.options, require('./Account'), args.callback);
 };
 
 Tenant.prototype.getGroups = function getTenantGroups(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.groups.href, options, require('./Group'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.groups.href, args.options, require('./Group'), args.callback);
 };
 
 Tenant.prototype.getApplications = function getTenantApplications(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.applications.href, options, require('./Application'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.applications.href, args.options, require('./Application'), args.callback);
 };
 
 Tenant.prototype.getOrganizations = function getTenantOrganizations(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.organizations.href, options, require('./Organization'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.organizations.href, args.options, require('./Organization'), args.callback);
 };
 
-
 Tenant.prototype.createApplication = function createTenantApplication(/* app, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var app = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  this.dataStore.createResource('/applications', options, app, require('./Application'), callback);
+  var args = utils.resolveArgs(arguments, ['app', 'options', 'callback']);
+  this.dataStore.createResource('/applications', args.options, args.app, require('./Application'), args.callback);
 };
 
 Tenant.prototype.createOrganization = function createTenantOrganization(/* app, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var app = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  this.dataStore.createResource('/organizations', options, app, require('./Organization'), callback);
+  var args = utils.resolveArgs(arguments, ['app', 'options', 'callback']);
+  this.dataStore.createResource('/organizations', args.options, args.app, require('./Organization'), args.callback);
 };
 
 Tenant.prototype.getDirectories = function getTenantDirectories(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.directories.href, options, require('./Directory'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.directories.href, args.options, require('./Directory'), args.callback);
 };
 
 Tenant.prototype.createDirectory = function createTenantDirectory(/* dir, [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var dir = args.shift();
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
+  var args = utils.resolveArgs(arguments, ['dir', 'options', 'callback']);
 
-  if (dir.provider){
-    options = _.extend(options || {}, {expand:'provider'});
+  if (args.dir.provider){
+    args.options = _.extend(args.options || {}, {expand:'provider'});
   }
 
-  this.dataStore.createResource('/directories', options, dir, require('./Directory'), callback);
+  this.dataStore.createResource('/directories', args.options, args.dir, require('./Directory'), args.callback);
 };
 
 Tenant.prototype.verifyAccountEmail = function verifyAccountEmail(token, callback) {
@@ -95,13 +68,9 @@ Tenant.prototype.verifyAccountEmail = function verifyAccountEmail(token, callbac
   });
 };
 
-
 Tenant.prototype.getCustomData = function getCustomData(/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = (args.length > 0) ? args.shift() : null;
-
-  return this.dataStore.getResource(this.customData.href, options, require('./CustomData'), callback);
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
 module.exports = Tenant;

--- a/lib/saml/SamlIdpUrlBuilder.js
+++ b/lib/saml/SamlIdpUrlBuilder.js
@@ -4,6 +4,8 @@ var njwt = require('njwt');
 var uuid = require('node-uuid');
 var querystring = require('querystring');
 
+var utils = require('../utils');
+
 function SamlIdpUrlBuilder(application) {
   this.application = application;
   this.apiKey = application.dataStore.requestExecutor.options.client.apiKey;
@@ -24,16 +26,14 @@ SamlIdpUrlBuilder.prototype._buildInitializationUrl = function _buildInitializat
 };
 
 SamlIdpUrlBuilder.prototype.build = function (/* [options,] callback */) {
-  var args = Array.prototype.slice.call(arguments);
-  var callback = args.pop();
-  var options = args.length > 0 ? args.shift() : {};
-
   var self = this;
+
   var apiKey = this.apiKey;
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   this._getServiceProvider(function (err, serviceProvider) {
     if (err) {
-      return callback(err);
+      return args.callback(err);
     }
 
     var claims = {
@@ -41,6 +41,8 @@ SamlIdpUrlBuilder.prototype.build = function (/* [options,] callback */) {
       iss: self.application.href,
       iat: new Date().getTime() / 1000
     };
+
+    var options = args.options || {};
 
     if (options.cb_uri) {
       claims.cb_uri = options.cb_uri;
@@ -69,7 +71,7 @@ SamlIdpUrlBuilder.prototype.build = function (/* [options,] callback */) {
     var ssoInitiationEndpoint = serviceProvider.ssoInitiationEndpoint.href;
     var initializationUrl = self._buildInitializationUrl(ssoInitiationEndpoint, parameters);
 
-    callback(null, initializationUrl);
+    args.callback(null, initializationUrl);
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,35 @@ function shallowCopy(src, dest) {
   return dest;
 }
 
+function take(source, fromRight) {
+  return fromRight ? source.pop() : source.shift();
+}
+
+/**
+ * Takes a list of arguments and maps them to a list of names
+ * in an alternating either a left-to-right, or right-to-left direction.
+ */
+function resolveArgs(argumentsObject, nameMap, rightToLeft) {
+  var result = {};
+
+  var takeFromRight = rightToLeft;
+  var args = Array.prototype.slice.call(argumentsObject);
+
+  while (nameMap.length) {
+    var value = null;
+    var name = take(nameMap, takeFromRight);
+
+    if (args.length > 0) {
+      value = take(args, takeFromRight);
+      takeFromRight = !takeFromRight;
+    }
+
+    result[name] = value;
+  }
+
+  return result;
+}
+
 /**
  * Ensures 'undefined' is never encountered on value assignment.  Works as follows:
  * 1. Return obj if not null or undefined.
@@ -152,6 +181,7 @@ function isNumber(val){
 }
 
 module.exports = {
+  resolveArgs: resolveArgs,
   nowEpochSeconds: nowEpochSeconds,
   inherits: util.inherits,
   isAssignableFrom: isAssignableFrom,

--- a/test/sp.resource.account_test.js
+++ b/test/sp.resource.account_test.js
@@ -152,7 +152,7 @@ describe('Resources: ', function () {
 
         it('should throw unhandled exception', function () {
           addToGroupWithoutGroupHref.should
-            .throw(/cannot read property 'href' of undefined/i);
+            .throw(/cannot read property 'href' of null/i);
         });
       });
 

--- a/test/sp.resource.group_test.js
+++ b/test/sp.resource.group_test.js
@@ -32,7 +32,7 @@ describe('Resources: ', function () {
 
         it('should throw unhandled exception', function () {
           addAccountWithoutGroupHref.should
-            .throw(/cannot read property 'href' of undefined/i);
+            .throw(/cannot read property 'href' of null/i);
         });
       });
 

--- a/test/sp.utils_test.js
+++ b/test/sp.utils_test.js
@@ -162,5 +162,39 @@ describe('util', function () {
     });
   });
 
+  describe('resolveArgs', function () {
+    var mockHref = 'http://mock.com/';
+    var mockOptions = {};
+    var mockCallback = function () {};
 
+    describe('when parsing args', function () {
+      it('should parse from left to right', function () {
+        var args = utils.resolveArgs([mockHref, null, null], ['href', 'options', 'callback']);
+        assert.equal(args.href, mockHref);
+        assert.equal(args.options, null);
+        assert.equal(args.callback, null);
+      });
+
+      it('should parse from right to left', function () {
+        var args = utils.resolveArgs([null, null, mockCallback], ['href', 'options', 'callback'], true);
+        assert.equal(args.href, null);
+        assert.equal(args.options, null);
+        assert.equal(args.callback, mockCallback);
+      });
+
+      it('should parse from left to right and alternate direction', function () {
+        var args = utils.resolveArgs([mockHref, null, mockCallback], ['href', 'options', 'callback']);
+        assert.equal(args.href, mockHref);
+        assert.equal(args.options, null);
+        assert.equal(args.callback, mockCallback);
+      });
+
+      it('should default to null when no args are provided', function () {
+        var args = utils.resolveArgs([], ['href', 'options', 'callback']);
+        assert.equal(args.href, null);
+        assert.equal(args.options, null);
+        assert.equal(args.callback, null);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Replaces manual dynamic argument mapping with a utility function.

I.e.

```javascript
var args = Array.prototype.slice.call(arguments);
var href = args.shift();
var callback = args.pop();
var options = (args.length > 0) ? args.shift() : null;
```

Can be replaced with:

```javascript
var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
```

**Note:**

This is just the first step in refactoring the dynamic argument mapping. The second will be to build out the `resolveArgs()` method so that one can write, e.g.: `['href!', 'options', 'callback!']`. I.e. giving the ability to require an argument to be present, and an error to be thrown if it isn't. Also removing the need for the `rightToLeft` parameter.