### PR TITLE
Add application and ttl references to the authentication result

### DIFF
--- a/lib/authc/OauthAccessTokenAuthenticator.js
+++ b/lib/authc/OauthAccessTokenAuthenticator.js
@@ -85,6 +85,7 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
 
         var result = new AuthenticationResult(data,self.application.dataStore);
 
+        result.application = self.application;
         result.ttl = self.ttl;
 
         callback(null, result);
@@ -107,7 +108,12 @@ OauthAccessTokenAuthenticator.prototype.authenticate = function authenticate(cal
           data.grantedScopes = self.scopes;
         }
 
-        callback(null,new AuthenticationResult(apiKey,self.application.dataStore));
+        var result = new AuthenticationResult(apiKey, self.application.dataStore);
+
+        result.application = self.application;
+        result.ttl = self.ttl;
+
+        callback(null, result);
       }else{
         callback(new ApiAuthRequestError({userMessage: 'Invalid Client Credentials', error: 'invalid_client', statusCode: 401 }));
       }


### PR DESCRIPTION
Thanks to @areichman for reporting and fixing #342.

This PR adds the `application` and `ttl` as a reference to the returned `AuthenticationResult`.

@typerandom please review.