### PR TITLE
Fix: Remove refresh_token option validation in refresh grant authenticator

### DIFF
--- a/lib/oauth/refresh-grant.js
+++ b/lib/oauth/refresh-grant.js
@@ -27,8 +27,6 @@ OAuthRefreshTokenGrantAuthenticator.prototype.authenticate = function authentica
   var application = this.application;
   if(arguments.length !==2 ){
     throw new Error('Must call authenticate with (data,callback)');
-  }else if (!data.refresh_token){
-    throw new Error('data does not have refresh_token property');
   }else{
     var href = application.href + '/oauth/token';
     var formData = {


### PR DESCRIPTION
For consistency, remove validation of the `refresh_grant` option in the refresh token grant authenticator. I.e. if missing, then let the error fall through and be handled by the API.

Fixes #306 