### PR TITLE
Fix: Correct invalid data store reference

### DIFF
--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -83,7 +83,7 @@ Tenant.prototype.createDirectory = function createTenantDirectory(/* dir, [optio
 };
 
 Tenant.prototype.verifyAccountEmail = function verifyAccountEmail(token, callback) {
-  var dataStore = this;
+  var dataStore = this.dataStore;
   var href = "/accounts/emailVerificationTokens/" + token;
 
   return dataStore.createResource(href, null, null, function(err,result){


### PR DESCRIPTION
Fixes invalid data store reference that accidentally shipped with the redundant 'self = this;' refactor.

https://github.com/stormpath/stormpath-sdk-node/pull/319/files#diff-3193b733bc7c2d342d9967025ed46746R86