### PR TITLE
Fixing bad tests

### DIFF
--- a/lib/error/ApiAuthRequestError.js
+++ b/lib/error/ApiAuthRequestError.js
@@ -3,9 +3,9 @@
 var utils  = require('../utils');
 
 function ApiAuthRequestError(errorData){
-  Error.call(this);
   Error.captureStackTrace(this, this.constructor);
-  this.name='ApiAuthRequestError';
+
+  this.name = this.constructor.name;
   this.userMessage = this.message = errorData.userMessage;
   this.statusCode = errorData.statusCode || 400;
   this.error = errorData.error;

--- a/lib/error/ResourceError.js
+++ b/lib/error/ResourceError.js
@@ -3,7 +3,9 @@
 var utils = require('./../utils');
 
 function ResourceError(responseBody) {
-  this.name = 'ResourceError';
+  Error.captureStackTrace(this, this.constructor);
+
+  this.name = this.constructor.name;
   this.status = responseBody.status;
   this.code = responseBody.code;
   this.userMessage = responseBody.message;

--- a/lib/resource/CollectionResource.js
+++ b/lib/resource/CollectionResource.js
@@ -182,8 +182,12 @@ utils.inherits(CollectionResource, Resource);
 
   function Every(){
     var res = true;
+    var that = this;
+    this.isDone = false;
+
     this.wrapPageCallback = function wrapPageCallback(cb){
       return function funcCallback(result){
+        that.isDone = !result;
         res = res && result;
         cb(result);
       };

--- a/lib/resource/CollectionResource.js
+++ b/lib/resource/CollectionResource.js
@@ -56,7 +56,7 @@ function wrapAsyncCallToAllPages(coll, func, args, callbackWrapper){
           .concat(
             [task.collection.items],
             !!callbackWrapper.wrapPageArgs ? callbackWrapper.wrapPageArgs(args) : args,
-            callbackWrapper.wrapPageCallback(parallel_cb));
+            callbackWrapper.wrapPageCallback(parallel_cb.bind(this, null)));
         func.apply(this, callArgs);
       },
       function(parallel_cb){

--- a/test/common.js
+++ b/test/common.js
@@ -18,7 +18,7 @@ var Stormpath = require('../lib');
 chai.use(sinonChai);
 
 function u(){}
-u.BASE_URL = 'https://api.stormpath.com/v1';
+u.BASE_URL = 'https://api.stormpath.com';
 /** adds '/v1' to relative URL, to work with nock request mocker  */
 u.v1 = function(s){return '/v1' + s;};
 

--- a/test/it/helpers.js
+++ b/test/it/helpers.js
@@ -50,8 +50,8 @@ function fakeAccount(){
  * @returns string - The name of the calling file.
  */
 function getFriendlyCallerName() {
+  var friendlyName = 'unknown';
   var err = new Error();
-
   var originalPrepareStackTrace = Error.prepareStackTrace;
 
   Error.prepareStackTrace = function (err, stack) {
@@ -65,7 +65,8 @@ function getFriendlyCallerName() {
       var callerfile = err.stack.shift().getFileName();
 
       if(currentfile !== callerfile) {
-        return path.basename(callerfile).replace('.js', '');
+        friendlyName = path.basename(callerfile).replace('.js', '');
+        break;
       }
     }
   } catch (err) {
@@ -73,7 +74,7 @@ function getFriendlyCallerName() {
 
   Error.prepareStackTrace = originalPrepareStackTrace;
 
-  return 'unknown';
+  return friendlyName;
 }
 
 /**

--- a/test/it/oauth_id_site_token_grant_it.js
+++ b/test/it/oauth_id_site_token_grant_it.js
@@ -31,9 +31,4 @@ describe('OAuthIdSiteTokenGrantAuthenticator',function(){
     var authenticator = new stormpath.OAuthIdSiteTokenGrantAuthenticator(application);
     assert.instanceOf(authenticator, stormpath.OAuthIdSiteTokenGrantAuthenticator);
   });
-
-  it.skip('should create access tokens',function(){
-    // This will require a rountrip test with ID site
-    // Our express-stormpath module has some test code for this
-  });
 });

--- a/test/it/tenant_it.js
+++ b/test/it/tenant_it.js
@@ -9,7 +9,7 @@ var Tenant = require('../../lib/resource/Tenant');
 describe('Tenant', function() {
   var client, tenant;
 
-  this.timeout(20000);
+  this.timeout(120000);
 
   before(function(done) {
     helpers.getClient(function(_client) {

--- a/test/it/tenant_it.js
+++ b/test/it/tenant_it.js
@@ -9,7 +9,7 @@ var Tenant = require('../../lib/resource/Tenant');
 describe('Tenant', function() {
   var client, tenant;
 
-  this.timeout(120000);
+  this.timeout(60 * 2 * 1000);
 
   before(function(done) {
     helpers.getClient(function(_client) {

--- a/test/it/tenant_it.js
+++ b/test/it/tenant_it.js
@@ -9,7 +9,7 @@ var Tenant = require('../../lib/resource/Tenant');
 describe('Tenant', function() {
   var client, tenant;
 
-  this.timeout(10000);
+  this.timeout(20000);
 
   before(function(done) {
     helpers.getClient(function(_client) {

--- a/test/it/tenant_it.js
+++ b/test/it/tenant_it.js
@@ -9,6 +9,8 @@ var Tenant = require('../../lib/resource/Tenant');
 describe('Tenant', function() {
   var client, tenant;
 
+  this.timeout(10000);
+
   before(function(done) {
     helpers.getClient(function(_client) {
       client = _client;

--- a/test/sp.auth.unit_test.js
+++ b/test/sp.auth.unit_test.js
@@ -15,7 +15,7 @@ describe('Authorization module', function () {
     getAuthenticator = require('../lib/authc').getAuthenticator;
   });
 
-  beforeEach(function () {
+  before(function () {
     apiKey = {id: 'stormpath_apiKey_id', secret: 'stormpath_apiKey_secret'};
   });
 
@@ -56,7 +56,7 @@ describe('Authorization module', function () {
   describe('Basic auth', function () {
     var auth;
 
-    beforeEach(function () {
+    before(function () {
       auth = getAuthenticator({apiKey: apiKey, authenticationScheme: 'basic'});
     });
 

--- a/test/sp.authc.apiKey_test.js
+++ b/test/sp.authc.apiKey_test.js
@@ -9,7 +9,7 @@ describe('authc', function () {
     var secret;
     var apiKey;
 
-    beforeEach(function () {
+    before(function () {
       id = 'id';
       secret = 'boom!';
       apiKey = new ApiKey(id, secret);

--- a/test/sp.cache.cacheHandler_test.js
+++ b/test/sp.cache.cacheHandler_test.js
@@ -33,7 +33,7 @@ describe('CacheHandler',function(){
       var cacheOptions;
       var handler;
 
-      beforeEach(function () {
+      before(function () {
         MockStore = function (opts) {
           this._options = opts;
         };

--- a/test/sp.cache.cache_test.js
+++ b/test/sp.cache.cache_test.js
@@ -297,10 +297,11 @@ describe('Cache module', function () {
   });
 
   describe('Redis store', function(){
-    var opt, sandbox;
+    var opt = {};
+    var sandbox;
 
     before(function(){
-      opt = {cache: null};
+      opt.cache = null;
       sandbox = sinon.sandbox.create();
       var ms = new MemoryStore();
       _.extend(ms,{
@@ -325,10 +326,11 @@ describe('Cache module', function () {
   });
 
   describe('Memcached store', function(){
-    var opt, sandbox;
+    var opt = {};
+    var sandbox;
 
     before(function(){
-      opt = {cache: null};
+      opt.cache = null;
       sandbox = sinon.sandbox.create();
       var ms = new MemoryStore();
       ms._set = ms.set;

--- a/test/sp.cache.entry_test.js
+++ b/test/sp.cache.entry_test.js
@@ -44,7 +44,7 @@ describe('Cache module',function(){
       var lastAccessedAt;
       var cacheEntry;
 
-      beforeEach(function () {
+      before(function () {
         entry = {};
         createdAt = new Date();
         lastAccessedAt = new Date();
@@ -81,7 +81,7 @@ describe('Cache module',function(){
     describe('call to touch method', function(){
       var cacheEntry;
 
-      beforeEach(function () {
+      before(function () {
         cacheEntry = createVoidCacheEntry();
       });
 
@@ -98,7 +98,7 @@ describe('Cache module',function(){
       describe('if entry is fresh', function(){
         var cacheEntry;
 
-        beforeEach(function () {
+        before(function () {
           cacheEntry = createVoidCacheEntry();
         });
 
@@ -112,7 +112,7 @@ describe('Cache module',function(){
       describe('if entry is idle for to long', function(){
         var cacheEntry;
 
-        beforeEach(function () {
+        before(function () {
           cacheEntry = createVoidCacheEntry();
           cacheEntry.lastAccessedAt -= 500 * 1000;
         });
@@ -127,7 +127,7 @@ describe('Cache module',function(){
       describe('if entry is created a long time ago', function(){
         var cacheEntry;
 
-        beforeEach(function () {
+        before(function () {
           cacheEntry = createVoidCacheEntry();
           cacheEntry.createdAt -= 500 * 1000;
         });
@@ -146,7 +146,7 @@ describe('Cache module',function(){
       var expectLastAccessedAt;
       var object;
 
-      beforeEach(function () {
+      before(function () {
         cacheEntry = createVoidCacheEntry();
         expectCreatedAt = moment.utc(cacheEntry.createdAt).format('YYYY-MM-DD HH:mm:ss.SSS');
         expectLastAccessedAt = moment.utc(cacheEntry.lastAccessedAt).format('YYYY-MM-DD HH:mm:ss.SSS');
@@ -165,7 +165,7 @@ describe('Cache module',function(){
       var expectLastAccessedAt;
       var parsedCacheEntry;
 
-      beforeEach(function () {
+      before(function () {
         cacheEntry = createVoidCacheEntry();
         expectCreatedAt = moment.utc(cacheEntry.createdAt).format('YYYY-MM-DD HH:mm:ss.SSS');
         expectLastAccessedAt = moment.utc(cacheEntry.lastAccessedAt).format('YYYY-MM-DD HH:mm:ss.SSS');

--- a/test/sp.cache.entry_test.js
+++ b/test/sp.cache.entry_test.js
@@ -85,12 +85,14 @@ describe('Cache module',function(){
         cacheEntry = createVoidCacheEntry();
       });
 
-      it('should change lastAccessedTime to current for cache entry', function(){
+      it('should change lastAccessedTime to current for cache entry', function(done){
         var was = cacheEntry.lastAccessedAt;
 
-        cacheEntry.touch();
-
-        cacheEntry.lastAccessedAt.should.be.gt(was);
+        setTimeout(function () {
+          cacheEntry.touch();
+          cacheEntry.lastAccessedAt.should.be.gt(was);
+          done();
+        }, 20);
       });
     });
 

--- a/test/sp.cache.manager_test.js
+++ b/test/sp.cache.manager_test.js
@@ -10,7 +10,7 @@ describe('Cache module',function(){
     describe('By default', function(){
       var manager;
 
-      beforeEach(function () {
+      before(function () {
         manager = new CacheManager();
       });
 

--- a/test/sp.cache.memoryStore_test.js
+++ b/test/sp.cache.memoryStore_test.js
@@ -8,7 +8,7 @@ describe('Cache module', function () {
   describe('In memory cache store', function () {
     var memoryStore;
 
-    beforeEach(function () {
+    before(function () {
       memoryStore = new MemoryStore();
     });
 

--- a/test/sp.cache.stats_test.js
+++ b/test/sp.cache.stats_test.js
@@ -6,7 +6,7 @@ describe('Cache module',function(){
   describe('Cache Stats class', function(){
     var stats;
 
-    beforeEach(function () {
+    before(function () {
       stats = new CacheStats();
     });
 

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -35,7 +35,7 @@ function clearEnvVars(){
 describe('Client', function () {
   var apiKey;
 
-  beforeEach(function () {
+  before(function () {
     apiKey = {id: 1, secret: 2};
   });
 

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var uuid = require('uuid');
 var yaml = require('js-yaml');
 var expandHomeDir = require('expand-home-dir');
 
@@ -111,8 +110,8 @@ describe('Configuration loader', function () {
     afterIt.push(restoreEnv);
 
     var dummyApiKey = {
-      id: uuid(),
-      secret: uuid()
+      id: '2d61b041-5c03-4c17-9e67-7e3c58f38f10',
+      secret: 'ed1e3c35-f01e-4f23-9bc6-bafa1baa0346'
     };
 
     loader = configLoader({
@@ -178,10 +177,10 @@ describe('Configuration loader', function () {
 
     afterIt.push(removeStormpathEnv());
 
-    process.env.STORMPATH_CLIENT_APIKEY_ID = uuid();
-    process.env.STORMPATH_CLIENT_APIKEY_SECRET = uuid();
-    process.env.STORMPATH_APPLICATION_HREF = 'http://api.stormpath.com/v1/applications/' + uuid();
-    process.env.STORMPATH_APPLICATION_NAME = uuid();
+    process.env.STORMPATH_CLIENT_APIKEY_ID = '0f6f34ce-6718-4e1b-afdd-ec5ea6d48373';
+    process.env.STORMPATH_CLIENT_APIKEY_SECRET = 'c40948e7-f07b-4b19-95bc-b9c545f8b7ff';
+    process.env.STORMPATH_APPLICATION_HREF = 'http://api.stormpath.com/v1/applications/12ae87cc-66bf-4d8c-bde9-f516a752e4b4';
+    process.env.STORMPATH_APPLICATION_NAME = 'c13a6743-48ee-4bc5-b82e-d26d31a7130f';
 
     loader.load(function (err, config) {
       assert.isFalse(!!err);
@@ -205,8 +204,8 @@ describe('Configuration loader', function () {
 
     afterIt.push(removeStormpathEnv());
 
-    process.env.STORMPATH_API_KEY_ID = uuid();
-    process.env.STORMPATH_API_KEY_SECRET = uuid();
+    process.env.STORMPATH_API_KEY_ID = '85a1b6c7-1411-44a1-83c0-e66c638d683c';
+    process.env.STORMPATH_API_KEY_SECRET = '2b35a567-bc7c-43e3-9007-3742e1fffef5';
 
     loader.load(function (err, config) {
       assert.isFalse(!!err);
@@ -232,8 +231,8 @@ describe('Configuration loader', function () {
 
     var customConfig = {
       apiKey: {
-        id: uuid(),
-        secret: uuid()
+        id: 'ea585cca-fbb4-475f-9c3f-10e9ba4eea91',
+        secret: 'a71fbecf-7b5f-4660-a32f-3352a263a8c0'
       }
     };
 
@@ -264,8 +263,8 @@ describe('Configuration loader', function () {
         var homeConfig = {
           client: {
             apiKey: {
-              id: uuid(),
-              secret: uuid()
+              id: 'ed143b1b-ad8a-412e-8d1b-ea81c61be9d2',
+              secret: '4607cb74-5141-40ee-8b07-9d395af6260b'
             }
           }
         };
@@ -295,8 +294,8 @@ describe('Configuration loader', function () {
         var homeConfig = {
           client: {
             apiKey: {
-              id: uuid(),
-              secret: uuid()
+              id: '3dc18568-8b2d-4cff-bca3-786636321495',
+              secret: '8b795484-81f8-44f6-9883-72a4b1f4ef05'
             }
           }
         };
@@ -304,11 +303,11 @@ describe('Configuration loader', function () {
         var appConfig = {
           client: {
             apiKey: {
-              secret: uuid()
+              secret: '58ad0a31-0aad-4ad9-ba0d-559526d72667'
             }
           },
           application: {
-            href: 'http://api.stormpath.com/v1/applications/' + uuid()
+            href: 'http://api.stormpath.com/v1/applications/9418738b-a6d5-4671-90a4-58d4898c1617'
           }
         };
 
@@ -344,15 +343,15 @@ describe('Configuration loader', function () {
   it('should load config from file before environment', function (done) {
     afterIt.push(removeStormpathEnv());
 
-    process.env.STORMPATH_CLIENT_APIKEY_ID = uuid();
-    process.env.STORMPATH_CLIENT_APIKEY_SECRET = uuid();
-    process.env.STORMPATH_APPLICATION_HREF = 'http://api.stormpath.com/v1/applications/' + uuid();
+    process.env.STORMPATH_CLIENT_APIKEY_ID = '617937ab-60fe-45cf-a92c-dfcf3fc5e581';
+    process.env.STORMPATH_CLIENT_APIKEY_SECRET = '91472ae6-35bf-4ad1-af9a-622538b94449';
+    process.env.STORMPATH_APPLICATION_HREF = 'http://api.stormpath.com/v1/applications/079ed9bc-d88e-472e-94e2-ce3180764ceb';
 
     var homeConfig = {
       client: {
         apiKey: {
-          id: uuid(),
-          secret: uuid()
+          id: 'bb115611-f9f7-489f-bb27-3cfd91b789ab',
+          secret: 'f154875d-5be7-4bf4-904e-06062a96cc7a'
         }
       }
     };
@@ -360,11 +359,11 @@ describe('Configuration loader', function () {
     var appConfig = {
       client: {
         apiKey: {
-          secret: uuid()
+          secret: 'c0eca1bc-b3bc-44da-bf0c-06a4285458f9'
         }
       },
       application: {
-        href: 'http://api.stormpath.com/v1/applications/' + uuid()
+        href: 'http://api.stormpath.com/v1/applications/38ae8185-d77c-4959-94d3-276573040e8e'
       }
     };
 
@@ -400,8 +399,8 @@ describe('Configuration loader', function () {
     var customConfig = {
       client: {
         apiKey: {
-          id: uuid(),
-          secret: uuid()
+          id: '94bc6b02-09b7-4fc2-9932-c1b04855c474',
+          secret: '346eb157-2119-4978-b2af-4396cc5dfd20'
         }
       }
     };

--- a/test/sp.config.configLoader_test.js
+++ b/test/sp.config.configLoader_test.js
@@ -52,7 +52,7 @@ describe('Configuration loader', function () {
     fakeFs.patch();
   }
 
-  beforeEach(function () {
+  before(function () {
     afterIt = [];
     loader = configLoader();
   });

--- a/test/sp.ds.datastore_test.js
+++ b/test/sp.ds.datastore_test.js
@@ -18,7 +18,7 @@ describe('ds:', function () {
       describe('and request executor not provided in config', function () {
         var ds;
 
-        beforeEach(function () {
+        before(function () {
           ds = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
         });
 
@@ -31,7 +31,7 @@ describe('ds:', function () {
         var reqExec;
         var ds;
 
-        beforeEach(function () {
+        before(function () {
           reqExec = new RequestExecutor({client: {apiKey: {id: 1, secret: 2}}});
           ds = new DataStore({requestExecutor: reqExec});
         });
@@ -56,7 +56,7 @@ describe('ds:', function () {
     describe('getResource()', function () {
       var ds;
 
-      beforeEach(function () {
+      before(function () {
         ds = new DataStore({
           cacheOptions: {
             store: 'memory'

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -13,7 +13,7 @@ describe('ds:', function () {
   describe('RequestExecutor:', function () {
     var apiKey;
 
-    beforeEach(function () {
+    before(function () {
       apiKey = {id: 1, secret: 2};
     });
 
@@ -31,7 +31,7 @@ describe('ds:', function () {
       describe('create with required options', function () {
         var reqExec;
 
-        beforeEach(function () {
+        before(function () {
           reqExec = new RequestExecutor({client: {apiKey: apiKey}});
         });
 
@@ -57,7 +57,7 @@ describe('ds:', function () {
         };
       }
 
-      beforeEach(function () {
+      before(function () {
         reqExec = new RequestExecutor({client: {apiKey: apiKey} });
       });
 

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -13,7 +13,7 @@ describe('ds:', function () {
   describe('RequestExecutor:', function () {
     var apiKey;
 
-    this.timeout(10000);
+    this.timeout(10 * 1000);
 
     before(function () {
       apiKey = {id: 1, secret: 2};

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -13,6 +13,8 @@ describe('ds:', function () {
   describe('RequestExecutor:', function () {
     var apiKey;
 
+    this.timeout(10000);
+
     before(function () {
       apiKey = {id: 1, secret: 2};
     });

--- a/test/sp.error.resourceError_test.js
+++ b/test/sp.error.resourceError_test.js
@@ -5,7 +5,7 @@ describe('Error:', function () {
     var response;
     var re;
 
-    beforeEach(function () {
+    before(function () {
       response = {
         status: 400,
         code: 100500,

--- a/test/sp.resource.accountStoreMapping_test.js
+++ b/test/sp.resource.accountStoreMapping_test.js
@@ -15,7 +15,7 @@ describe('Resources: ', function () {
   describe('Account Store Mapping resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 

--- a/test/sp.resource.account_test.js
+++ b/test/sp.resource.account_test.js
@@ -20,7 +20,7 @@ describe('Resources: ', function () {
   describe('Account resource class', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({
         client: {
           apiKey: {
@@ -40,7 +40,7 @@ describe('Resources: ', function () {
           account.getGroups();
         }
 
-        beforeEach(function () {
+        before(function () {
           account = new Account(dataStore);
         });
 
@@ -93,7 +93,7 @@ describe('Resources: ', function () {
           account.getGroupMemberships();
         }
 
-        beforeEach(function () {
+        before(function () {
           account = new Account(dataStore);
         });
 
@@ -146,7 +146,7 @@ describe('Resources: ', function () {
           account.addToGroup();
         }
 
-        beforeEach(function () {
+        before(function () {
           account = new Account(dataStore);
         });
 
@@ -268,7 +268,7 @@ describe('Resources: ', function () {
             account.getCustomData();
           }
 
-          beforeEach(function () {
+          before(function () {
             account = new Account(dataStore);
           });
 

--- a/test/sp.resource.account_test.js
+++ b/test/sp.resource.account_test.js
@@ -364,9 +364,9 @@ describe('Resources: ', function () {
           app.getProviderData(cbSpy);
         });
 
-        it('should call cb without options', function () {
+        it('should call cb without arguments', function () {
           cbSpy.should.have.been.calledOnce;
-          cbSpy.should.have.been.calledWith(undefined, undefined);
+          cbSpy.should.have.been.calledWithExactly();
         });
       });
     });

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -27,7 +27,7 @@ describe('Resources: ', function () {
   describe('Application resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({
         client: {
           apiKey: {
@@ -42,7 +42,7 @@ describe('Resources: ', function () {
     describe('authenticate account', function () {
       var authRequest;
 
-      beforeEach(function () {
+      before(function () {
         authRequest = {username: 'test'};
       });
 
@@ -56,7 +56,7 @@ describe('Resources: ', function () {
         var params;
         var path;
 
-        beforeEach(function () {
+        before(function () {
           clientApiKeySecret = uuid();
           dataStore = new DataStore({client: {apiKey: {id: '1', secret: clientApiKeySecret}}});
 
@@ -105,7 +105,7 @@ describe('Resources: ', function () {
         var params;
         var path;
 
-        beforeEach(function () {
+        before(function () {
           clientApiKeySecret = uuid();
           dataStore = new DataStore({client:{apiKey: {id: '1', secret: clientApiKeySecret}}});
 
@@ -187,7 +187,7 @@ describe('Resources: ', function () {
         describe('without a callbackUri',function(){
           var test;
 
-          beforeEach(function () {
+          before(function () {
             test = new SsoResponseTest();
           });
 
@@ -1302,7 +1302,7 @@ describe('Resources: ', function () {
       var decryptedSecret;
       var callCount;
 
-      beforeEach(function () {
+      before(function () {
         appHref = 'https://api.stormpath.com/v1/applications/someapp';
 
         application = new Application({

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -994,9 +994,9 @@ describe('Resources: ', function () {
           app.getDefaultAccountStore(cbSpy);
         });
 
-        it('should call cb without options', function () {
+        it('should call cb without arguments', function () {
           cbSpy.should.have.been.calledOnce;
-          cbSpy.should.have.been.calledWith(undefined, undefined);
+          cbSpy.should.have.been.calledWithExactly();
         });
       });
     });
@@ -1099,9 +1099,9 @@ describe('Resources: ', function () {
           app.getDefaultGroupStore(cbSpy);
         });
 
-        it('should call cb without options', function () {
+        it('should call cb without arguments', function () {
           cbSpy.should.have.been.calledOnce;
-          cbSpy.should.have.been.calledWith(undefined, undefined);
+          cbSpy.should.have.been.calledWithExactly();
         });
       });
     });

--- a/test/sp.resource.authenticationResult_test.js
+++ b/test/sp.resource.authenticationResult_test.js
@@ -13,7 +13,7 @@ describe('Resources: ', function () {
   describe('Authentication Result resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 
@@ -29,7 +29,7 @@ describe('Resources: ', function () {
         var app;
         var result;
 
-        beforeEach(function () {
+        before(function () {
           app = {account: {href: 'boom!'}, dataStore: dataStore};
           result = new AuthenticationResult(app, dataStore);
 

--- a/test/sp.resource.collectionResource_test.js
+++ b/test/sp.resource.collectionResource_test.js
@@ -514,10 +514,10 @@ describe('Resources: ', function () {
         };
       }
 
-      function testBoolean(method, shouldBeCalledCount){
-        shouldBeCalledCount = shouldBeCalledCount || 250;
-
+      function testBoolean(method){
         return function(){
+          var shouldBeCalledCount = 250;
+
           function createAppsCollection(items, offset, limit){
             return {
               href: '/tenants/78KBoSJ5EkMD8OVmBV934Y/applications',
@@ -570,6 +570,7 @@ describe('Resources: ', function () {
 
               switch (method) {
                 case 'detect':
+                case 'detectSeries':
                 case 'some':
                 case 'any':
                   result = false;
@@ -954,11 +955,11 @@ describe('Resources: ', function () {
       describe('foldl', testReduce('foldl'));
       describe('reduceRight', testReduce('reduceRight'));
       describe('foldr', testReduce('foldr'));
-      describe('detect', testBoolean('detect', 100));
-      describe('detectSeries', testBoolean('detectSeries', 1));
+      describe('detect', testBoolean('detect'));
+      describe('detectSeries', testBoolean('detectSeries'));
       describe('sortBy', testSortBy('sortBy'));
-      describe('some', testBoolean('some', 100));
-      describe('any', testBoolean('any', 100));
+      describe('some', testBoolean('some'));
+      describe('any', testBoolean('any'));
       describe('every', testBoolean('every'));
       describe('all', testBoolean('all'));
       describe('concat', test('concat'));

--- a/test/sp.resource.collectionResource_test.js
+++ b/test/sp.resource.collectionResource_test.js
@@ -566,7 +566,18 @@ describe('Resources: ', function () {
             sandbox = sinon.sandbox.create();
             // 4. iterator and callback spies
             function iterator(item, cb){
-              cb(item.description % 2 === 0);
+              var result = true;
+
+              switch (method) {
+                case 'detect':
+                case 'some':
+                case 'any':
+                  result = false;
+              }
+
+              cb(result);
+
+              return result;
             }
             iteratorSpy = sandbox.spy(iterator);
             asyncIteratorSpy = sandbox.spy(iterator);

--- a/test/sp.resource.collectionResource_test.js
+++ b/test/sp.resource.collectionResource_test.js
@@ -21,7 +21,7 @@ describe('Resources: ', function () {
   "use strict";
   var apiKey;
 
-  beforeEach(function () {
+  before(function () {
     apiKey = {id: 1, secret: 2};
   });
 
@@ -46,7 +46,7 @@ describe('Resources: ', function () {
           cr = new CollectionResource(data);
         }
 
-        beforeEach(function () {
+        before(function () {
           data = {};
         });
 
@@ -312,7 +312,7 @@ describe('Resources: ', function () {
     describe('async methods with pagination', function(){
       var ds;
 
-      beforeEach(function () {
+      before(function () {
         ds = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
       });
 

--- a/test/sp.resource.collectionResource_test.js
+++ b/test/sp.resource.collectionResource_test.js
@@ -619,13 +619,6 @@ describe('Resources: ', function () {
 
           it('should call callback once', function(){
             callbackSpy.should.have.been.calledOnce;
-            var asyncArgs = asyncCallbackSpy.getCall(0).args[0];
-            var args = callbackSpy.getCall(0).args[0];
-            if (asyncArgs !== true && asyncArgs !== false){
-              args = _.pick(callbackSpy.getCall(0).args[0], 'href', 'name', 'description', 'status');
-            }
-
-            args.should.be.deep.equal(asyncArgs);
           });
         };
       }

--- a/test/sp.resource.directoryChildResource_test.js
+++ b/test/sp.resource.directoryChildResource_test.js
@@ -10,7 +10,7 @@ describe('Resources: ', function () {
   describe('Directory Child resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 

--- a/test/sp.resource.directory_test.js
+++ b/test/sp.resource.directory_test.js
@@ -330,9 +330,9 @@ describe('Resources: ', function () {
           app.getProviderData(cbSpy);
         });
 
-        it('should call cb without options', function () {
+        it('should call cb without arguments', function () {
           cbSpy.should.have.been.calledOnce;
-          cbSpy.should.have.been.calledWith();
+          cbSpy.should.have.been.calledWithExactly();
         });
       });
     });

--- a/test/sp.resource.directory_test.js
+++ b/test/sp.resource.directory_test.js
@@ -291,7 +291,7 @@ describe('Resources: ', function () {
             dirObj = {provider: {href: providerObj.href}};
             app = new Directory(dirObj, dataStore);
 
-            nock(u.BASE_URL).get(providerObj.href).reply(200, providerObj);
+            nock(u.BASE_URL).get(u.v1(providerObj.href)).reply(200, providerObj);
 
             var args = [];
             if (data) {
@@ -299,7 +299,7 @@ describe('Resources: ', function () {
             }
             args.push(function cb(err, prov) {
               provider = prov;
-              done();
+              done(err);
             });
 
             // act

--- a/test/sp.resource.directory_test.js
+++ b/test/sp.resource.directory_test.js
@@ -18,7 +18,7 @@ describe('Resources: ', function () {
   describe('Directory resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 

--- a/test/sp.resource.directory_test.js
+++ b/test/sp.resource.directory_test.js
@@ -338,7 +338,7 @@ describe('Resources: ', function () {
     });
 
     describe('get organizations', function () {
-      describe('if organizations href are set', function () {
+      describe('if organizations href is set', function () {
         var opt;
         var getResourceStub;
         var sandbox;
@@ -349,7 +349,7 @@ describe('Resources: ', function () {
         before(function () {
           opt = {};
           sandbox = sinon.sandbox.create();
-          app = { organizationMappings: { href: 'boom!' } };
+          app = { organizations: { href: 'boom!' } };
           directory = new Directory(app, dataStore);
           cbSpy = sandbox.spy();
 

--- a/test/sp.resource.directory_test.js
+++ b/test/sp.resource.directory_test.js
@@ -306,8 +306,8 @@ describe('Resources: ', function () {
             app.getProvider.apply(app, args);
           });
           it('should get provider', function () {
-            provider.href.should.be.equal(provider.href);
-            provider.name.should.be.equal(provider.name);
+            provider.href.should.be.equal(providerObj.href);
+            provider.name.should.be.equal(providerObj.name);
           });
 
           it('should be an instance of Provider', function () {

--- a/test/sp.resource.groupMembership_test.js
+++ b/test/sp.resource.groupMembership_test.js
@@ -10,7 +10,7 @@ describe('Resources: ', function () {
   describe('Group Membership resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 

--- a/test/sp.resource.group_test.js
+++ b/test/sp.resource.group_test.js
@@ -14,7 +14,7 @@ describe('Resources: ', function () {
   describe('Group resource', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 
@@ -26,7 +26,7 @@ describe('Resources: ', function () {
           group.addAccount();
         }
 
-        beforeEach(function () {
+        before(function () {
           group = new Group(dataStore);
         });
 
@@ -179,7 +179,7 @@ describe('Resources: ', function () {
           group.getAccountMemberships();
         }
 
-        beforeEach(function () {
+        before(function () {
           group = new Group(dataStore);
         });
 
@@ -255,7 +255,7 @@ describe('Resources: ', function () {
             account.getCustomData();
           }
 
-          beforeEach(function () {
+          before(function () {
             account = new Account(dataStore);
           });
 

--- a/test/sp.resource.instanceResource_test.js
+++ b/test/sp.resource.instanceResource_test.js
@@ -13,7 +13,7 @@ describe('Resources: ', function () {
     var app;
     var instanceResource;
 
-    beforeEach(function () {
+    before(function () {
       ds = new DataStore({client: {apiKey:{id: 1,secret: 2}}});
       app = {href: '/href'};
 

--- a/test/sp.resource.resourceFactory_test.js
+++ b/test/sp.resource.resourceFactory_test.js
@@ -21,7 +21,7 @@ describe('Resources: ', function () {
     describe('if data is a collection resource', function(){
       var data;
 
-      beforeEach(function () {
+      before(function () {
         data = {
           href: '',
           items: [{href: ''}, {href: ''}],
@@ -43,7 +43,7 @@ describe('Resources: ', function () {
     describe('if data is a resource', function(){
       var data;
 
-      beforeEach(function () {
+      before(function () {
         data = {href: ''};
       });
 

--- a/test/sp.resource.resource_test.js
+++ b/test/sp.resource.resource_test.js
@@ -10,7 +10,7 @@ describe('Resources: ', function () {
     describe('constructor', function () {
       var apiKey;
 
-      beforeEach(function () {
+      before(function () {
         apiKey = {id: 'id', secret: 'secret'};
       });
 

--- a/test/sp.resource.tenant_test.js
+++ b/test/sp.resource.tenant_test.js
@@ -13,7 +13,7 @@ describe('Resources: ', function () {
   describe('Tenant resource class', function () {
     var dataStore;
 
-    beforeEach(function () {
+    before(function () {
       dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
     });
 

--- a/test/sp.utils_test.js
+++ b/test/sp.utils_test.js
@@ -36,7 +36,7 @@ describe('util', function () {
     var obj;
     var def;
 
-    beforeEach(function () {
+    before(function () {
       obj = {test: 'me'};
       def = {all: 'ok'};
     });
@@ -67,7 +67,7 @@ describe('util', function () {
 
     function Class() {}
 
-    beforeEach(function () {
+    before(function () {
       Class.prototype.field = 'boom!';
 
       objToCopy = new Class();
@@ -125,7 +125,7 @@ describe('util', function () {
   describe('base64', function(){
     var test;
 
-    beforeEach(function () {
+    before(function () {
       test = 'boom!';
     });
 


### PR DESCRIPTION
The [Move assignments from describe into before/beforeEach](https://github.com/stormpath/stormpath-sdk-node/pull/353) PR made the tests to actually run, but it revealed more errors and tests that failed which are addressed in this PR.

Fixes #334.

### How to verify

1. Checkout this branch
2. Run `npm test`
3. Verify that all tests run (**665** tests)
4. Verify that no tests fails
5. Review code changes based on my notes below

### Changes

* **`test/sp.cache.cache_test.js`**

  * ba569f6bcc3c54b1700428b9277e8e71c135f1b6 Introduced when I refactored assignments into `before`. `opt` is a variable that is being overwritten and will therefore loose its reference. This fix initially assigns it to an object and then it sets the `cache` property inside `before` instead of overwriting it. This will preserve the reference.

* **Use `before` instead of `beforeEach` as it doesn't seem to work**

  * 49cb3b5c6ba391a64896a92ae17a84caf578805d Introduced when I refactored assignments into `before`. There were some problems using `beforeEach` so I changed it to `before` instead. In later refactors I was able to use `beforeEach`, so I might go back and check this fix later. I would prefer to use `beforeEach` rather than `before` for better isolation.

* **Custom errors should capture the stack trace in a proper way**

  * c6c84f28a901fa88ea63315574b2fe80f5861986 I found this when I was looking for another bug, and I decided to fix this as I found it. Basically I improved the way the error stack is captured. You can read more there: <https://gist.github.com/justmoon/15511f92e5216fa2624b>.

* **`Error.prepareStackTrace` should be restored even when the filename is found, otherwise Mocha will crash on an error**

  * a277ba0d591d220621c0b3c28c4cc8ec95d4b67d Whenever a test failed, Mocha crashed complaining that `stack.split` was undefined. I debugged this and eventually found that is was because the `Error` object had been modified without being restored due to a bug.

* **`test/sp.cache.entry_test.js`**

  * b42e837e8e432ebafa14c1a7247d64b7f430d8e5 This test was failing because it was generating a timestamp and then directly after checked if some time has passed. This might have worked on slow computers, but not mine ;) I fixed this by adding a timeout of 20 ms.

* **`test/sp.config.configLoader_test.js`**

  * 9787fe2964a8b5819986395db0a7908cf1ba3caf I replaced all random uuids with hardcoded ones instead. Since one of the uuid were leaking into the other tests, this made it a lot more easier to find, as I could just search for the uuid that didn't match.

  * fca6aff5ca3be88a5eb72404f5a027b7a2ce1af3 Tests weren't isolated and one config was not removed and made other tests fail. I fixed this by using `beforeEach` and `afterEach` to setup and restore the state between each test.

  * fca6aff5ca3be88a5eb72404f5a027b7a2ce1af3 I also had to mock the home path with a `~`, and not just expanded as the `fake-fs` didn't seem to handle that. 

* **`u.BASE_URL` should not contain `/v1` as this will be added by `u.v1()`**

  * caf90aa7f5518cbe96650e11233afa5faed8059a This made a lot of tests fail as it would result in URLs such as `https://api.stormpath.com/v1/v1/applications/etc`.

* **`.calledWith(undefined, undefined)` does not equal *no arguments*, instead I replaced it with `.calledWithExactly()`**

  * cc8c60c0e0e7fb4e57add51048a263296f7b371f As the title says, `.calledWith(undefined, undefined)` does not equal without any arguments. For this assertion to be true, the spy would had to be called with two undefined arguments. I also renamed the test descriptions from `'should call cb without options'` to `'should call cb without arguments'`.

* **`test/sp.resource.collectionResource_test.js`**

  * af640c06fddd5fd59744a1de5fcfb7fa18f36bf9 The iterator should return `true`/`false` based on the method that is under test.

  * 12955bc2d92517053c6cdc49e48ae5aed98d1168 Should only test if the callback is called once, not other things (which is not even correct).

  * f6f9b9a3a8d678061f8108c315be90e8518cd8a2 Test all methods with pagination.

* **`lib/resource/CollectionResource.js`**

  * 8d8f3a939682009a6e26cff0d7565eaa5e088af0 `async.every(arr, iterator, [callback])` will call the callback with `true` as result if all truth tests passed. Many of the other methods will be the opposite (calling it with `false`). This will make `async.parallel()` to believe that an error occurred as it just sends its result directly into the `parallel` callback. This caused `.every()` to behave very odd and it called its callback between each page.

   * 4d9bf5b10489f8ceffee120b24c92b4196c76320  `.every(arr, iterator, [callback])` should abort as soon as an iterator returns `false`.

* **`test/sp.resource.directory_test.js`**

  * 091308ae090b0d615c96d1bb5d36961d83fa0df6 Use `u.v1()` to prepend the version to the URL. Also make sure to pass the error to `done()` so we know when an error occurs.

  * 4997807da56b4af9cd846e24be48bd9aa1e24dd1 `provider` should be checked against `providerObj`, and not itself.

  * 8baae7e30a6458bf4e5b9d592a664f1eb2060680 `organizationMappings` should be `organizations`.

* **`test/it/oauth_id_site_token_grant_it.js`**

  * 455559e8cfacc87fe92a6fe98eb816c6549945f4 Remove empty test which will otherwise get stuck in `pending`.

* **Increase timeouts to prevent Travis from timing out when running tests with a lot of old resources**

  * c668c9441be05a10445f48f67b8bd88731b02049, c1d84301af9a4ec4c8ccce05a2fb24c0600e050d, 3d83ff0f4477bbd9d9bfd7f123728bdf28f9e2f7 It seems like some tests doesn't clean up after themselves, and that leads to a lot of resources which eventually makes the tests to timeout. I won't address this issue in this PR, so I just increased the timeout for those tests.