### PR TITLE
Fix: Correctly pass TTL to authentication result

### DIFF
--- a/lib/authc/BasicApiAuthenticator.js
+++ b/lib/authc/BasicApiAuthenticator.js
@@ -32,7 +32,7 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
         var authenticationResult = new AuthenticationResult(apiKey,self.application.dataStore);
 
         authenticationResult.application = self.application;
-        authenticationResult.expiration = self.ttl;
+        authenticationResult.ttl = self.ttl;
 
         callback(null,authenticationResult);
       }else{

--- a/lib/authc/BasicApiAuthenticator.js
+++ b/lib/authc/BasicApiAuthenticator.js
@@ -3,14 +3,18 @@
 var ApiAuthRequestError = require('../error/ApiAuthRequestError');
 var AuthenticationResult = require('../resource/AuthenticationResult');
 
-function BasicApiAuthenticator(application,authHeaderValue){
+function BasicApiAuthenticator(application,authHeaderValue, ttl){
   var parts = new Buffer(authHeaderValue.replace(/Basic /i,''),'base64').toString('utf8').split(':');
-  if(parts.length!==2){
+
+  if(parts.length !== 2){
     return new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400});
   }
+
   this.application = application;
   this.id = parts[0];
   this.secret = parts[1];
+
+  this.ttl = ttl || 3600;
 }
 
 BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
@@ -26,7 +30,10 @@ BasicApiAuthenticator.prototype.authenticate = function authenticate(callback) {
         (apiKey.account.status==='ENABLED')
       ){
         var authenticationResult = new AuthenticationResult(apiKey,self.application.dataStore);
+
         authenticationResult.application = self.application;
+        authenticationResult.expiration = self.ttl;
+
         callback(null,authenticationResult);
       }else{
         callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client',  statusCode: 401}));

--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -47,7 +47,7 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
 
         result.forApiKey = apiKey;
         result.application = self.application;
-        result.expiration = self.ttl;
+        result.ttl = self.ttl;
 
         self.buildTokenResponse(apiKey, function onTokenResponse(err, tokenResponse) {
           if (err) {

--- a/lib/authc/OAuthBasicExchangeAuthenticator.js
+++ b/lib/authc/OAuthBasicExchangeAuthenticator.js
@@ -47,6 +47,7 @@ OAuthBasicExchangeAuthenticator.prototype.authenticate = function authenticate(c
 
         result.forApiKey = apiKey;
         result.application = self.application;
+        result.expiration = self.ttl;
 
         self.buildTokenResponse(apiKey, function onTokenResponse(err, tokenResponse) {
           if (err) {

--- a/lib/authc/OauthAccessTokenAuthenticator.js
+++ b/lib/authc/OauthAccessTokenAuthenticator.js
@@ -36,28 +36,33 @@ function validateJwt(jwtObject){
 }
 
 
-function OauthAccessTokenAuthenticator(application, token){
+function OauthAccessTokenAuthenticator(application, token, ttl){
   var jwtObject = getJwt(token, application.dataStore.requestExecutor.options.client.apiKey.secret);
 
   if(jwtObject instanceof Error){
     return jwtObject;
   }
+
   var jwtValidationResult = validateJwt(jwtObject);
+
   if(jwtValidationResult instanceof Error){
     return jwtValidationResult;
   }
 
   var scopes;
+
   if(jwtObject.scope){
     scopes = jwtObject.scope.split(' ');
   }else{
     scopes = [];
   }
+
   this.scopes = scopes;
   this.apiKey = jwtObject.sub;
   this.application = application;
   this.token = token;
   this.jwtObject = jwtObject;
+  this.ttl = ttl || 3600;
 }
 
 OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(callback) {
@@ -78,7 +83,11 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
           data.grantedScopes = self.scopes;
         }
 
-        callback(null,new AuthenticationResult(data,self.application.dataStore));
+        var result = new AuthenticationResult(data,self.application.dataStore);
+
+        result.expiration = self.ttl;
+
+        callback(null, result);
       }else{
         callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401}));
       }

--- a/lib/authc/OauthAccessTokenAuthenticator.js
+++ b/lib/authc/OauthAccessTokenAuthenticator.js
@@ -85,7 +85,7 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
 
         var result = new AuthenticationResult(data,self.application.dataStore);
 
-        result.expiration = self.ttl;
+        result.ttl = self.ttl;
 
         callback(null, result);
       }else{

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -358,20 +358,21 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
       }else{
         authenticator = new BasicApiAuthenticator(
           this,
-          authHeaderValue
+          authHeaderValue,
+          ttl
         );
       }
     }else if(authHeaderValue.match(/Bearer/i)){
       authenticator = new OauthAccessTokenAuthenticator(
         this,
         authHeaderValue.replace(/Bearer /i,''),
-        callback
+        ttl
       );
     }else{
       return callback(new ApiAuthRequestError({userMessage: 'Invalid Authorization value', statusCode: 400}));
     }
   }else if(accessToken){
-    authenticator = new OauthAccessTokenAuthenticator(this, accessToken, callback);
+    authenticator = new OauthAccessTokenAuthenticator(this, accessToken, ttl);
   }
 
   if(!authenticator){
@@ -383,7 +384,6 @@ Application.prototype.authenticateApiRequest = function authenticateApiRequest(o
   }
 
   authenticator.authenticate(callback);
-
 };
 
 Application.prototype.getAccountStoreMappings = function getAccountStoreMappings(/* [options,] callback */) {

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -9,7 +9,7 @@ function AuthenticationResult() {
   AuthenticationResult.super_.apply(this, arguments);
   Object.defineProperty(this, 'application', { enumerable:false, writable:true });
   Object.defineProperty(this, 'forApiKey', { enumerable:false, writable:true });
-  Object.defineProperty(this, 'expiration', { enumerable:false, writable:true });
+  Object.defineProperty(this, 'ttl', { enumerable:false, writable:true, value: 3600 });
 }
 
 utils.inherits(AuthenticationResult, InstanceResource);
@@ -23,8 +23,6 @@ AuthenticationResult.prototype.getAccount = function getAuthenticationResultAcco
 };
 
 AuthenticationResult.prototype.getJwt = function getJwt() {
-  var expiration = this.expiration || 3600;
-
   var secret = this.application.dataStore.requestExecutor
     .options.client.apiKey.secret;
 
@@ -34,7 +32,7 @@ AuthenticationResult.prototype.getJwt = function getJwt() {
     jti: utils.uuid()
   }, secret);
 
-  jwt.setExpiration(new Date().getTime() + (expiration * 1000));
+  jwt.setExpiration(new Date().getTime() + (this.ttl * 1000));
 
   return jwt;
 };
@@ -49,7 +47,7 @@ AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenR
   var resp = {
     'access_token': jwt.compact(),
     'token_type': 'Bearer',
-    'expires_in': jwt.body.exp
+    'expires_in': this.ttl
   };
 
   if(jwt.body.scope){

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -7,9 +7,11 @@ var utils = require('../utils');
 
 function AuthenticationResult() {
   AuthenticationResult.super_.apply(this, arguments);
-  Object.defineProperty(this, 'application', {enumerable:false,writable:true});
-  Object.defineProperty(this, 'forApiKey', {enumerable:false,writable:true});
+  Object.defineProperty(this, 'application', { enumerable:false, writable:true });
+  Object.defineProperty(this, 'forApiKey', { enumerable:false, writable:true });
+  Object.defineProperty(this, 'expiration', { enumerable:false, writable:true });
 }
+
 utils.inherits(AuthenticationResult, InstanceResource);
 
 AuthenticationResult.prototype.getAccount = function getAuthenticationResultAccount(/* [options,] callback */) {
@@ -21,12 +23,20 @@ AuthenticationResult.prototype.getAccount = function getAuthenticationResultAcco
 };
 
 AuthenticationResult.prototype.getJwt = function getJwt() {
-  return nJwt.create({
+  var expiration = this.expiration || 3600;
+
+  var secret = this.application.dataStore.requestExecutor
+    .options.client.apiKey.secret;
+
+  var jwt = nJwt.create({
     iss: this.application.href,
     sub: this.forApiKey ? this.forApiKey.id : this.account.href,
     jti: utils.uuid()
-  },this.application.dataStore.requestExecutor.options.client.apiKey.secret)
-  .setExpiration(new Date().getTime() + (3600*1000));
+  }, secret);
+
+  jwt.setExpiration(new Date().getTime() + (expiration * 1000));
+
+  return jwt;
 };
 
 AuthenticationResult.prototype.getAccessToken = function getAccessToken(jwt) {
@@ -34,16 +44,18 @@ AuthenticationResult.prototype.getAccessToken = function getAccessToken(jwt) {
 };
 
 AuthenticationResult.prototype.getAccessTokenResponse = function getAccessTokenResponse(jwt) {
-
   jwt = jwt || this.getJwt();
+
   var resp = {
     'access_token': jwt.compact(),
     'token_type': 'Bearer',
-    'expires_in': jwt.ttl
+    'expires_in': jwt.body.exp
   };
+
   if(jwt.body.scope){
     resp.scope = jwt.body.scope;
   }
+
   return resp;
 };
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "sinon": "~1.17.2",
     "sinon-chai": "~2.8.0",
     "time-grunt": "~1.3.0",
+    "timekeeper": "0.0.5",
     "tmp": "0.0.28",
     "uuid": "^2.0.1"
   }

--- a/test/common.js
+++ b/test/common.js
@@ -12,6 +12,7 @@ var moment = require('moment');
 var sinonChai = require("sinon-chai");
 var uuid = require('node-uuid');
 var nock = require('nock');
+var timekeeper = require('timekeeper');
 
 var Stormpath = require('../lib');
 chai.use(sinonChai);
@@ -73,6 +74,7 @@ module.exports = {
   should: should,
   moment: moment,
   Stormpath: Stormpath,
+  timekeeper: timekeeper,
   random: random,
   uuid: uuid,
   snapshotEnv: snapshotEnv,

--- a/test/sp.resource.authenticationResult_test.js
+++ b/test/sp.resource.authenticationResult_test.js
@@ -12,6 +12,34 @@ var DataStore = require('../lib/ds/DataStore');
 describe('Resources: ', function () {
   describe('Authentication Result resource', function () {
     var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+
+    describe('if ttl', function () {
+      describe('isn\'t set', function () {
+        it('should have a default value of 3600', function () {
+          var result = new AuthenticationResult();
+          assert.equal(result.ttl, 3600);
+        });
+      });
+
+      describe('is set', function () {
+        var app = {account: {href: 'boom!'}, dataStore: dataStore};
+
+        var result = new AuthenticationResult(app, dataStore);
+
+        result.application = app;
+        result.ttl = 9999;
+
+        it('should return jwt with specified ttl', function () {
+          timekeeper.freeze(0);
+
+          var jwt = result.getJwt();
+          assert.equal(jwt.body.exp, new Date().getTime() + result.ttl);
+
+          timekeeper.reset();
+        });
+      });
+    });
+
     describe('get accounts', function () {
       describe('if accounts not set', function () {
         //var authcResult = new AuthenticationResult();
@@ -24,24 +52,6 @@ describe('Resources: ', function () {
         //  getAccountsWithoutHref.should
         //    .throw(/cannot read property 'href' of undefined/i);
         //});
-      });
-
-      describe('if expiration is set', function () {
-        var app = {account: {href: 'boom!'}, dataStore: dataStore};
-
-        var result = new AuthenticationResult(app, dataStore);
-
-        result.application = app;
-        result.expiration = 9999;
-
-        it('should return jwt with specified expiration', function () {
-          timekeeper.freeze(0);
-
-          var jwt = result.getJwt();
-          assert.equal(jwt.body.exp, new Date().getTime() + result.expiration);
-
-          timekeeper.reset();
-        });
       });
 
       describe('if accounts are set', function () {

--- a/test/sp.resource.authenticationResult_test.js
+++ b/test/sp.resource.authenticationResult_test.js
@@ -1,12 +1,15 @@
+"use strict";
+
 var common = require('./common');
 var sinon = common.sinon;
+var assert = common.assert;
+var timekeeper = common.timekeeper;
 
 var Account = require('../lib/resource/Account');
 var AuthenticationResult = require('../lib/resource/AuthenticationResult');
 var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
-  "use strict";
   describe('Authentication Result resource', function () {
     var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     describe('get accounts', function () {
@@ -21,6 +24,24 @@ describe('Resources: ', function () {
         //  getAccountsWithoutHref.should
         //    .throw(/cannot read property 'href' of undefined/i);
         //});
+      });
+
+      describe('if expiration is set', function () {
+        var app = {account: {href: 'boom!'}, dataStore: dataStore};
+
+        var result = new AuthenticationResult(app, dataStore);
+
+        result.application = app;
+        result.expiration = 9999;
+
+        it('should return jwt with specified expiration', function () {
+          timekeeper.freeze(0);
+
+          var jwt = result.getJwt();
+          assert.equal(jwt.body.exp, new Date().getTime() + result.expiration);
+
+          timekeeper.reset();
+        });
       });
 
       describe('if accounts are set', function () {


### PR DESCRIPTION
Fixes so that TTL is correctly passed to from authenticators to Authentication Result and so that the access token response correctly translates the JWT `exp` into the access token response `expires_in`.

Fixes #324