### PR TITLE
Move assignments from describe into before/beforeEach

### DIFF
--- a/test/it/account_it.js
+++ b/test/it/account_it.js
@@ -12,10 +12,10 @@ var CustomData = require('../../lib/resource/CustomData');
 var AccountAccessTokenFixture = require('../fixtures/account-token');
 
 describe('Account', function() {
-
-  var fixture = new AccountAccessTokenFixture();
+  var fixture;
 
   before(function(done) {
+    fixture = new AccountAccessTokenFixture();
     fixture.before(done);
   });
 
@@ -90,10 +90,13 @@ describe('Account', function() {
 
       describe('when saved and re-fetched', function() {
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
 
         before(function(done) {
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
 
           customData.save(function(err) {
@@ -145,10 +148,13 @@ describe('Account', function() {
 
       describe('when saved and re-fetched', function() {
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
 
         before(function(done) {
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
 
           customData.save(function(err) {

--- a/test/it/api_auth_it.js
+++ b/test/it/api_auth_it.js
@@ -247,10 +247,12 @@ describe('Application.authenticateApiRequest',function(){
   });
 
   describe('with a previously issued access token',function(){
-    var customScope = 'custom-scope';
+    var customScope;
     var accessToken;
 
     before(function(done){
+      customScope = 'custom-scope';
+
       var requestObject = {
         headers: {
           'authorization': 'Basic ' + new Buffer([apiKey.id,apiKey.secret].join(':')).toString('base64')
@@ -550,12 +552,15 @@ describe('Application.authenticateApiRequest',function(){
   describe('with a scope factory',function(){
     var result;
     var requestObject;
-    var requestedScope = 'scope-a scope-b';
-    var givenScope = ['given-scope-a given-scope-b'];
+    var requestedScope;
+    var givenScope;
     var scopeFactoryArgs;
     var decodedAccessToken;
 
     before(function(done){
+      requestedScope = 'scope-a scope-b';
+      givenScope = ['given-scope-a given-scope-b'];
+
       requestObject = {
         headers: {
           'authorization': 'Basic ' + new Buffer([apiKey.id,apiKey.secret].join(':')).toString('base64')
@@ -644,11 +649,13 @@ describe('Application.authenticateApiRequest',function(){
   describe('with a custom ttl',function(){
 
     var result;
-    var desiredTtl = 13;
+    var desiredTtl;
     var tokenResponse;
     var decodedAccessToken;
 
     before(function(done){
+      desiredTtl = 13;
+
       var requestObject = {
         headers: {
           'authorization': 'Basic ' + new Buffer([apiKey.id,apiKey.secret].join(':')).toString('base64')

--- a/test/it/application_it.js
+++ b/test/it/application_it.js
@@ -165,8 +165,11 @@ describe('Application',function(){
   });
 
   describe('authenticateAccount',function(){
-    var fakeAccount = helpers.fakeAccount();
+    var fakeAccount;
+
     before(function(done){
+      fakeAccount = helpers.fakeAccount();
+
       directory.createAccount(fakeAccount,function(err,_account){
         if(err){ throw err; }
         account = _account;
@@ -272,9 +275,13 @@ describe('Application',function(){
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }

--- a/test/it/client_credential_auth_it.js
+++ b/test/it/client_credential_auth_it.js
@@ -8,9 +8,9 @@ describe('Client Credential Authentication',function(){
 
   var app, account, client, fakeAccount, accessToken;
 
-  fakeAccount = helpers.fakeAccount();
-
   before(function(done){
+    fakeAccount = helpers.fakeAccount();
+
     helpers.getClient(function(_client){
       client = _client;
 

--- a/test/it/client_it.js
+++ b/test/it/client_it.js
@@ -30,10 +30,13 @@ describe('Client', function() {
   });
 
   describe('getAccessToken',function(){
-    var AccountAccessTokenFixture = require('../fixtures/account-token');
-    var accountCase = new AccountAccessTokenFixture();
+    var AccountAccessTokenFixture;
+    var accountCase;
 
     before(function(done) {
+      AccountAccessTokenFixture = require('../fixtures/account-token');
+      accountCase = new AccountAccessTokenFixture();
+
       accountCase.before(done);
     });
 
@@ -54,10 +57,13 @@ describe('Client', function() {
   });
 
   describe('getRefreshToken',function(){
-    var AccountRefreshTokenFixture = require('../fixtures/account-token');
-    var accountCase = new AccountRefreshTokenFixture();
+    var AccountRefreshTokenFixture;
+    var accountCase;
 
     before(function(done) {
+      AccountRefreshTokenFixture = require('../fixtures/account-token');
+      accountCase = new AccountRefreshTokenFixture();
+
       accountCase.before(done);
     });
 
@@ -78,7 +84,11 @@ describe('Client', function() {
   });
 
   describe('getCurrentTenant', function() {
-    var Tenant = require('../../lib/resource/Tenant');
+    var Tenant;
+
+    before(function() {
+      Tenant = require('../../lib/resource/Tenant');
+    });
 
     it('should not err', function(done) {
       helpers.getClient(function(client) {

--- a/test/it/directory_it.js
+++ b/test/it/directory_it.js
@@ -52,9 +52,13 @@ describe('Directory',function(){
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }
@@ -100,9 +104,13 @@ describe('Directory',function(){
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }

--- a/test/it/group_it.js
+++ b/test/it/group_it.js
@@ -66,9 +66,13 @@ describe('Group',function(){
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }
@@ -114,9 +118,13 @@ describe('Group',function(){
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }
@@ -135,8 +143,10 @@ describe('Group',function(){
 
   describe('name',function(){
     var saveResult, getResult;
-    var newName = 'it-group-'+helpers.uniqId();
+    var newName;
+
     before(function(done){
+      newName = 'it-group-' + helpers.uniqId();
 
       group.name = newName;
       group.save(function(err){
@@ -158,8 +168,10 @@ describe('Group',function(){
 
   describe('description',function(){
     var saveResult, getResult;
-    var newDescription = 'it-group-description'+helpers.uniqId();
+    var newDescription;
+
     before(function(done){
+      newDescription = 'it-group-description' + helpers.uniqId();
 
       group.description = newDescription;
       group.save(function(err){

--- a/test/it/jwt_authenticator_it.js
+++ b/test/it/jwt_authenticator_it.js
@@ -34,9 +34,9 @@ describe('JwtAuthenticator',function(){
 
   var application, application2, passwordGrantResponse;
 
-  var newAccount = helpers.fakeAccount();
+  var newAccount;
 
-  var unsignedToken = nJwt.create({hello:'world'},'not a secret').compact();
+  var unsignedToken;
 
   var expiredToken;
   /*
@@ -44,6 +44,9 @@ describe('JwtAuthenticator',function(){
     has a very short access token ttl - for testing token expiration
    */
   before(function(done){
+    newAccount = helpers.fakeAccount();
+    unsignedToken = nJwt.create({hello:'world'},'not a secret').compact();
+
     helpers.createApplication(function(err,app){
       if(err){
         done(err);

--- a/test/it/oauth_authenticator_it.js
+++ b/test/it/oauth_authenticator_it.js
@@ -39,9 +39,9 @@ describe('OAuthAuthenticator',function(){
 
   var application, application2, passwordGrantResponse;
 
-  var newAccount = helpers.fakeAccount();
+  var newAccount;
 
-  var unsignedToken = nJwt.create({hello:'world'},'not a secret').compact();
+  var unsignedToken;
 
   var expiredToken;
   /*
@@ -49,6 +49,9 @@ describe('OAuthAuthenticator',function(){
     has a very short access token ttl - for testing token expiration
    */
   before(function(done){
+    newAccount = helpers.fakeAccount();
+    unsignedToken = nJwt.create({hello:'world'},'not a secret').compact();
+
     helpers.createApplication(function(err,app){
       if(err){
         done(err);

--- a/test/it/oauth_id_site_token_grant_it.js
+++ b/test/it/oauth_id_site_token_grant_it.js
@@ -7,9 +7,11 @@ var stormpath = require('../../');
 
 describe('OAuthIdSiteTokenGrantAuthenticator',function(){
   var application;
-  var newAccount = helpers.fakeAccount();
+  var newAccount;
 
   before(function(done){
+    newAccount = helpers.fakeAccount();
+
     helpers.createApplication(function(err,app){
       application = app;
       application.createAccount(newAccount,done);

--- a/test/it/oauth_password_grant_it.js
+++ b/test/it/oauth_password_grant_it.js
@@ -9,9 +9,11 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
 
   var application;
 
-  var newAccount = helpers.fakeAccount();
+  var newAccount;
 
   before(function(done){
+    newAccount = helpers.fakeAccount();
+
     helpers.createApplication(function(err,app){
       application = app;
       application.createAccount(newAccount,done);

--- a/test/it/oauth_refresh_grant_it.js
+++ b/test/it/oauth_refresh_grant_it.js
@@ -9,9 +9,11 @@ describe('OAuthRefreshTokenGrantRequestAuthenticator',function(){
 
   var application, refreshToken;
 
-  var newAccount = helpers.fakeAccount();
+  var newAccount;
 
   before(function(done){
+    newAccount = helpers.fakeAccount();
+
     helpers.createApplication(function(err,app){
       if(err){
         done(err);

--- a/test/it/tenant_it.js
+++ b/test/it/tenant_it.js
@@ -30,9 +30,13 @@ describe('Tenant', function() {
 
   describe('getAccounts',function(){
     var directory, account;
-    var accounts = [];
-    var fakeAccount = helpers.fakeAccount();
+    var accounts;
+    var fakeAccount;
+
     before(function(done){
+      accounts = [];
+      fakeAccount = helpers.fakeAccount();
+
       helpers.getClient(function(_client){
         client = _client;
         client.createDirectory(
@@ -69,10 +73,13 @@ describe('Tenant', function() {
   });
 
   describe('getGroups',function(){
+    var groups;
+    var groupName;
 
-    var groups = [];
-    var groupName = helpers.uniqId();
     before(function(done){
+      groups = [];
+      groupName = helpers.uniqId();
+
       helpers.getClient(function(_client){
         client = _client;
         client.createDirectory(
@@ -127,9 +134,13 @@ describe('Tenant', function() {
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }
@@ -174,9 +185,13 @@ describe('Tenant', function() {
 
       describe('when saved and re-fetched',function(){
         var customDataAfterGet;
-        var propertyName = helpers.uniqId();
-        var propertyValue = helpers.uniqId();
+        var propertyName;
+        var propertyValue;
+
         before(function(done){
+          propertyName = helpers.uniqId();
+          propertyValue = helpers.uniqId();
+
           customData[propertyName] = propertyValue;
           customData.save(function(err){
             if(err){ throw err; }

--- a/test/live/sp.cache.memcachedStore_live.js
+++ b/test/live/sp.cache.memcachedStore_live.js
@@ -8,10 +8,14 @@ var Cache = require('../../lib/cache/Cache');
 var memcachedActionTests = function(memcachedStore) {
 
     describe('set entry', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
       var entry;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         memcachedStore.put(key, val, function () {
           memcachedStore.get(key, function (err, ent) {
             entry = ent;
@@ -31,9 +35,13 @@ var memcachedActionTests = function(memcachedStore) {
     });
 
     describe('get entry', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         memcachedStore.put(key, val, done);
       });
       after(function (done) {
@@ -58,9 +66,13 @@ var memcachedActionTests = function(memcachedStore) {
     });
 
     describe('delete entry', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         memcachedStore.put(key, val, done);
       });
       it('should remove entry from store', function (done) {
@@ -74,9 +86,13 @@ var memcachedActionTests = function(memcachedStore) {
     });
 
     describe('clear cache', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         memcachedStore.put(key, val, done);
       });
       it('should remove all entries from store', function (done) {
@@ -90,9 +106,13 @@ var memcachedActionTests = function(memcachedStore) {
     });
 
     describe('cache size', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         memcachedStore.clear(function(){
           memcachedStore.put(key, val, done);
         });

--- a/test/live/sp.cache.redisStore_live.js
+++ b/test/live/sp.cache.redisStore_live.js
@@ -9,10 +9,14 @@ var redis = require('redis');
 
 var redisActionTests = function(redisStore) {
     describe('set entry', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
       var entry;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         redisStore.put(key, val, function () {
           redisStore.get(key, function (err, ent) {
             entry = ent;
@@ -32,9 +36,13 @@ var redisActionTests = function(redisStore) {
     });
 
     describe('get entry', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         redisStore.put(key, val, done);
       });
       after(function (done) {
@@ -59,9 +67,13 @@ var redisActionTests = function(redisStore) {
     });
 
     describe('delete entry', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         redisStore.put(key, val, done);
       });
       it('should remove entry from store', function (done) {
@@ -75,9 +87,13 @@ var redisActionTests = function(redisStore) {
     });
 
     describe('clear cache', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         redisStore.put(key, val, done);
       });
       it('should remove all entries from store', function (done) {
@@ -91,9 +107,13 @@ var redisActionTests = function(redisStore) {
     });
 
     describe('cache size', function () {
-      var key = 'key' + random();
-      var val = 'val' + random();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + random();
+        val = 'val' + random();
+
         redisStore.clear(function(){
           redisStore.put(key, val, done);
         });

--- a/test/sp.auth.unit_test.js
+++ b/test/sp.auth.unit_test.js
@@ -8,8 +8,16 @@ var Buffer = require('buffer').Buffer;
 
 describe('Authorization module', function () {
   'use strict';
-  var getAuthenticator = require('../lib/authc').getAuthenticator;
-  var apiKey = {id: 'stormpath_apiKey_id', secret: 'stormpath_apiKey_secret'};
+  var getAuthenticator;
+  var apiKey;
+
+  before(function () {
+    getAuthenticator = require('../lib/authc').getAuthenticator;
+  });
+
+  beforeEach(function () {
+    apiKey = {id: 'stormpath_apiKey_id', secret: 'stormpath_apiKey_secret'};
+  });
 
   describe('constructor', function(){
     function createAuth(options){
@@ -46,7 +54,12 @@ describe('Authorization module', function () {
   });
 
   describe('Basic auth', function () {
-    var auth = getAuthenticator({apiKey: apiKey, authenticationScheme: 'basic'});
+    var auth;
+
+    beforeEach(function () {
+      auth = getAuthenticator({apiKey: apiKey, authenticationScheme: 'basic'});
+    });
+
     it('should sign request with base64 signature', function () {
       var req = {headers: {}};
       var basicAuthToken = new Buffer(apiKey.id + ':' + apiKey.secret)
@@ -58,10 +71,14 @@ describe('Authorization module', function () {
     });
   });
   describe('Digest auth', function () {
-    var uuid = require('node-uuid');
-    var auth = getAuthenticator({apiKey: apiKey, authenticationScheme:'SAUTHC1'});
+    var uuid;
+    var auth;
     var sandbox, guidStub;
+
     before(function () {
+      uuid = require('node-uuid');
+      auth = getAuthenticator({apiKey: apiKey, authenticationScheme:'SAUTHC1'});
+
       sandbox = sinon.sandbox.create();
       guidStub = sandbox.stub(uuid, 'v4', function () {
         return '3412d026-624e-4778-b02d-f9906f40fc4f';

--- a/test/sp.authc.apiKey.js
+++ b/test/sp.authc.apiKey.js
@@ -5,10 +5,15 @@ var ApiKey = require('../lib/authc/ApiKey');
 
 describe('authc', function () {
   describe('ApiKey class', function(){
-    var id = 'id';
-    var secret = 'boom!';
+    var id;
+    var secret;
+    var apiKey;
 
-    var apiKey = new ApiKey(id, secret);
+    beforeEach(function () {
+      id = 'id';
+      secret = 'boom!';
+      apiKey = new ApiKey(id, secret);
+    });
 
     it('should expose id and secret as fields', function(){
       apiKey.id.should.be.equal(id);

--- a/test/sp.cache.cacheHandler_test.js
+++ b/test/sp.cache.cacheHandler_test.js
@@ -29,11 +29,16 @@ describe('CacheHandler',function(){
     });
 
     describe('with a custom store constructor', function(){
+      var MockStore;
+      var cacheOptions;
+      var handler;
 
-      var MockStore = function(opts){
-        this._options = opts;
-      };
-      var cacheOptions= {
+      beforeEach(function () {
+        MockStore = function (opts) {
+          this._options = opts;
+        };
+
+        cacheOptions = {
           ttl: rand(),
           tti: rand(),
           options: {
@@ -41,9 +46,11 @@ describe('CacheHandler',function(){
             b: rand()
           },
           store: MockStore
-      };
-      var handler = new CacheHandler({
-        cacheOptions: cacheOptions
+        };
+
+        handler = new CacheHandler({
+          cacheOptions: cacheOptions
+        });
       });
 
       it('should construct the custom store with the global options', function(){
@@ -68,12 +75,14 @@ describe('CacheHandler',function(){
       customDataRegionPutSpy;
 
     describe('with a resource result',function(){
-      var result = {
-        href: '/v1/accounts/' + common.uuid(),
-        username: common.uuid()
-      };
+      var result;
 
       before(function(done) {
+        result = {
+          href: '/v1/accounts/' + common.uuid(),
+          username: common.uuid()
+        };
+
         cacheHandler = new CacheHandler();
         sandbox = sinon.sandbox.create();
         acountRegionPutSpy = sandbox.spy(cacheHandler.cacheManager.caches.accounts, 'put');
@@ -87,31 +96,36 @@ describe('CacheHandler',function(){
     });
 
     describe('with a resource result that cotains an expanded collection and a linked resource',function(){
-      var parentResourceHref = '/v1/accounts/' + common.uuid();
-      var result = {
-        'href': parentResourceHref,
-        'username': common.uuid(),
-        'groups': {
-          'href': parentResourceHref + '/groups',
-          'offset': 0,
-          'limit': 50,
-          'size': 2,
-          'items': [
-            {
-              'href': '/v1/groups/' + common.uuid(),
-              'name': common.uuid()
-            },
-            {
-              'href': '/v1/groups/' + common.uuid(),
-              'name': common.uuid()
-            }
-          ]
-        },
-        'directory': {
-          'href': '/v1/directories/' + common.uuid()
-        }
-      };
+      var parentResourceHref;
+      var result;
+
       before(function(done) {
+        parentResourceHref = '/v1/accounts/' + common.uuid();
+
+        result = {
+          'href': parentResourceHref,
+          'username': common.uuid(),
+          'groups': {
+            'href': parentResourceHref + '/groups',
+            'offset': 0,
+            'limit': 50,
+            'size': 2,
+            'items': [
+              {
+                'href': '/v1/groups/' + common.uuid(),
+                'name': common.uuid()
+              },
+              {
+                'href': '/v1/groups/' + common.uuid(),
+                'name': common.uuid()
+              }
+            ]
+          },
+          'directory': {
+            'href': '/v1/directories/' + common.uuid()
+          }
+        };
+
         cacheHandler = new CacheHandler();
         sandbox = sinon.sandbox.create();
         acountRegionPutSpy = sandbox.spy(cacheHandler.cacheManager.caches.accounts, 'put');
@@ -132,24 +146,29 @@ describe('CacheHandler',function(){
     });
 
     describe('with a collection result',function(){
-      var collectionHref = 'http://api.stormpath.com/v1/tenants/'+common.uuid()+'/groups';
-      var collectionResult = {
-        'href': collectionHref,
-        'offset': 0,
-        'limit': 50,
-        'size': 2,
-        'items': [
-          {
-            'href': 'http://api.stormpath.com/v1/groups/' + common.uuid(),
-            'name': common.uuid()
-          },
-          {
-            'href': 'http://api.stormpath.com/v1/groups/' + common.uuid(),
-            'name': common.uuid()
-          }
-        ]
-      };
+      var collectionHref;
+      var collectionResult;
+
       before(function(done) {
+        collectionHref = 'http://api.stormpath.com/v1/tenants/' + common.uuid() + '/groups';
+
+        collectionResult = {
+          'href': collectionHref,
+          'offset': 0,
+          'limit': 50,
+          'size': 2,
+          'items': [
+            {
+              'href': 'http://api.stormpath.com/v1/groups/' + common.uuid(),
+              'name': common.uuid()
+            },
+            {
+              'href': 'http://api.stormpath.com/v1/groups/' + common.uuid(),
+              'name': common.uuid()
+            }
+          ]
+        };
+
         cacheHandler = new CacheHandler();
         sandbox = sinon.sandbox.create();
         groupRegionPutSpy = sandbox.spy(cacheHandler.cacheManager.caches.groups, 'put');
@@ -161,34 +180,41 @@ describe('CacheHandler',function(){
     });
 
     describe('with a collection result where the collection items have expansions',function(){
-      var collectionHref = 'http://api.stormpath.com/v1/tenants/'+common.uuid()+'/groups?expand=customData';
-      var groupId1 = common.uuid();
-      var groupId2 = common.uuid();
-      var collectionResult = {
-        'href': collectionHref,
-        'offset': 0,
-        'limit': 50,
-        'size': 2,
-        'items': [
-          {
-            'href': 'http://api.stormpath.com/v1/groups/' + groupId1,
-            'name': common.uuid(),
-            'customData': {
-              'href': 'http://api.stormpath.com/v1/groups/' + groupId1 + '/customData',
-              'createdAt': new Date().toISOString()
-            }
-          },
-          {
-            'href': 'http://api.stormpath.com/v1/groups/' + groupId2,
-            'name': common.uuid(),
-            'customData': {
-              'href': 'http://api.stormpath.com/v1/groups/' + groupId2 + '/customData',
-              'createdAt': new Date().toISOString()
-            }
-          }
-        ]
-      };
+      var collectionHref;
+      var groupId1;
+      var groupId2;
+      var collectionResult;
+
       before(function(done) {
+        collectionHref = 'http://api.stormpath.com/v1/tenants/' + common.uuid() + '/groups?expand=customData';
+        groupId1 = common.uuid();
+        groupId2 = common.uuid();
+
+        collectionResult = {
+          'href': collectionHref,
+          'offset': 0,
+          'limit': 50,
+          'size': 2,
+          'items': [
+            {
+              'href': 'http://api.stormpath.com/v1/groups/' + groupId1,
+              'name': common.uuid(),
+              'customData': {
+                'href': 'http://api.stormpath.com/v1/groups/' + groupId1 + '/customData',
+                'createdAt': new Date().toISOString()
+              }
+            },
+            {
+              'href': 'http://api.stormpath.com/v1/groups/' + groupId2,
+              'name': common.uuid(),
+              'customData': {
+                'href': 'http://api.stormpath.com/v1/groups/' + groupId2 + '/customData',
+                'createdAt': new Date().toISOString()
+              }
+            }
+          ]
+        };
+
         cacheHandler = new CacheHandler();
         sandbox = sinon.sandbox.create();
         groupRegionPutSpy = sandbox.spy(cacheHandler.cacheManager.caches.groups, 'put');
@@ -207,15 +233,18 @@ describe('CacheHandler',function(){
 
 
     describe('with a resource result that contains an expanded resource',function(){
-      var result = {
-        href: '/v1/accounts/' + common.uuid(),
-        username: common.uuid(),
-        directory: {
-          href: '/v1/directories/' + common.uuid(),
-          name: common.uuid()
-        }
-      };
+      var result;
+
       before(function(done) {
+        result = {
+          href: '/v1/accounts/' + common.uuid(),
+          username: common.uuid(),
+          directory: {
+            href: '/v1/directories/' + common.uuid(),
+            name: common.uuid()
+          }
+        };
+
         cacheHandler = new CacheHandler();
         sandbox = sinon.sandbox.create();
         acountRegionPutSpy = sandbox.spy(cacheHandler.cacheManager.caches.accounts, 'put');

--- a/test/sp.cache.cache_test.js
+++ b/test/sp.cache.cache_test.js
@@ -52,11 +52,12 @@ describe('Cache module', function () {
     describe('get entry', function () {
       describe('if entry exists', function () {
         var sandbox, entry, hitsCounter;
-        var key = 'key' + random();
-        var key2 = 'key' + random();
-        var data = 'entry' + random();
-        var initialTime = 100500;
-        var tickDelta = 150;
+        var key;
+        var key2;
+        var data;
+        var initialTime;
+        var tickDelta;
+
         before(function (done) {
           function createCacheWithDifferentTTL(cache, done) {
             cache.ttl = 300;
@@ -69,7 +70,14 @@ describe('Cache module', function () {
               });
             });
           }
+
           sandbox = sinon.sandbox.create();
+          key = 'key' + random();
+          key2 = 'key' + random();
+          data = 'entry' + random();
+          initialTime = 100500;
+          tickDelta = 150;
+
           var clock = sandbox.useFakeTimers(initialTime, 'Date');
           hitsCounter = cache.stats.hits;
           cache.put(key, data, function () {
@@ -117,16 +125,22 @@ describe('Cache module', function () {
       });
 
       describe('if entry expired', function () {
-        var key = 'key' +  random();
-        var data = 'entry' + random();
+        var key ;
+        var data;
         var entry;
         var missCounter;
-        var initialTime = 100500;
-        var tickDelta = 310 * 1000;
+        var initialTime;
+        var tickDelta;
         var sandbox;
         var storeDeleteSpy;
+
         before(function (done) {
+          key = 'key' +  random();
+          data = 'entry' + random();
+          initialTime = 100500;
+          tickDelta = 310 * 1000;
           sandbox = sinon.sandbox.create();
+
           var clock = sandbox.useFakeTimers(initialTime, 'Date');
           storeDeleteSpy = sandbox.spy(cache.store, 'delete');
           missCounter = cache.stats.misses;
@@ -161,11 +175,14 @@ describe('Cache module', function () {
     });
 
     describe('put entry', function () {
-      var key = 'key' + random();
-      var data = 'data' + random();
+      var key;
+      var data;
       var sandbox;
       var statsPutSpy;
+
       before(function (done) {
+        key = 'key' + random();
+        data = 'data' + random();
         sandbox = sinon.sandbox.create();
         statsPutSpy = sandbox.spy(cache.stats, 'put');
         cache.put(key, data, done);
@@ -195,11 +212,13 @@ describe('Cache module', function () {
     });
 
     describe('delete entry', function () {
-      var key = 'key' + random();
-      var cb = function () {
-      };
+      var key;
+      var cb;
       var sandbox, statsDeleteSpy, storeDeleteSpy;
+
       before(function () {
+        key = 'key' + random();
+        cb = function () {};
         sandbox = sinon.sandbox.create();
         statsDeleteSpy = sandbox.spy(cache.stats, 'delete');
         storeDeleteSpy = sandbox.spy(cache.store, 'delete');
@@ -221,9 +240,11 @@ describe('Cache module', function () {
     });
 
     describe('clear cache', function () {
-      var cb = function () {};
+      var cb;
       var sandbox, statsClearSpy, storeClearSpy;
+
       before(function () {
+        cb = function () {};
         sandbox = sinon.sandbox.create();
         statsClearSpy = sandbox.spy(cache.stats, 'clear');
         storeClearSpy = sandbox.spy(cache.store, 'clear');
@@ -245,10 +266,11 @@ describe('Cache module', function () {
     });
 
     describe('cache size', function () {
-      var cb = function () {
-      };
+      var cb;
       var sandbox, storeSizeSpy;
+
       before(function () {
+        cb = function () {};
         sandbox = sinon.sandbox.create();
         storeSizeSpy = sandbox.spy(cache.store, 'size');
 
@@ -275,8 +297,10 @@ describe('Cache module', function () {
   });
 
   describe('Redis store', function(){
-    var opt = {cache:null}, sandbox;
+    var opt, sandbox;
+
     before(function(){
+      opt = {cache: null};
       sandbox = sinon.sandbox.create();
       var ms = new MemoryStore();
       _.extend(ms,{
@@ -301,8 +325,10 @@ describe('Cache module', function () {
   });
 
   describe('Memcached store', function(){
-    var opt = {cache:null}, sandbox;
+    var opt, sandbox;
+
     before(function(){
+      opt = {cache: null};
       sandbox = sinon.sandbox.create();
       var ms = new MemoryStore();
       ms._set = ms.set;

--- a/test/sp.cache.entry_test.js
+++ b/test/sp.cache.entry_test.js
@@ -18,8 +18,10 @@ describe('Cache module',function(){
   describe('Cache Entry class', function(){
     describe('default arguments values ',function(){
       var sandbox;
-      var testTime = 100500;
+      var testTime;
+
       before(function(){
+        testTime = 100500;
         sandbox = sinon.sandbox.create();
         sandbox.useFakeTimers(testTime, 'Date');
       });
@@ -37,11 +39,18 @@ describe('Cache module',function(){
     });
 
     describe('constructor expecting', function(){
-      var entry = {};
-      var createdAt = new Date();
-      var lastAccessedAt = new Date();
-      var cacheEntry =
-        new CacheEntry(entry, createdAt.valueOf(), lastAccessedAt.valueOf());
+      var entry;
+      var createdAt;
+      var lastAccessedAt;
+      var cacheEntry;
+
+      beforeEach(function () {
+        entry = {};
+        createdAt = new Date();
+        lastAccessedAt = new Date();
+        cacheEntry = new CacheEntry(entry, createdAt.valueOf(), lastAccessedAt.valueOf());
+      });
+
       it('should store entry in it initial state', function(){
         cacheEntry.value.should.be.equal(entry);
       });
@@ -70,7 +79,12 @@ describe('Cache module',function(){
     });
 
     describe('call to touch method', function(){
-      var cacheEntry = createVoidCacheEntry();
+      var cacheEntry;
+
+      beforeEach(function () {
+        cacheEntry = createVoidCacheEntry();
+      });
+
       it('should change lastAccessedTime to current for cache entry', function(){
         var was = cacheEntry.lastAccessedAt;
 
@@ -82,7 +96,12 @@ describe('Cache module',function(){
 
     describe('call to isExpired', function(){
       describe('if entry is fresh', function(){
-        var cacheEntry = createVoidCacheEntry();
+        var cacheEntry;
+
+        beforeEach(function () {
+          cacheEntry = createVoidCacheEntry();
+        });
+
         it('should not be expired', function(){
           var notExpired = cacheEntry.isExpired(300,300);
           /* jshint -W030 */
@@ -91,8 +110,13 @@ describe('Cache module',function(){
       });
 
       describe('if entry is idle for to long', function(){
-        var cacheEntry = createVoidCacheEntry();
-        cacheEntry.lastAccessedAt -= 500*1000;
+        var cacheEntry;
+
+        beforeEach(function () {
+          cacheEntry = createVoidCacheEntry();
+          cacheEntry.lastAccessedAt -= 500 * 1000;
+        });
+
         it('should be expired', function(){
           var expired = cacheEntry.isExpired(300,300);
           /* jshint -W030 */
@@ -101,8 +125,13 @@ describe('Cache module',function(){
       });
 
       describe('if entry is created a long time ago', function(){
-        var cacheEntry = createVoidCacheEntry();
-        cacheEntry.createdAt -= 500*1000;
+        var cacheEntry;
+
+        beforeEach(function () {
+          cacheEntry = createVoidCacheEntry();
+          cacheEntry.createdAt -= 500 * 1000;
+        });
+
         it('should be expired', function(){
           var expired = cacheEntry.isExpired(300,300);
           /* jshint -W030 */
@@ -112,12 +141,18 @@ describe('Cache module',function(){
     });
 
     describe('call to toObject', function(){
-      var cacheEntry = createVoidCacheEntry();
-      var expectCreatedAt = moment.utc(cacheEntry.createdAt)
-        .format('YYYY-MM-DD HH:mm:ss.SSS');
-      var expectLastAccessedAt = moment.utc(cacheEntry.lastAccessedAt)
-        .format('YYYY-MM-DD HH:mm:ss.SSS');
-      var object = cacheEntry.toObject();
+      var cacheEntry;
+      var expectCreatedAt;
+      var expectLastAccessedAt;
+      var object;
+
+      beforeEach(function () {
+        cacheEntry = createVoidCacheEntry();
+        expectCreatedAt = moment.utc(cacheEntry.createdAt).format('YYYY-MM-DD HH:mm:ss.SSS');
+        expectLastAccessedAt = moment.utc(cacheEntry.lastAccessedAt).format('YYYY-MM-DD HH:mm:ss.SSS');
+        object = cacheEntry.toObject();
+      });
+
       it('should return current entry state with formatted dates', function(){
         object.createdAt.should.be.equal(expectCreatedAt);
         object.lastAccessedAt.should.be.equal(expectLastAccessedAt);
@@ -125,14 +160,21 @@ describe('Cache module',function(){
     });
 
     describe('call to type method parse', function(){
-      var cacheEntry = createVoidCacheEntry();
-      var expectCreatedAt = moment.utc(cacheEntry.createdAt)
-        .format('YYYY-MM-DD HH:mm:ss.SSS');
-      var expectLastAccessedAt = moment.utc(cacheEntry.lastAccessedAt)
-        .format('YYYY-MM-DD HH:mm:ss.SSS');
-      var parsedCacheEntry = CacheEntry.parse({
-        createdAt: expectCreatedAt,
-        lastAccessedAt: expectLastAccessedAt});
+      var cacheEntry;
+      var expectCreatedAt;
+      var expectLastAccessedAt;
+      var parsedCacheEntry;
+
+      beforeEach(function () {
+        cacheEntry = createVoidCacheEntry();
+        expectCreatedAt = moment.utc(cacheEntry.createdAt).format('YYYY-MM-DD HH:mm:ss.SSS');
+        expectLastAccessedAt = moment.utc(cacheEntry.lastAccessedAt).format('YYYY-MM-DD HH:mm:ss.SSS');
+
+        parsedCacheEntry = CacheEntry.parse({
+          createdAt: expectCreatedAt,
+          lastAccessedAt: expectLastAccessedAt
+        });
+      });
 
       it('should return instance of CacheEntry with utc time', function(){
         parsedCacheEntry.createdAt.should.be.equal(cacheEntry.createdAt);

--- a/test/sp.cache.manager_test.js
+++ b/test/sp.cache.manager_test.js
@@ -8,7 +8,12 @@ describe('Cache module',function(){
 
   describe('Cache Manager class', function(){
     describe('By default', function(){
-      var manager = new CacheManager();
+      var manager;
+
+      beforeEach(function () {
+        manager = new CacheManager();
+      });
+
       it('cache should be empty', function(){
         /* jshint -W030 */
         manager.caches.should.deep.equal({});
@@ -20,9 +25,13 @@ describe('Cache module',function(){
     });
 
     describe('create cache',function(){
-      var manager = new CacheManager();
-      var region = common.uuid();
+      var manager;
+      var region;
+
       before(function(){
+        manager = new CacheManager();
+        region = common.uuid();
+
         manager.createCache(region);
       });
       it('should create cache instance', function(){
@@ -34,9 +43,13 @@ describe('Cache module',function(){
     });
 
     describe('get cache',function(){
-      var manager = new CacheManager();
-      var region = common.uuid();
+      var manager;
+      var region;
+
       before(function(){
+        manager = new CacheManager();
+        region = common.uuid();
+
         manager.createCache(region);
       });
       it('should return cache instance', function(){

--- a/test/sp.cache.memoryStore_test.js
+++ b/test/sp.cache.memoryStore_test.js
@@ -6,13 +6,21 @@ var MemoryStore = require('../lib/cache/MemoryStore');
 describe('Cache module', function () {
 
   describe('In memory cache store', function () {
-    var memoryStore = new MemoryStore();
+    var memoryStore;
+
+    beforeEach(function () {
+      memoryStore = new MemoryStore();
+    });
 
     describe('set entry', function () {
-      var key = 'key' + Date.now();
-      var val = 'val' + Date.now();
+      var key;
+      var val;
       var entry;
+
       before(function (done) {
+        key = 'key' + Date.now();
+        val = 'val' + Date.now();
+
         memoryStore.set(key, val, function () {
           memoryStore.get(key, function (err, ent) {
             entry = ent;
@@ -32,9 +40,13 @@ describe('Cache module', function () {
     });
 
     describe('get entry', function () {
-      var key = 'key' + Date.now();
-      var val = 'val' + Date.now();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + Date.now();
+        val = 'val' + Date.now();
+
         memoryStore.set(key, val, done);
       });
       after(function (done) {
@@ -59,9 +71,13 @@ describe('Cache module', function () {
     });
 
     describe('delete entry', function () {
-      var key = 'key' + Date.now();
-      var val = 'val' + Date.now();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + Date.now();
+        val = 'val' + Date.now();
+
         memoryStore.set(key, val, done);
       });
       it('should remove entry from store', function (done) {
@@ -75,9 +91,13 @@ describe('Cache module', function () {
     });
 
     describe('clear cache', function () {
-      var key = 'key' + Date.now();
-      var val = 'val' + Date.now();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + Date.now();
+        val = 'val' + Date.now();
+
         memoryStore.set(key, val, done);
       });
       it('should remove all entries from store', function (done) {
@@ -91,9 +111,13 @@ describe('Cache module', function () {
     });
 
     describe('cache size', function () {
-      var key = 'key' + Date.now();
-      var val = 'val' + Date.now();
+      var key;
+      var val;
+
       before(function (done) {
+        key = 'key' + Date.now();
+        val = 'val' + Date.now();
+
         memoryStore.clear(function(){
           memoryStore.set(key, val, done);
         });

--- a/test/sp.cache.stats_test.js
+++ b/test/sp.cache.stats_test.js
@@ -4,7 +4,11 @@ describe('Cache module',function(){
 
   // make sens only for single instance!!!
   describe('Cache Stats class', function(){
-    var stats = new CacheStats();
+    var stats;
+
+    beforeEach(function () {
+      stats = new CacheStats();
+    });
 
     describe('if we put a new entry', function(){
       var putsCounter, sizeCounter;

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -33,7 +33,11 @@ function clearEnvVars(){
 }
 
 describe('Client', function () {
-  var apiKey = {id: 1, secret: 2};
+  var apiKey;
+
+  beforeEach(function () {
+    apiKey = {id: 1, secret: 2};
+  });
 
   describe('constructor', function () {
     var client;
@@ -212,9 +216,10 @@ describe('Client', function () {
     describe('first call should get resource', function () {
 
       var sandbox, client, getResourceStub, cbSpy, err, tenant, onCurrentTenantCb;
-      var currentTenantHref = '/tenants/current';
+      var currentTenantHref;
 
       before(function (done) {
+        currentTenantHref = '/tenants/current';
         sandbox = sinon.sandbox.create();
         err = {error: 'boom!'};
         tenant = { href: 'foo'};
@@ -274,9 +279,10 @@ describe('Client', function () {
 
     describe('second and after call', function () {
       var sandbox, client, getResourceStub, cbSpy, err, tenant, onCurrentTenantCb;
-      var currentTenantHref = '/tenants/current';
+      var currentTenantHref;
 
       before(function (done) {
+        currentTenantHref = '/tenants/current';
         sandbox = sinon.sandbox.create();
         err = {error: 'boom!'};
         tenant = { href: 'foo'};
@@ -323,9 +329,10 @@ describe('Client', function () {
 
   describe('call to get resource', function () {
     var sandbox, client, getResourceStub, cbSpy;
-    var href = '/boom!';
+    var href;
 
     before(function (done) {
+      href = '/boom!';
       sandbox = sinon.sandbox.create();
       client = makeTestClient({apiKey: apiKey});
 
@@ -363,9 +370,10 @@ describe('Client', function () {
 
   describe('call to create resource', function () {
     var sandbox, client, createResourceStub, cbSpy;
-    var href = '/boom!';
+    var href;
 
     before(function (done) {
+      href = '/boom!';
       sandbox = sinon.sandbox.create();
       client = makeTestClient({apiKey: apiKey});
 
@@ -404,9 +412,10 @@ describe('Client', function () {
   describe('call to get accounts', function() {
     var cbSpy, client, err, sandbox, tenant;
     var getCurrentTenantStub, getTenantAccounts;
-    var returnError = false;
+    var returnError;
 
     before(function(done) {
+      returnError = false;
       sandbox = sinon.sandbox.create();
       err = {error: 'boom!'};
 
@@ -474,9 +483,10 @@ describe('Client', function () {
   describe('call to get groups', function() {
     var cbSpy, client, err, sandbox, tenant;
     var getCurrentTenantStub, getTenantGroups;
-    var returnError = false;
+    var returnError;
 
     before(function (done) {
+      returnError = false;
       sandbox = sinon.sandbox.create();
       err = {error: 'boom!'};
 
@@ -538,10 +548,10 @@ describe('Client', function () {
 
   describe('call to get applications', function () {
     var sandbox, client, getCurrentTenantStub, getTenantApplications,
-      cbSpy, err, tenant;
-    var returnError = false;
+      cbSpy, err, tenant, returnError;
 
     before(function (done) {
+      returnError = false;
       sandbox = sinon.sandbox.create();
       err = {error: 'boom!'};
       client = makeTestClient({apiKey: apiKey});
@@ -600,10 +610,10 @@ describe('Client', function () {
 
   describe('call to create application', function () {
     var sandbox, client, getCurrentTenantStub, createTenantApplication,
-      cbSpy, app, err, tenant;
-    var returnError = false;
+      cbSpy, app, err, tenant, returnError;
 
     before(function (done) {
+      returnError = false;
       sandbox = sinon.sandbox.create();
       err = {error: 'boom!'};app = {href: 'boom!'};
       client = makeTestClient({apiKey: apiKey});
@@ -662,10 +672,10 @@ describe('Client', function () {
 
   describe('call to get directories', function () {
     var sandbox, client, getCurrentTenantStub, getTenantDirectories,
-      cbSpy, err, tenant;
-    var returnError = false;
+      cbSpy, err, tenant, returnError;
 
     before(function (done) {
+      returnError = false;
       sandbox = sinon.sandbox.create();
       err = {error: 'boom!'};
       client = makeTestClient({apiKey: apiKey});
@@ -724,10 +734,10 @@ describe('Client', function () {
 
   describe('call to create Directory', function () {
     var sandbox, client, getCurrentTenantStub, createTenantDirectory,
-      cbSpy, app, err, tenant;
-    var returnError = false;
+      cbSpy, app, err, tenant, returnError;
 
     before(function (done) {
+      returnError = false;
       sandbox = sinon.sandbox.create();
       err = {error: 'boom!'};app = {href: 'boom!'};
       client = makeTestClient({apiKey: apiKey});

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -11,7 +11,7 @@ var assert = common.assert;
 var configLoader = require('../lib/configLoader');
 
 describe('Configuration loader', function () {
-  var loader, fakeFs, afterIt = [];
+  var loader, fakeFs, afterIt;
 
   // Removes any Stormpath environment variables
   // and provides a callback to restore them.
@@ -53,6 +53,7 @@ describe('Configuration loader', function () {
   }
 
   beforeEach(function () {
+    afterIt = [];
     loader = configLoader();
   });
 

--- a/test/sp.ds.datastore_test.js
+++ b/test/sp.ds.datastore_test.js
@@ -16,15 +16,26 @@ describe('ds:', function () {
 
     describe('when constructed', function () {
       describe('and request executor not provided in config', function () {
-        var ds = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+        var ds;
+
+        beforeEach(function () {
+          ds = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+        });
+
         it('should create instance of default RequestExecutor', function () {
           ds.requestExecutor.should.be.an.instanceof(RequestExecutor);
         });
       });
 
       describe('and request executor was provided in config', function () {
-        var reqExec = new RequestExecutor({client: {apiKey: {id: 1, secret: 2}}});
-        var ds = new DataStore({requestExecutor: reqExec});
+        var reqExec;
+        var ds;
+
+        beforeEach(function () {
+          reqExec = new RequestExecutor({client: {apiKey: {id: 1, secret: 2}}});
+          ds = new DataStore({requestExecutor: reqExec});
+        });
+
         it('should reuse provided request executor instance', function () {
           ds.requestExecutor.should.be.equal(reqExec);
         });
@@ -43,13 +54,17 @@ describe('ds:', function () {
     });
 
     describe('getResource()', function () {
-      var ds = new DataStore({
-        cacheOptions: {
-          store: 'memory'
-        },
-        client: {
-          apiKey: {id: 1, secret: 2}
-        }
+      var ds;
+
+      beforeEach(function () {
+        ds = new DataStore({
+          cacheOptions: {
+            store: 'memory'
+          },
+          client: {
+            apiKey: {id: 1, secret: 2}
+          }
+        });
       });
 
       describe('without required params', function () {
@@ -63,14 +78,18 @@ describe('ds:', function () {
       });
 
       describe('when resource is already cached', function () {
-
-        var resource = {
-          href: '/tenants/' + common.uuid(),
-          data: common.uuid()
-        };
-        var cbSpy = sinon.spy();
+        var resource;
+        var cbSpy;
         var sandbox, cacheGetSpy, reqExecSpy;
+
         before(function (done) {
+          resource = {
+            href: '/tenants/' + common.uuid(),
+            data: common.uuid()
+          };
+
+          cbSpy = sinon.spy();
+
           sandbox = sinon.sandbox.create();
           reqExecSpy = sandbox.spy(ds.requestExecutor, 'execute');
           var cache = ds.cacheHandler.cacheManager.getCache('tenants');
@@ -100,13 +119,18 @@ describe('ds:', function () {
        });*/
 
       describe('when resource is not in cache', function () {
-        var resource = {
-          href: '/tenants/' + common.uuid(),
-          data: common.uuid()
-        };
-        var cbSpy = sinon.spy();
+        var resource;
+        var cbSpy;
         var sandbox, cacheGetSpy, cachePutSpy, reqExecStub;
+
         before(function () {
+          resource = {
+            href: '/tenants/' + common.uuid(),
+            data: common.uuid()
+          };
+
+          cbSpy = sinon.spy();
+
           sandbox = sinon.sandbox.create();
           var cache = ds.cacheHandler.cacheManager.getCache('tenants');
           cacheGetSpy = sandbox.spy(cache, 'get');
@@ -138,11 +162,16 @@ describe('ds:', function () {
       });
 
       describe('if href not cached', function () {
-        var href = '/directory/2' + random();
-        var data = {'data': random()};
-        var cbSpy = sinon.spy();
+        var href;
+        var data;
+        var cbSpy;
         var sandbox, reqExecStub;
+
         before(function () {
+          href = '/directory/2' + random();
+          data = {'data': random()};
+          cbSpy = sinon.spy();
+
           sandbox = sinon.sandbox.create();
           reqExecStub = sandbox.stub(ds.requestExecutor, 'execute', function (req, cb) {
             cb(null, data);
@@ -163,24 +192,30 @@ describe('ds:', function () {
       });
 
       describe('request error handling', function () {
-        var ds = new DataStore({
-          cacheOptions: {
-            tenants: {
-              store: MemoryStore,
-              ttl: 60,
-              tti: 60
-            }
-          },
-          client: {
-            apiKey: {id: 1, secret: 2}
-          }
-        });
-
-        var href = '/tenants/3' + random();
-        var cbSpy = sinon.spy();
-        var error = new Error();
+        var ds;
+        var href;
+        var cbSpy;
+        var error;
         var sandbox, reqExecStub;
+
         before(function () {
+          ds = new DataStore({
+            cacheOptions: {
+              tenants: {
+                store: MemoryStore,
+                ttl: 60,
+                tti: 60
+              }
+            },
+            client: {
+              apiKey: {id: 1, secret: 2}
+            }
+          });
+
+          href = '/tenants/3' + random();
+          cbSpy = sinon.spy();
+          error = new Error();
+
           sandbox = sinon.sandbox.create();
           reqExecStub = sandbox.stub(ds.requestExecutor, 'execute', function (req, cb) {
             cb(error);
@@ -214,23 +249,28 @@ describe('ds:', function () {
       });
 
       describe('request undefined state handling', function () {
-        var ds = new DataStore({
-          cacheOptions: {
-            tenants: {
-              store: MemoryStore,
-              ttl: 60,
-              tti: 60
-            }
-          },
-          client: {
-            apiKey: {id: 1, secret: 2}
-          }
-        });
-
-        var href = '/tenants/3' + random();
-        var cbSpy = sinon.spy();
+        var ds;
+        var href;
+        var cbSpy;
         var sandbox, reqExecStub;
+
         before(function () {
+          ds = new DataStore({
+            cacheOptions: {
+              tenants: {
+                store: MemoryStore,
+                ttl: 60,
+                tti: 60
+              }
+            },
+            client: {
+              apiKey: {id: 1, secret: 2}
+            }
+          });
+
+          href = '/tenants/3' + random();
+          cbSpy = sinon.spy();
+
           sandbox = sinon.sandbox.create();
           reqExecStub = sandbox.stub(ds.requestExecutor, 'execute', function (req, cb) {
             cb(null, null);
@@ -251,29 +291,39 @@ describe('ds:', function () {
     });
 
     describe('createResource:', function () {
-      var ds = new DataStore({
-        cacheOptions: {
-          tenants: {
-            store: MemoryStore,
-            ttl: 60,
-            tti: 60
-          }
-        },
-        client: {
-          apiKey: {id: 1, secret: 2}
-        }
-      });
-
-      var href = '/tenants/3' + random();
-      var query = {q: 'all'};
-      var data = {'data': random()};
-      var response = {
-        href: href,
-        data: random()
-      };
-      var cbSpy = sinon.spy();
+      var ds;
+      var href;
+      var query;
+      var data;
+      var response;
+      var cbSpy;
       var sandbox, cachePutSpy, reqExecStub, requestSpy;
+
       before(function () {
+        ds = new DataStore({
+          cacheOptions: {
+            tenants: {
+              store: MemoryStore,
+              ttl: 60,
+              tti: 60
+            }
+          },
+          client: {
+            apiKey: {id: 1, secret: 2}
+          }
+        });
+
+        href = '/tenants/3' + random();
+        query = {q: 'all'};
+        data = {'data': random()};
+
+        response = {
+          href: href,
+          data: random()
+        };
+
+        cbSpy = sinon.spy();
+
         sandbox = sinon.sandbox.create();
         var cache = ds.cacheHandler.cacheManager.getCache('tenants');
         cachePutSpy = sandbox.spy(cache, 'put');
@@ -321,23 +371,30 @@ describe('ds:', function () {
     });
 
     describe('save resource', function () {
-      var ds = new DataStore({
-        cacheOptions: {
-          store: 'memory',
-          ttl: 60,
-          tti: 60
-        },
-        client: {
-          apiKey: {id: 1, secret: 2}
-        }
-      });
-
-      var href = '/tenants/2' + random();
-      var data = {'data': random()};
-      var response = {'data': data, href: href};
-      var cbSpy = sinon.spy();
+      var ds;
+      var href;
+      var data;
+      var response;
+      var cbSpy;
       var sandbox, cachePutSpy, reqExecStub, requestSpy;
+
       before(function () {
+        ds = new DataStore({
+          cacheOptions: {
+            store: 'memory',
+            ttl: 60,
+            tti: 60
+          },
+          client: {
+            apiKey: {id: 1, secret: 2}
+          }
+        });
+
+        href = '/tenants/2' + random();
+        data = {'data': random()};
+        response = {'data': data, href: href};
+        cbSpy = sinon.spy();
+
         sandbox = sinon.sandbox.create();
         var cache = ds.cacheHandler.cacheManager.getCache('tenants');
         cachePutSpy = sandbox.spy(cache, 'put');
@@ -375,23 +432,30 @@ describe('ds:', function () {
     });
 
     describe('delete resource', function () {
-      var ds = new DataStore({
-        cacheOptions: {
-          store: MemoryStore,
-          ttl: 60,
-          tti: 60
-        },
-        client: {
-          apiKey: {id: 1, secret: 2}
-        }
-      });
-
-      var href = '/tenants/2' + random();
-      var data = {'data': random()};
-      var response = {'data': data, href: href};
-      var cbSpy = sinon.spy();
+      var ds;
+      var href;
+      var data;
+      var response;
+      var cbSpy;
       var sandbox, cacheDeleteSpy, reqExecStub, requestSpy;
+
       before(function () {
+        ds = new DataStore({
+          cacheOptions: {
+            store: MemoryStore,
+            ttl: 60,
+            tti: 60
+          },
+          client: {
+            apiKey: {id: 1, secret: 2}
+          }
+        });
+
+        href = '/tenants/2' + random();
+        data = {'data': random()};
+        response = {'data': data, href: href};
+        cbSpy = sinon.spy();
+
         sandbox = sinon.sandbox.create();
         var cache = ds.cacheHandler.cacheManager.getCache('tenants');
         cacheDeleteSpy = sandbox.spy(cache, 'delete');

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -11,7 +11,11 @@ var ResourceError = require('../lib/error/ResourceError');
 
 describe('ds:', function () {
   describe('RequestExecutor:', function () {
-    var apiKey = {id: 1, secret: 2};
+    var apiKey;
+
+    beforeEach(function () {
+      apiKey = {id: 1, secret: 2};
+    });
 
     describe('constructor', function () {
       describe('create without options', function () {
@@ -25,7 +29,12 @@ describe('ds:', function () {
         });
       });
       describe('create with required options', function () {
-        var reqExec = new RequestExecutor({client: {apiKey: apiKey}});
+        var reqExec;
+
+        beforeEach(function () {
+          reqExec = new RequestExecutor({client: {apiKey: apiKey}});
+        });
+
         it('should instantiate request authenticator', function () {
           reqExec.requestAuthenticator.should.be.ok;
         });
@@ -40,13 +49,17 @@ describe('ds:', function () {
 
     });
     describe('call to execute', function () {
-      var reqExec = new RequestExecutor({client: {apiKey: apiKey} });
+      var reqExec;
 
       function exec(req, cb) {
         return function () {
           reqExec.execute(req, cb);
         };
       }
+
+      beforeEach(function () {
+        reqExec = new RequestExecutor({client: {apiKey: apiKey} });
+      });
 
       it('should throw if called without req', function () {
         exec().should.throw(/Request argument is required/i);

--- a/test/sp.error.resourceError_test.js
+++ b/test/sp.error.resourceError_test.js
@@ -2,14 +2,20 @@ var ResourceError = require('../lib/error/ResourceError');
 
 describe('Error:', function () {
   describe('Resource Error', function () {
-    var response = {
-      status: 400,
-      code: 100500,
-      message: 'hi user',
-      developerMessage: 'hi dev',
-      moreInfo: 'boom!'
-    };
-    var re = new ResourceError(response);
+    var response;
+    var re;
+
+    beforeEach(function () {
+      response = {
+        status: 400,
+        code: 100500,
+        message: 'hi user',
+        developerMessage: 'hi dev',
+        moreInfo: 'boom!'
+      };
+
+      re = new ResourceError(response);
+    });
 
     it('should inherit from error', function () {
       re.should.be.an.instanceof(Error);

--- a/test/sp.resource.accountStoreMapping_test.js
+++ b/test/sp.resource.accountStoreMapping_test.js
@@ -13,7 +13,11 @@ var BASE_URL = u.BASE_URL;
 describe('Resources: ', function () {
   "use strict";
   describe('Account Store Mapping resource', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
 
     describe('get application', function () {
       var asm, appData, app, app2, accountStoreMapping;

--- a/test/sp.resource.account_test.js
+++ b/test/sp.resource.account_test.js
@@ -18,23 +18,31 @@ var GroupMembership = require('../lib/resource/GroupMembership');
 describe('Resources: ', function () {
   "use strict";
   describe('Account resource class', function () {
-    var dataStore = new DataStore({
-      client: {
-        apiKey: {
-          id: 1,
-          // this secret will decrypt the api keys correctly
-          secret: '6b2c3912-4779-49c1-81e7-23c204f43d2d'
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({
+        client: {
+          apiKey: {
+            id: 1,
+            // this secret will decrypt the api keys correctly
+            secret: '6b2c3912-4779-49c1-81e7-23c204f43d2d'
+          }
         }
-      }
+      });
     });
 
     describe('get groups', function () {
       describe('if groups not set', function () {
-        var account = new Account(dataStore);
+        var account;
 
         function getGroupsWithoutHref() {
           account.getGroups();
         }
+
+        beforeEach(function () {
+          account = new Account(dataStore);
+        });
 
         it('should throw unhandled exception', function () {
           getGroupsWithoutHref.should
@@ -79,11 +87,15 @@ describe('Resources: ', function () {
 
     describe('get group membership', function () {
       describe('if group membership not set', function () {
-        var account = new Account(dataStore);
+        var account;
 
         function getGroupMembershipsWithoutHref() {
           account.getGroupMemberships();
         }
+
+        beforeEach(function () {
+          account = new Account(dataStore);
+        });
 
         it('should throw unhandled exception', function () {
           getGroupMembershipsWithoutHref.should
@@ -128,11 +140,15 @@ describe('Resources: ', function () {
 
     describe('add to group', function () {
       describe('if group href not set', function () {
-        var account = new Account(dataStore);
+        var account;
 
         function addToGroupWithoutGroupHref() {
           account.addToGroup();
         }
+
+        beforeEach(function () {
+          account = new Account(dataStore);
+        });
 
         it('should throw unhandled exception', function () {
           addToGroupWithoutGroupHref.should
@@ -142,10 +158,15 @@ describe('Resources: ', function () {
 
       describe('if group href is set', function () {
         var sandbox, account, createResourceStub, cbSpy, acc, opt;
-        var group = {href: 'boom1!'};
-        var groupHref = 'boom2!';
-        var createGroupMembershipHref = '/groupMemberships';
+        var group;
+        var groupHref;
+        var createGroupMembershipHref;
+
         before(function () {
+          group = {href: 'boom1!'};
+          groupHref = 'boom2!';
+          createGroupMembershipHref = '/groupMemberships';
+
           sandbox = sinon.sandbox.create();
           opt = {};
           acc = {href: 'acc_boom', groupMemberships: {href: 'boom!'}};
@@ -241,11 +262,15 @@ describe('Resources: ', function () {
 
       describe('get custom data', function () {
         describe('if custom data not set', function () {
-          var account = new Account(dataStore);
+          var account;
 
           function getCustomDataWithoutHref() {
             account.getCustomData();
           }
+
+          beforeEach(function () {
+            account = new Account(dataStore);
+          });
 
           it('should throw unhandled exception', function () {
             getCustomDataWithoutHref.should
@@ -347,26 +372,30 @@ describe('Resources: ', function () {
     });
 
     describe('createApiKey',function () {
-      var sandbox = sinon.sandbox.create();
-      var accountHref = 'accounts/'+uuid();
+      var sandbox;
+      var accountHref;
       var result, cacheResult, requestedOptions;
-
-      var creationResponse = {
-        "account": {
-          "href": "https://api.stormpath.com/v1/accounts/8897"
-        },
-        "href": "https://api.stormpath.com/v1/apiKeys/5678",
-        "id": "5678",
-        "secret": "NuUYYcIAjRYS+LiNBPhpu/p8iYP+jBltei1n1wxcMye3FTKRCTILpP/cD6Ynfvu6S4UokPM/SwuBaEn77aM3Ww==",
-        "status": "ENABLED",
-        "tenant": {
-          "href": "https://api.stormpath.com/v1/tenants/abc123"
-        }
-      };
-
-      var decryptedSecret = 'rncdUXr2dtjjQ5OyDdWRHRxncRW7K0OnU6/Wqf2iqdQ';
+      var creationResponse;
+      var decryptedSecret;
 
       before(function(done){
+        sandbox = sinon.sandbox.create();
+        accountHref = 'accounts/' + uuid();
+        decryptedSecret = 'rncdUXr2dtjjQ5OyDdWRHRxncRW7K0OnU6/Wqf2iqdQ';
+
+        creationResponse = {
+          'account': {
+            'href': 'https://api.stormpath.com/v1/accounts/8897'
+          },
+          'href': 'https://api.stormpath.com/v1/apiKeys/5678',
+          'id': '5678',
+          'secret': 'NuUYYcIAjRYS+LiNBPhpu/p8iYP+jBltei1n1wxcMye3FTKRCTILpP/cD6Ynfvu6S4UokPM/SwuBaEn77aM3Ww==',
+          'status': 'ENABLED',
+          'tenant': {
+            'href': 'https://api.stormpath.com/v1/tenants/abc123'
+          }
+        };
+
         sandbox.stub(dataStore.requestExecutor,'execute',function(requestOptions,cb) {
           requestedOptions = requestOptions;
           // hack - override the salt
@@ -411,11 +440,14 @@ describe('Resources: ', function () {
     });
 
     describe('getApiKeys',function () {
-      var sandbox = sinon.sandbox.create();
-      var accountHref = 'accounts/'+uuid();
+      var sandbox;
+      var accountHref;
       var result, requestedOptions;
 
       before(function(done){
+        sandbox = sinon.sandbox.create();
+        accountHref = 'accounts/' + uuid();
+
         sandbox.stub(dataStore.requestExecutor,'execute',function(requestOptions,cb) {
           requestedOptions = requestOptions;
 

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -25,35 +25,56 @@ var url = require('url');
 describe('Resources: ', function () {
   "use strict";
   describe('Application resource', function () {
+    var dataStore;
 
-    var dataStore = new DataStore({
-      client: {
-        apiKey: {
-          id: 1,
-          // this secret will decrypt the api keys correctly
-          secret: '6b2c3912-4779-49c1-81e7-23c204f43d2d'
+    beforeEach(function () {
+      dataStore = new DataStore({
+        client: {
+          apiKey: {
+            id: 1,
+            // this secret will decrypt the api keys correctly
+            secret: '6b2c3912-4779-49c1-81e7-23c204f43d2d'
+          }
         }
-      }
+      });
     });
+
     describe('authenticate account', function () {
-      var authRequest = {username: 'test'};
+      var authRequest;
+
+      beforeEach(function () {
+        authRequest = {username: 'test'};
+      });
 
       describe('createIdSiteUrl', function () {
-        var clientApiKeySecret = uuid();
-        var dataStore = new DataStore({client: {apiKey: {id: '1', secret: clientApiKeySecret}}});
-        var app = {
-          href:'http://api.stormpath.com/v1/applications/' + uuid()
-        };
-        var application = new Application(app, dataStore);
-        var clientState = uuid();
+        var clientApiKeySecret;
+        var dataStore;
+        var app;
+        var application;
+        var clientState;
+        var redirectUrl;
+        var params;
+        var path;
 
-        var redirectUrl = application.createIdSiteUrl({
-          callbackUri: 'https://stormpath.com',
-          state: clientState
+        beforeEach(function () {
+          clientApiKeySecret = uuid();
+          dataStore = new DataStore({client: {apiKey: {id: '1', secret: clientApiKeySecret}}});
+
+          app = {
+            href: 'http://api.stormpath.com/v1/applications/' + uuid()
+          };
+
+          application = new Application(app, dataStore);
+          clientState = uuid();
+
+          redirectUrl = application.createIdSiteUrl({
+            callbackUri: 'https://stormpath.com',
+            state: clientState
+          });
+
+          params = url.parse(redirectUrl,true).query;
+          path = url.parse(redirectUrl).pathname;
         });
-
-        var params = url.parse(redirectUrl,true).query;
-        var path = url.parse(redirectUrl).pathname;
 
         it('should create a request to /sso',function(){
           common.assert.equal(path,'/sso');
@@ -75,22 +96,35 @@ describe('Resources: ', function () {
 
 
       describe('createIdSiteUrl with logout option', function () {
-        var clientApiKeySecret = uuid();
-        var dataStore = new DataStore({client:{apiKey: {id: '1', secret: clientApiKeySecret}}});
-        var app = {
-          href:'http://api.stormpath.com/v1/applications/' + uuid()
-        };
-        var application = new Application(app, dataStore);
-        var clientState = uuid();
+        var clientApiKeySecret;
+        var dataStore;
+        var app;
+        var application;
+        var clientState;
+        var redirectUrl;
+        var params;
+        var path;
 
-        var redirectUrl = application.createIdSiteUrl({
-          callbackUri: 'https://stormpath.com',
-          state: clientState,
-          logout: true
+        beforeEach(function () {
+          clientApiKeySecret = uuid();
+          dataStore = new DataStore({client:{apiKey: {id: '1', secret: clientApiKeySecret}}});
+
+          app = {
+            href: 'http://api.stormpath.com/v1/applications/' + uuid()
+          };
+
+          application = new Application(app, dataStore);
+          clientState = uuid();
+
+          redirectUrl = application.createIdSiteUrl({
+            callbackUri: 'https://stormpath.com',
+            state: clientState,
+            logout: true
+          });
+
+          params = url.parse(redirectUrl,true).query;
+          path = url.parse(redirectUrl).pathname;
         });
-
-        var params = url.parse(redirectUrl,true).query;
-        var path = url.parse(redirectUrl).pathname;
 
         it('should create a request to /sso/logout',function(){
           common.assert.equal(path,'/sso/logout');
@@ -151,18 +185,26 @@ describe('Resources: ', function () {
 
       describe('handleIdSiteCallback',function(){
         describe('without a callbackUri',function(){
-          var test = new SsoResponseTest();
+          var test;
+
+          beforeEach(function () {
+            test = new SsoResponseTest();
+          });
+
           it('should throw the callbackUri required error',function(){
             common.assert.throws(test.before,errorMessages.ID_SITE_INVALID_CB_URI);
           });
         });
 
         describe('with out the responseUri argument',function(){
-          var test = new SsoResponseTest({
-            callbackUri: '/',
-            state: uuid()
-          });
+          var test;
+
           before(function(){
+            test = new SsoResponseTest({
+              callbackUri: '/',
+              state: uuid()
+            });
+
             test.before();
           });
           after(function(){
@@ -175,15 +217,22 @@ describe('Resources: ', function () {
 
 
         describe('with a valid jwt response',function(){
-          var accountHref = uuid();
-          var clientState = uuid();
-          var statusValue = uuid();
-          var test = new SsoResponseTest({
-            callbackUri: '/',
-            state: clientState
-          });
+          var accountHref;
+          var clientState;
+          var statusValue;
+          var test;
           var responseJwt;
+
           before(function(){
+            accountHref = uuid();
+            clientState = uuid();
+            statusValue = uuid();
+
+            test = new SsoResponseTest({
+              callbackUri: '/',
+              state: clientState
+            });
+
             test.before();
             responseJwt = {
               sub: accountHref,
@@ -229,12 +278,17 @@ describe('Resources: ', function () {
 
 
         describe('with an expired token',function(){
-          var accountHref = uuid();
+          var accountHref;
           var responseJwt;
-          var test = new SsoResponseTest({
-            callbackUri: '/'
-          });
+          var test;
+
           before(function(){
+            accountHref = uuid();
+
+            test = new SsoResponseTest({
+              callbackUri: '/'
+            });
+
             test.before();
             responseJwt = nJwt.create({
               sub: accountHref,
@@ -255,13 +309,17 @@ describe('Resources: ', function () {
         });
 
         describe('with a different client id (aud)',function(){
-          var accountHref = uuid();
-
+          var accountHref;
           var responseJwt;
-          var test = new SsoResponseTest({
-            callbackUri: '/'
-          });
+          var test;
+
           before(function(){
+            accountHref = uuid();
+
+            test = new SsoResponseTest({
+              callbackUri: '/'
+            });
+
             test.before();
             responseJwt = nJwt.create({
               sub: accountHref,
@@ -281,13 +339,17 @@ describe('Resources: ', function () {
         });
 
         describe('with an invalid exp value',function(){
-          var accountHref = uuid();
-
+          var accountHref;
           var responseJwt;
-          var test = new SsoResponseTest({
-            callbackUri: '/'
-          });
+          var test;
+
           before(function(){
+            accountHref = uuid();
+
+            test = new SsoResponseTest({
+              callbackUri: '/'
+            });
+
             test.before();
             responseJwt = nJwt.create({
               sub: accountHref,
@@ -308,11 +370,16 @@ describe('Resources: ', function () {
         });
 
         describe('with a replayed nonce',function(){
-          var accountHref = uuid();
-          var test = new SsoResponseTest({
-            callbackUri: '/'
-          });
+          var accountHref;
+          var test;
+
           before(function(){
+            accountHref = uuid();
+
+            test = new SsoResponseTest({
+              callbackUri: '/'
+            });
+
             test.before();
             var responseJwt = nJwt.create({
               sub: accountHref,
@@ -335,12 +402,17 @@ describe('Resources: ', function () {
         });
 
         describe('with an invalid signature',function(){
-          var clientState = uuid();
-          var test = new SsoResponseTest({
-            callbackUri: '/',
-            state: clientState
-          });
+          var clientState;
+          var test;
+
           before(function(){
+            clientState = uuid();
+
+            test = new SsoResponseTest({
+              callbackUri: '/',
+              state: clientState
+            });
+
             test.before();
             var responseJwt = nJwt.create({
               irt: test.givenNonce,
@@ -1119,9 +1191,12 @@ describe('Resources: ', function () {
 
     describe('resend verification email', function () {
       var app, createResourceStub;
-      var options = {login:uuid()};
-      var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+      var options;
+      var dataStore;
+
       before(function (done) {
+        options = {login: uuid()};
+        dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
 
         app = new Application(
           { href: uuid() , verificationEmails: {href:uuid()} },
@@ -1220,48 +1295,61 @@ describe('Resources: ', function () {
     //});
 
     describe('get apiKey',function(){
-      var appHref = 'https://api.stormpath.com/v1/applications/someapp';
-      var application = new Application({
-        href:appHref,
-        apiKeys: {
-          href: appHref + '/apiKeys'
-        }
-      }, dataStore);
+      var appHref;
+      var application;
+      var foundResponse;
+      var notFoundResponse;
+      var decryptedSecret;
+      var callCount;
 
-      var foundResponse = {
-        "offset" : 0,
-        "href" : "https://api.stormpath.com/v1/applications/1ux4vVy4SBeeLLfZtldtXj/apiKeys",
-        "limit" : 25,
-        "items" : [
-          {
-            "secret" : "NuUYYcIAjRYS+LiNBPhpu/p8iYP+jBltei1n1wxcMye3FTKRCTILpP/cD6Ynfvu6S4UokPM/SwuBaEn77aM3Ww==",
-            "status" : "ENABLED",
-            "account" : {
-              "href" : "https://api.stormpath.com/v1/accounts/Uu87kzssxEcnjmhC9uzwF"
-            },
-            "id" : "1S9H13Q61HLJHIVU7N357QI7U",
-            "tenant" : {
-              "href" : "https://api.stormpath.com/v1/tenants/eU0gloBbz42wGUtGXEjED"
-            },
-            "href" : "https://api.stormpath.com/v1/apiKeys/1S9H13Q61HLJHIVU7N357QI7U"
+      beforeEach(function () {
+        appHref = 'https://api.stormpath.com/v1/applications/someapp';
+
+        application = new Application({
+          href: appHref,
+          apiKeys: {
+            href: appHref + '/apiKeys'
           }
-        ]
-      };
+        }, dataStore);
 
-      var notFoundResponse = {
-        "offset" : 0,
-        "href" : "https://api.stormpath.com/v1/applications/1234/apiKeys",
-        "limit" : 25,
-        "items" : []
-      };
+        foundResponse = {
+          'offset': 0,
+          'href': 'https://api.stormpath.com/v1/applications/1ux4vVy4SBeeLLfZtldtXj/apiKeys',
+          'limit': 25,
+          'items': [
+            {
+              'secret': 'NuUYYcIAjRYS+LiNBPhpu/p8iYP+jBltei1n1wxcMye3FTKRCTILpP/cD6Ynfvu6S4UokPM/SwuBaEn77aM3Ww==',
+              'status': 'ENABLED',
+              'account': {
+                'href': 'https://api.stormpath.com/v1/accounts/Uu87kzssxEcnjmhC9uzwF'
+              },
+              'id': '1S9H13Q61HLJHIVU7N357QI7U',
+              'tenant': {
+                'href': 'https://api.stormpath.com/v1/tenants/eU0gloBbz42wGUtGXEjED'
+              },
+              'href': 'https://api.stormpath.com/v1/apiKeys/1S9H13Q61HLJHIVU7N357QI7U'
+            }
+          ]
+        };
 
-      var decryptedSecret = 'rncdUXr2dtjjQ5OyDdWRHRxncRW7K0OnU6/Wqf2iqdQ';
-      var callCount=0;
+        notFoundResponse = {
+          'offset': 0,
+          'href': 'https://api.stormpath.com/v1/applications/1234/apiKeys',
+          'limit': 25,
+          'items': []
+        };
+
+        decryptedSecret = 'rncdUXr2dtjjQ5OyDdWRHRxncRW7K0OnU6/Wqf2iqdQ';
+        callCount=0;
+      });
 
       describe('when apikey is found',function(){
-        var sandbox = sinon.sandbox.create();
+        var sandbox;
         var result, requestedOptions, cacheResult;
+
         before(function(done){
+          sandbox = sinon.sandbox.create();
+
           sandbox.stub(dataStore.requestExecutor,'execute',function(requestOptions,cb) {
             callCount++;
             // hack - override the salt
@@ -1302,8 +1390,11 @@ describe('Resources: ', function () {
       });
       describe('on second get',function(){
         var result;
-        var sandbox = sinon.sandbox.create();
+        var sandbox;
+
         before(function(done){
+          sandbox = sinon.sandbox.create();
+
           sandbox.stub(dataStore.requestExecutor,'execute',function(requestOptions,cb) {
             cb(null,_.extend({},foundResponse.items[0].account));
           });
@@ -1323,10 +1414,12 @@ describe('Resources: ', function () {
         });
       });
       describe('when apikey is not found',function(){
-        var sandbox = sinon.sandbox.create();
+        var sandbox;
         var result, requestedOptions;
 
         before(function(done){
+          sandbox = sinon.sandbox.create();
+
           sandbox.stub(dataStore.requestExecutor,'execute',function(requestOptions,cb) {
             requestedOptions = requestOptions;
             cb(null,notFoundResponse);

--- a/test/sp.resource.authenticationResult_test.js
+++ b/test/sp.resource.authenticationResult_test.js
@@ -11,7 +11,11 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   describe('Authentication Result resource', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
 
     describe('if ttl', function () {
       describe('isn\'t set', function () {
@@ -22,12 +26,16 @@ describe('Resources: ', function () {
       });
 
       describe('is set', function () {
-        var app = {account: {href: 'boom!'}, dataStore: dataStore};
+        var app;
+        var result;
 
-        var result = new AuthenticationResult(app, dataStore);
+        beforeEach(function () {
+          app = {account: {href: 'boom!'}, dataStore: dataStore};
+          result = new AuthenticationResult(app, dataStore);
 
-        result.application = app;
-        result.ttl = 9999;
+          result.application = app;
+          result.ttl = 9999;
+        });
 
         it('should return jwt with specified ttl', function () {
           timekeeper.freeze(0);

--- a/test/sp.resource.collectionResource_test.js
+++ b/test/sp.resource.collectionResource_test.js
@@ -19,7 +19,12 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   "use strict";
-  var apiKey = {id: 1, secret: 2};
+  var apiKey;
+
+  beforeEach(function () {
+    apiKey = {id: 1, secret: 2};
+  });
+
   describe('CollectionResource class', function () {
     describe('constructor: ', function () {
       /*data, dataStore, query, InstanceCtor*/
@@ -35,11 +40,15 @@ describe('Resources: ', function () {
 
       describe('if provided data don`t have items:', function () {
         var cr;
-        var data = {};
+        var data;
 
         function createCollectionResource() {
           cr = new CollectionResource(data);
         }
+
+        beforeEach(function () {
+          data = {};
+        });
 
         it('should not throw exception', function () {
           createCollectionResource.should.not.throw();
@@ -52,12 +61,17 @@ describe('Resources: ', function () {
 
       describe('if provided data has items:', function () {
         describe('if items is a raw json', function () {
-          var data = {items: [
-            {href: ''},
-            {href: ''}
-          ]};
+          var data;
           var cr;
+
           before(function () {
+            data = {
+              items: [
+                {href: ''},
+                {href: ''}
+              ]
+            };
+
             cr = new CollectionResource(data);
           });
 
@@ -69,13 +83,20 @@ describe('Resources: ', function () {
         });
 
         describe('if items already converted', function () {
-          var ds = new DataStore({client: {apiKey: apiKey}});
-          var data = {items: [
-            new Tenant({href: ''}, ds),
-            new Tenant({href: ''}, ds)
-          ]};
+          var ds;
+          var data;
           var cr;
+
           before(function () {
+            ds = new DataStore({client: {apiKey: apiKey}});
+
+            data = {
+              items: [
+                new Tenant({href: ''}, ds),
+                new Tenant({href: ''}, ds)
+              ]
+            };
+
             cr = new CollectionResource(data);
           });
 
@@ -99,8 +120,13 @@ describe('Resources: ', function () {
 
       describe('if query provided:', function () {
         var cr;
-        var data = {}, query = {};
+        var data;
+        var query;
+
         before(function () {
+          data = {};
+          query = {};
+
           cr = new CollectionResource(data, query);
         });
         it('query field should be undefined', function () {
@@ -168,15 +194,20 @@ describe('Resources: ', function () {
 
       describe('with items list', function () {
         var cr, sandbox, iteratorSpy, cbSpy, getResourceStub;
-        var ds = new DataStore({client: {apiKey: apiKey}});
-        var data = {
-          offset: 0,
-          items:[
-          new Tenant({href:''}, ds),
-          new Tenant({href:''}, ds)
-        ]};
+        var ds;
+        var data;
 
         before(function () {
+          ds = new DataStore({client: {apiKey: apiKey}});
+
+          data = {
+            offset: 0,
+            items: [
+              new Tenant({href: ''}, ds),
+              new Tenant({href: ''}, ds)
+            ]
+          };
+
           cr = new CollectionResource(data, null, Tenant, ds);
           sandbox = sinon.sandbox.create();
           iteratorSpy = sandbox.spy(iterator);
@@ -210,33 +241,43 @@ describe('Resources: ', function () {
       describe('when all items in current page are processed', function () {
         var sandbox;
         var cr, iteratorSpy, getResourceStub;
-        var ds = new DataStore({client: {apiKey: apiKey}});
-        var query = {q: 'boom!'};
-        var data = {
-          href: 'test_href',
-          query: query,
-          offset: 0,
-          limit: 2,
-          items:[
-            new Tenant({href:''}, ds),
-            new Tenant({href:''}, ds)
-          ]};
-
-        var nextQuery = {
-          q: query.q,
-          offset: 2,
-          limit: 100
-        };
-        var data2 = {
-          query: query,
-          offset: 2,
-          limit: 2,
-          items:[
-            new Tenant({href:''}, ds),
-            new Tenant({href:''}, ds)
-          ]};
+        var ds;
+        var query;
+        var data;
+        var nextQuery;
+        var data2;
 
         before(function (done) {
+          ds = new DataStore({client: {apiKey: apiKey}});
+          query = {q: 'boom!'};
+
+          data = {
+            href: 'test_href',
+            query: query,
+            offset: 0,
+            limit: 2,
+            items:[
+              new Tenant({href: ''}, ds),
+              new Tenant({href: ''}, ds)
+            ]
+          };
+
+          nextQuery = {
+            q: query.q,
+            offset: 2,
+            limit: 100
+          };
+
+          data2 = {
+            query: query,
+            offset: 2,
+            limit: 2,
+            items: [
+              new Tenant({href: ''}, ds),
+              new Tenant({href: ''}, ds)
+            ]
+          };
+
           sandbox = sinon.sandbox.create();
 
           getResourceStub = sandbox.stub(ds, 'getResource',
@@ -269,11 +310,16 @@ describe('Resources: ', function () {
     });
 
     describe('async methods with pagination', function(){
-      var ds = new DataStore({client: {apiKey: {id:1, secret: 2}}});
+      var ds;
+
+      beforeEach(function () {
+        ds = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+      });
 
       function test(method){
         return function(){
-          var n = 250;
+          var n;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -299,10 +345,13 @@ describe('Resources: ', function () {
             return items;
           }
 
-          var i, items, pages = [], applications;
+          var i, items, pages, applications;
           var sandbox, iteratorSpy, callbackSpy, asyncIteratorSpy, asyncCallbackSpy;
 
           before(function(done){
+            n = 250;
+            pages = [];
+
             // set up:
             // 1. items
             items = createNApps(n);
@@ -368,7 +417,8 @@ describe('Resources: ', function () {
 
       function testLimit(method){
         return function(){
-          var n = 250;
+          var n;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -394,10 +444,13 @@ describe('Resources: ', function () {
             return items;
           }
 
-          var i, items, pages = [], applications;
+          var i, items, pages, applications;
           var sandbox, iteratorSpy, callbackSpy, asyncIteratorSpy, asyncCallbackSpy;
 
           before(function(done){
+            n = 250;
+            pages = [];
+
             // set up:
             // 1. items
             items = createNApps(n);
@@ -463,8 +516,8 @@ describe('Resources: ', function () {
 
       function testBoolean(method, shouldBeCalledCount){
         return function(){
-          var n = 250;
-          shouldBeCalledCount = shouldBeCalledCount || n;
+          var n;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -490,10 +543,14 @@ describe('Resources: ', function () {
             return items;
           }
 
-          var i, items, pages = [], applications;
+          var i, items, pages, applications;
           var sandbox, iteratorSpy, callbackSpy, asyncIteratorSpy, asyncCallbackSpy;
 
           before(function(done){
+            n = 250;
+            shouldBeCalledCount = shouldBeCalledCount || n;
+            pages = [];
+
             // set up:
             // 1. items
             items = createNApps(n);
@@ -566,7 +623,8 @@ describe('Resources: ', function () {
 
       function testCheck(method){
         return function(){
-          var n = 250;
+          var n;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -592,10 +650,13 @@ describe('Resources: ', function () {
             return items;
           }
 
-          var i, items, pages = [], applications;
+          var i, items, pages, applications;
           var sandbox, iteratorSpy, callbackSpy, asyncIteratorSpy, asyncCallbackSpy;
 
           before(function(done){
+            n = 250;
+            pages = [];
+
             // set up:
             // 1. items
             items = createNApps(n);
@@ -667,7 +728,8 @@ describe('Resources: ', function () {
 
       function testSortBy(method){
         return function(){
-          var n = 250;
+          var n;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -693,10 +755,13 @@ describe('Resources: ', function () {
             return items;
           }
 
-          var i, items, pages = [], applications;
+          var i, items, pages, applications;
           var sandbox, iteratorSpy, callbackSpy, asyncIteratorSpy, asyncCallbackSpy;
 
           before(function(done){
+            n = 250;
+            pages = [];
+
             // set up:
             // 1. items
             items = createNApps(n);
@@ -768,7 +833,8 @@ describe('Resources: ', function () {
 
       function testReduce(method){
         return function(){
-          var n = 250;
+          var n;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -794,10 +860,13 @@ describe('Resources: ', function () {
             return items;
           }
 
-          var i, items, pages = [], applications;
+          var i, items, pages, applications;
           var sandbox, iteratorSpy, callbackSpy, asyncIteratorSpy, asyncCallbackSpy;
 
           before(function(done){
+            n = 250;
+            pages = [];
+
             // set up:
             // 1. items
             items = createNApps(n);

--- a/test/sp.resource.customData_test.js
+++ b/test/sp.resource.customData_test.js
@@ -66,22 +66,29 @@ describe('Resources: ', function () {
 
     describe('when fetched via resource.getCustomData',function(){
       var resource;
-      var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
-      var sandbox = sinon.sandbox.create();
-      var cacheSpy = sinon.spy(dataStore.cacheHandler.cacheManager.caches.customData,'put');
-      var parentHref = 'http://api.stormpath.com/v1/accounts/' + common.uuid();
-        resource = instantiate(Account,{
+      var dataStore;
+      var sandbox;
+      var cacheSpy;
+      var parentHref;
+      var customDataObject;
+
+      before(function(done){
+        dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+        sandbox = sinon.sandbox.create();
+        cacheSpy = sinon.spy(dataStore.cacheHandler.cacheManager.caches.customData, 'put');
+        parentHref = 'http://api.stormpath.com/v1/accounts/' + common.uuid();
+
+        resource = instantiate(Account, {
           href: parentHref,
           customData: {
             href: parentHref + '/customData'
           }
         }, null, dataStore);
-      var customDataObject = {
-        href: resource.customData.href,
-        hello: 'world'
-      };
 
-      before(function(done){
+        customDataObject = {
+          href: resource.customData.href,
+          hello: 'world'
+        };
 
         sandbox.stub(dataStore.requestExecutor, 'execute', function (request) {
           // callback with a mock custom data resource
@@ -114,8 +121,11 @@ describe('Resources: ', function () {
 
       });
       describe('and reserved properties are added',function(){
-        var reserverdFieldName = 'createdAt';
+        var reserverdFieldName;
+
         before(function(){
+          reserverdFieldName = 'createdAt';
+
           resource.customData[reserverdFieldName] = common.uuid();
         });
         describe('and save is called on the parent resource',function(){
@@ -129,9 +139,13 @@ describe('Resources: ', function () {
         });
       });
       describe('and non-reserved properties are added',function(){
-        var customFieldName = 'myCustomProperty';
-        var customFieldValue = common.uuid();
+        var customFieldName;
+        var customFieldValue;
+
         before(function(){
+          customFieldName = 'myCustomProperty';
+          customFieldValue = common.uuid();
+
           resource.customData[customFieldName] = customFieldValue;
         });
         describe('and save is called on the parent resource',function(){

--- a/test/sp.resource.directoryChildResource_test.js
+++ b/test/sp.resource.directoryChildResource_test.js
@@ -8,7 +8,11 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   describe('Directory Child resource', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
 
     describe('get directory', function () {
       describe('if directory href not set', function () {

--- a/test/sp.resource.directory_test.js
+++ b/test/sp.resource.directory_test.js
@@ -16,7 +16,11 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   describe('Directory resource', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
 
     describe('get accounts', function () {
       describe('if accounts not set', function () {
@@ -335,15 +339,20 @@ describe('Resources: ', function () {
 
     describe('get organizations', function () {
       describe('if organizations href are set', function () {
-        var opt = {};
-
+        var opt;
         var getResourceStub;
-        var sandbox = sinon.sandbox.create();
-        var app = { organizationMappings: { href: 'boom!' } };
-        var directory = new Directory(app, dataStore);
-        var cbSpy = sandbox.spy();
+        var sandbox;
+        var app;
+        var directory;
+        var cbSpy;
 
         before(function () {
+          opt = {};
+          sandbox = sinon.sandbox.create();
+          app = { organizationMappings: { href: 'boom!' } };
+          directory = new Directory(app, dataStore);
+          cbSpy = sandbox.spy();
+
           getResourceStub = sandbox.stub(dataStore, 'getResource', function (href, options, ctor, cb) {
             cb();
           });
@@ -373,15 +382,20 @@ describe('Resources: ', function () {
 
     describe('get organization mappings', function () {
       describe('if organizationMappings href are set', function () {
-        var opt = {};
-
+        var opt;
         var getResourceStub;
-        var sandbox = sinon.sandbox.create();
-        var app = { organizationMappings: { href: 'boom!' } };
-        var directory = new Directory(app, dataStore);
-        var cbSpy = sandbox.spy();
+        var sandbox;
+        var app;
+        var directory;
+        var cbSpy;
 
         before(function () {
+          opt = {};
+          sandbox = sinon.sandbox.create();
+          app = { organizationMappings: { href: 'boom!' } };
+          directory = new Directory(app, dataStore);
+          cbSpy = sandbox.spy();
+
           getResourceStub = sandbox.stub(dataStore, 'getResource', function (href, options, ctor, cb) {
             cb();
           });

--- a/test/sp.resource.groupMembership_test.js
+++ b/test/sp.resource.groupMembership_test.js
@@ -8,7 +8,11 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   describe('Group Membership resource', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
 
     describe('get account', function () {
       describe('if group membership href not set', function () {

--- a/test/sp.resource.group_test.js
+++ b/test/sp.resource.group_test.js
@@ -12,15 +12,23 @@ var GroupMembership = require('../lib/resource/GroupMembership');
 describe('Resources: ', function () {
   "use strict";
   describe('Group resource', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
 
     describe('add account', function () {
       describe('if group href not set', function () {
-        var group = new Group(dataStore);
+        var group;
 
         function addAccountWithoutGroupHref() {
           group.addAccount();
         }
+
+        beforeEach(function () {
+          group = new Group(dataStore);
+        });
 
         it('should throw unhandled exception', function () {
           addAccountWithoutGroupHref.should
@@ -30,10 +38,15 @@ describe('Resources: ', function () {
 
       describe('if group href is set', function () {
         var sandbox, group, createResourceStub, cbSpy, grp, opt;
-        var account = {href: 'boom1!'};
-        var accountHref = 'boom2!';
-        var createGroupMembershipHref = '/groupMemberships';
+        var account;
+        var accountHref;
+        var createGroupMembershipHref;
+
         before(function () {
+          account = {href: 'boom1!'};
+          accountHref = 'boom2!';
+          createGroupMembershipHref = '/groupMemberships';
+
           sandbox = sinon.sandbox.create();
           opt = {};
           grp = {href: 'acc_boom', groupMemberships: {href: 'boom!'}};
@@ -160,11 +173,15 @@ describe('Resources: ', function () {
 
     describe('get account membership', function () {
       describe('if account membership not set', function () {
-        var group = new Group(dataStore);
+        var group;
 
         function getAccountMembershipsWithoutHref() {
           group.getAccountMemberships();
         }
+
+        beforeEach(function () {
+          group = new Group(dataStore);
+        });
 
         it('should throw unhandled exception', function () {
           getAccountMembershipsWithoutHref.should
@@ -232,11 +249,15 @@ describe('Resources: ', function () {
 
       describe('get custom data', function () {
         describe('if custom data not set', function () {
-          var account = new Account(dataStore);
+          var account;
 
           function getCustomDataWithoutHref() {
             account.getCustomData();
           }
+
+          beforeEach(function () {
+            account = new Account(dataStore);
+          });
 
           it('should throw unhandled exception', function () {
             getCustomDataWithoutHref.should

--- a/test/sp.resource.instanceResource_test.js
+++ b/test/sp.resource.instanceResource_test.js
@@ -9,13 +9,19 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   describe('InstanceResource class', function(){
+    var ds;
+    var app;
+    var instanceResource;
 
-    var ds = new DataStore({client: {apiKey:{id:1,secret:2}}});
-    var app = {href: '/href'};
-    var instanceResource = new InstanceResource({
-      applications: app,
-      directory: {}
-    }, ds);
+    beforeEach(function () {
+      ds = new DataStore({client: {apiKey:{id: 1,secret: 2}}});
+      app = {href: '/href'};
+
+      instanceResource = new InstanceResource({
+        applications: app,
+        directory: {}
+      }, ds);
+    });
 
     describe('call to get resource', function(){
       describe('without property name', function(){
@@ -111,9 +117,11 @@ describe('Resources: ', function () {
       });
 
       describe('with optional query param', function(){
-        var query = {q:'asd'};
+        var query;
         var sandbox, error, cb, getResourceSpy;
+
         before(function(){
+          query = {q: 'asd'};
           cb = function(err){error = err;};
           sandbox = sinon.sandbox.create();
           getResourceSpy = sandbox.spy(ds, 'getResource');

--- a/test/sp.resource.resourceFactory_test.js
+++ b/test/sp.resource.resourceFactory_test.js
@@ -19,12 +19,16 @@ describe('Resources: ', function () {
     });
 
     describe('if data is a collection resource', function(){
-      var data = {
-        href:'',
-        items:[{href:''},{href:''}],
-        offset: 0,
-        limit: 5
-      };
+      var data;
+
+      beforeEach(function () {
+        data = {
+          href: '',
+          items: [{href: ''}, {href: ''}],
+          offset: 0,
+          limit: 5
+        };
+      });
 
       it('should return collection', function(){
         var coll = instantiate(Tenant, data);
@@ -37,7 +41,12 @@ describe('Resources: ', function () {
     });
 
     describe('if data is a resource', function(){
-      var data = {href: ''};
+      var data;
+
+      beforeEach(function () {
+        data = {href: ''};
+      });
+
       it('should return wrapped obj', function(){
         var coll = instantiate(Tenant, data);
 

--- a/test/sp.resource.resource_test.js
+++ b/test/sp.resource.resource_test.js
@@ -8,11 +8,18 @@ var DataStore = require('../lib/ds/DataStore');
 describe('Resources: ', function () {
   describe('Resource base class', function () {
     describe('constructor', function () {
-      var apiKey = {id:'id', secret:'secret'};
+      var apiKey;
+
+      beforeEach(function () {
+        apiKey = {id: 'id', secret: 'secret'};
+      });
+
       describe('if called with 2 params', function () {
         var resource, ds;
-        var obj = {data: 'boom!', data2: 'boom2!'};
+        var obj;
+
         before(function () {
+          obj = {data: 'boom!', data2: 'boom2!'};
           ds = new DataStore({client: {apiKey:apiKey}});
           resource = new Resource(obj, ds);
         });
@@ -30,8 +37,10 @@ describe('Resources: ', function () {
 
       describe('if called only with data param', function () {
         var resource;
-        var obj = {data: 'boom!', data2: 'boom2!'};
+        var obj;
+
         before(function () {
+          obj = {data: 'boom!', data2: 'boom2!'};
           resource = new Resource(obj);
         });
 
@@ -47,8 +56,10 @@ describe('Resources: ', function () {
 
       describe('if called only with data store param', function () {
         var resource, ds;
-        var hack = 'boom!';
+        var hack;
+
         before(function () {
+          hack = 'boom!';
           ds = new DataStore({client: {apiKey:apiKey}});
           ds.hack = hack;
 

--- a/test/sp.resource.tenant_test.js
+++ b/test/sp.resource.tenant_test.js
@@ -11,7 +11,12 @@ var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
   describe('Tenant resource class', function () {
-    var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    var dataStore;
+
+    beforeEach(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
+
     describe('get applications', function () {
       describe('if application not set', function () {
         //var tenant = new Tenant();
@@ -62,8 +67,10 @@ describe('Resources: ', function () {
 
     describe('create application', function () {
       var sandbox, tenant, createResourceStub, cbSpy, app, opt;
-      var createAppPath = '/applications';
+      var createAppPath;
+
       before(function () {
+        createAppPath = '/applications';
         sandbox = sinon.sandbox.create();
         app = {href: ''};
         opt = {};
@@ -146,8 +153,10 @@ describe('Resources: ', function () {
 
     describe('create directory', function () {
       var sandbox, tenant, createResourceStub, cbSpy, app, opt;
-      var createDirPath = '/directories';
+      var createDirPath;
+
       before(function () {
+        createDirPath = '/directories';
         sandbox = sinon.sandbox.create();
         app = {href: ''};
         opt = {};
@@ -183,11 +192,14 @@ describe('Resources: ', function () {
     describe('verify account email', function () {
       describe('with a successful token response',function(){
         var sandbox, tenant, tenantResult,cacheResult;
-        var accountResponse = {
-          href: '/v1/accounts/'+uuid(),
-          status: 'ENABLED'
-        };
+        var accountResponse;
+
         before(function (done) {
+          accountResponse = {
+            href: '/v1/accounts/' + uuid(),
+            status: 'ENABLED'
+          };
+
           sandbox = sinon.sandbox.create();
           tenant = new Tenant({href:'an href'}, dataStore);
 

--- a/test/sp.utils_test.js
+++ b/test/sp.utils_test.js
@@ -33,8 +33,13 @@ describe('util', function () {
   });
 
   describe('valueOf method', function(){
-    var obj = {test: 'me'};
-    var def = {all: 'ok'};
+    var obj;
+    var def;
+
+    beforeEach(function () {
+      obj = {test: 'me'};
+      def = {all: 'ok'};
+    });
 
     it('should return obj if obj not empty and default value not set', function(){
       var test = utils.valueOf(obj);
@@ -56,15 +61,24 @@ describe('util', function () {
   });
 
   describe('shallow copy', function(){
-    function Class(){}
-    Class.prototype.field = 'boom!';
-    var objToCopy = new Class();
-    objToCopy.prop = 'here I am';
-    var dest = new Class();
-    dest.prop = 'will be overridden';
-    dest.prop2 = 'should be in object';
+    var objToCopy;
+    var dest;
+    var result;
 
-    var result = utils.shallowCopy(objToCopy, dest);
+    function Class() {}
+
+    beforeEach(function () {
+      Class.prototype.field = 'boom!';
+
+      objToCopy = new Class();
+      objToCopy.prop = 'here I am';
+
+      dest = new Class();
+      dest.prop = 'will be overridden';
+      dest.prop2 = 'should be in object';
+
+      result = utils.shallowCopy(objToCopy, dest);
+    });
 
     it('should copy own fields', function(){
       dest.should.have.keys(['prop', 'prop2']);
@@ -109,8 +123,15 @@ describe('util', function () {
   });
 
   describe('base64', function(){
-    var test = 'boom!';
-    utils.base64.decode(utils.base64.encode(test)).should.be.equal(test);
+    var test;
+
+    beforeEach(function () {
+      test = 'boom!';
+    });
+
+    it('should be able to encode and decode without altering the data', function () {
+      utils.base64.decode(utils.base64.encode(test)).should.be.equal(test);
+    });
   });
 
   describe('isNumber', function(){


### PR DESCRIPTION
Fixes #334.

In many of the tests, there are assignments inside the `describe` blocks, which is not very good if they're used in deeper `describe` blocks. For example, in `sp.resource.group_test.js`:

```javascript
describe('Group resource', function () {
  var dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});

  describe('add account', function () {
    describe('if group href not set', function () {
      var group = new Group(dataStore);
      ...
    });
    ...
  });
  ...
});
```

Instead, the assignments should be done in `before`/`beforeEach` blocks while the declarations should be in the `describe` blocks:

```javascript
describe('Group resource', function () {
  var dataStore;

  beforeEach(function () {
    dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
  });

  describe('add account', function () {
    describe('if group href not set', function () {
      var group;

      beforeEach(function () {
        group = new Group(dataStore);
      });
      ...
    });
    ...
  });
  ...
});
```

You can read more about it here: [Variable in outer describe block is undefined when accessing in inner describe block with Mocha test](http://stackoverflow.com/questions/21470349/variable-in-outer-describe-block-is-undefined-when-accessing-in-inner-describe-b)

@typerandom, can you review and verify, please?