### PR TITLE
Feature: Add OAuth authenticator for stormpath_token

### DIFF
--- a/docs/app/scripts/app.js
+++ b/docs/app/scripts/app.js
@@ -98,6 +98,14 @@ angular.module('docsApp', [
         templateUrl: 'views/samlIdpUrlBuilder.html',
         controller: 'MainCtrl'
       })
+      .when('/oauthStormpathTokenAuthenticator', {
+        templateUrl: 'views/oauthStormpathTokenAuthenticator.html',
+        controller: 'MainCtrl'
+      })
+      .when('/oauthStormpathTokenAuthenticationResult', {
+        templateUrl: 'views/oauthStormpathTokenAuthenticationResult.html',
+        controller: 'MainCtrl'
+      })
       .otherwise({
         redirectTo: '/home'
       });

--- a/docs/app/scripts/controllers/mainNav.js
+++ b/docs/app/scripts/controllers/mainNav.js
@@ -220,6 +220,17 @@ function items() {
       anchor('authenticate')
     ]),
 
+    item('OAuthStormpathTokenAuthenticator', 'oauthStormpathTokenAuthenticator', [
+      anchor('Overview', 'top'),
+      anchor('constructor'),
+      anchor('authenticate')
+    ]),
+
+    item('OAuthStormpathTokenAuthenticationResult', 'oauthStormpathTokenAuthenticationResult', [
+      anchor('Overview', 'top'),
+      anchor('getAccount')
+    ]),
+
     item('Tenant', null, [
       anchor('Overview', 'top'),
       anchor('createApplication'),

--- a/docs/app/styles/main.scss
+++ b/docs/app/styles/main.scss
@@ -113,7 +113,7 @@ padding: 5px 30px 5px 30px;
 /*
  * Sidebar
  */
-$sidebarWidth: 275px;
+$sidebarWidth: 375px;
 .sidebar {
   padding: 20px 10px;
   background-color: #f5f5f5;

--- a/docs/app/views/oauthStormpathTokenAuthenticationResult.md
+++ b/docs/app/views/oauthStormpathTokenAuthenticationResult.md
@@ -1,9 +1,8 @@
-## AssertionAuthenticationResult
+## OAuthStormpathTokenAuthenticationResult
 
-An `AsssertionAuthenticationResult` is returned by the [StormpathAssertionAuthenticator](stormpathAssertionAuthenticator).
-It encapsulates an authentication result from ID Site Callback or SAML Callback, and allows you to get the account that has authenticated.
+An `OAuthStormpathTokenAuthenticationResult` is returned by the [OAuthStormpathTokenAuthenticator](oauthStormpathTokenAuthenticator).
+It encapsulates an authentication result from an ID Site callback, and allows you to get the account that has authenticated.
 
-**Since**: 0.16.0
 
 ---
 
@@ -15,7 +14,7 @@ Retrieves the [Account](account) object of the user that has authenticated.
 #### Usage
 
 ```javascript
-assertionAuthenticationResult.getAccount(function(err, account) {
+oauthStormpathTokenAuthenticationResult.getAccount(function(err, account) {
   console.log(account);
 });
 ```
@@ -49,18 +48,4 @@ assertionAuthenticationResult.getAccount(function(err, account) {
 
 #### Returns
 
-void; the retrieved [Account](account) resource will be provided to the `callback` as the callback's second parameter.
-
----
-
-<a name="stormpath_token"></a>
-### <span class="property">property</span> .stormpath_token <em>String</em>
-
-The original JWT that was returned to your application, as the `?jwtResponse=<stormpath_token>` parameter.
-
----
-
-<a name="expandedJwt"></a>
-### <span class="property">property</span> .expandedJwt <em>Object</em>
-
-The parsed `stormpath_token`.
+If the request fails, the callback's first parameter (err) will report the failure. If the request succeeds, a [Account](account) instance will be provided to the callback as the callback's second parameter.

--- a/docs/app/views/oauthStormpathTokenAuthenticationResult.md
+++ b/docs/app/views/oauthStormpathTokenAuthenticationResult.md
@@ -1,7 +1,9 @@
 ## OAuthStormpathTokenAuthenticationResult
 
-An `OAuthStormpathTokenAuthenticationResult` is returned by the [OAuthStormpathTokenAuthenticator](oauthStormpathTokenAuthenticator).
-It encapsulates an authentication result from an ID Site callback, and allows you to get the account that has authenticated.
+An `OAuthStormpathTokenAuthenticationResult` is returned by the
+[OAuthStormpathTokenAuthenticator](oauthStormpathTokenAuthenticator).
+It encapsulates an authentication result from an ID Site or SAML callback, and
+allows you to get the account that has authenticated.
 
 
 ---

--- a/docs/app/views/oauthStormpathTokenAuthenticator.md
+++ b/docs/app/views/oauthStormpathTokenAuthenticator.md
@@ -1,0 +1,110 @@
+## OAuthStormpathTokenAuthenticator
+
+Provides the ability to authenticate with Stormpath JWTs (`stormpath_token`).
+Your application will recieve this token when a user is redirected to your application from an ID Site.
+
+---
+
+
+<a name="constructor"></a>
+### <span class="member">constructor</span> OAuthStormpathTokenAuthenticator(application)
+
+Creates a new `OAuthStormpathTokenAuthenticator` instance for the provided application.
+
+
+#### Usage
+
+```javascript
+var authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
+```
+
+
+#### Parameters
+
+<table class="table table-striped table-hover table-curved">
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Type</th>
+      <th>Presence</th>
+      <th>Description<th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`application`</td>
+      <td>[`Application`](application)</td>
+      <td>required</td>
+      <td>Stormpath [Application](application) to authenticate against.</td>
+    </tr>
+  </tbody>
+</table>
+
+
+#### Returns
+
+A new [`OAuthStormpathTokenAuthenticator`](oauthStormpathTokenAuthenticator) instance.
+
+---
+
+
+<a name="authenticate"></a>
+### <span class="member">method</span> authenticate(data, callback)
+
+Authenticates a `stormpath_token` and returns a [OAuthStormpathTokenAuthenticationResult](outhStormpathTokenAuthenticationResult), which
+can provide the [Account](account) that has authenticated.
+
+The `stormpath_token` is the value of the `jwtResponse` parameter in the callback URL, e.g. `https://myapp.com/idsite/callback?jwtResponse=<stormpath_token>`.
+
+
+#### Usage
+
+```javascript
+authenticator.authenticate(data, function(err, authenticationResult) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  console.log(authenticationResult);
+});
+```
+
+
+#### Parameters
+
+<table class="table table-striped table-hover table-curved">
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Type</th>
+      <th>Presence</th>
+      <th>Description<th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`data`</td>
+      <td>`object`</td>
+      <td>required</td>
+      <td>
+        <p>An object literal, with the following properties:</p>
+        <ul>
+          <li>`stormpath_token` - REQUIRED - A Stormpath JWT from an ID Site callback.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>`callback`</td>
+      <td>`function`</td>
+      <td>required</td>
+      <td>The callback to execute upon server response. The 1st parameter is an [error](Error).  The 2nd parameter is an [OAuthStormpathTokenAuthenticationResult](oauthStormpathTokenAuthenticationResult) instance.</td>
+    </tr>
+  </tbody>
+</table>
+
+
+#### Returns
+
+If the request fails, the callback's first parameter (`err`) will report the
+failure.  If the request succeeds, a [OAuthStormpathTokenAuthenticationResult](oauthStormpathTokenAuthenticationResult) instance
+will be provided to the callback as the callback's second parameter.

--- a/docs/app/views/oauthStormpathTokenAuthenticator.md
+++ b/docs/app/views/oauthStormpathTokenAuthenticator.md
@@ -1,7 +1,8 @@
 ## OAuthStormpathTokenAuthenticator
 
 Provides the ability to authenticate with Stormpath JWTs (`stormpath_token`).
-Your application will recieve this token when a user is redirected to your application from an ID Site.
+Your application will recieve this token when a user is redirected to your
+application from an ID Site or SAML provider.
 
 ---
 
@@ -54,7 +55,8 @@ A new [`OAuthStormpathTokenAuthenticator`](oauthStormpathTokenAuthenticator) ins
 Authenticates a `stormpath_token` and returns a [OAuthStormpathTokenAuthenticationResult](outhStormpathTokenAuthenticationResult), which
 can provide the [Account](account) that has authenticated.
 
-The `stormpath_token` is the value of the `jwtResponse` parameter in the callback URL, e.g. `https://myapp.com/idsite/callback?jwtResponse=<stormpath_token>`.
+The `stormpath_token` is the value of the `jwtResponse` parameter in the
+callback URL, e.g. `https://myapp.com/idSiteCallback?jwtResponse=<stormpath_token>`.
 
 
 #### Usage
@@ -89,7 +91,7 @@ authenticator.authenticate(data, function(err, authenticationResult) {
       <td>
         <p>An object literal, with the following properties:</p>
         <ul>
-          <li>`stormpath_token` - REQUIRED - A Stormpath JWT from an ID Site callback.</li>
+          <li>`stormpath_token` - REQUIRED - A Stormpath JWT from an ID Site or SAML callback.</li>
         </ul>
       </td>
     </tr>

--- a/lib/authc/StormpathAssertionAuthenticator.js
+++ b/lib/authc/StormpathAssertionAuthenticator.js
@@ -23,6 +23,7 @@ StormpathAssertionAuthenticator.prototype.authenticate = function authenticate(s
     if (jwt.body.err){
       return callback(jwt.body.err);
     }
+
     // For Stormpath mapped JWT fields, see:
     // https://docs.stormpath.com/rest/product-guide/latest/005_auth_n.html#step-5-stormpath-response-with-jwt
     var accountHref = jwt.body.sub;

--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -5,6 +5,7 @@ var JwtAuthenticator = require('../jwt/jwt-authenticator');
 var OAuthPasswordGrantRequestAuthenticator = require('../oauth/password-grant').authenticator;
 var OAuthRefreshTokenGrantRequestAuthenticator = require('../oauth/refresh-grant').authenticator;
 var OAuthIdSiteTokenGrantAuthenticator = require('../oauth/id-site-grant').authenticator;
+var OAuthStormpathTokenAuthenticator = require('../oauth/stormpath-token').authenticator;
 
 function retrieveAuthTokenFromRequest(req) {
   var authHeader = req && req.headers && req.headers.authorization;
@@ -56,6 +57,9 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
         break;
       case 'id_site_token':
         authenticator = new OAuthIdSiteTokenGrantAuthenticator(this.application);
+        break;
+      case 'stormpath_token':
+        authenticator = new OAuthStormpathTokenAuthenticator(this.application);
         break;
     }
   }

--- a/lib/oauth/id-site-grant.js
+++ b/lib/oauth/id-site-grant.js
@@ -17,7 +17,7 @@ function OAuthIdSiteTokenGrantAuthenticator(application) {
   this.application = application;
 }
 
-OAuthIdSiteTokenGrantAuthenticator.prototype.authenticate = function authenticate(data, callback) {
+OAuthIdSiteTokenGrantAuthenticator.prototype.authenticate = util.deprecate(function authenticate(data, callback) {
   var application = this.application;
 
   var formData = {
@@ -34,9 +34,9 @@ OAuthIdSiteTokenGrantAuthenticator.prototype.authenticate = function authenticat
 
     callback(null, new OAuthIdSiteTokenGrantAuthenticationResult(application, tokenData));
   });
-};
+},'OAuthIdSiteTokenGrantAuthenticator is deprecated. Use OAuthStormpathTokenAuthenticator instead.  See http://docs.stormpath.com/nodejs/api/oauthStormpathTokenAuthenticator');
 
 module.exports = {
-  authenticator: util.deprecate(OAuthIdSiteTokenGrantAuthenticator, 'OAuthIdSiteTokenGrantAuthenticator is deprecated. Use OAuthStormpathTokenAuthenticator instead.'),
-  authenticationResult: util.deprecate(OAuthIdSiteTokenGrantAuthenticationResult, 'OAuthIdSiteTokenGrantAuthenticationResult is deprecated. Use OAuthStormpathTokenAuthenticationResult instead.')
+  authenticator: OAuthIdSiteTokenGrantAuthenticator,
+  authenticationResult: OAuthIdSiteTokenGrantAuthenticationResult
 };

--- a/lib/oauth/id-site-grant.js
+++ b/lib/oauth/id-site-grant.js
@@ -37,6 +37,6 @@ OAuthIdSiteTokenGrantAuthenticator.prototype.authenticate = function authenticat
 };
 
 module.exports = {
-  authenticator: OAuthIdSiteTokenGrantAuthenticator,
-  authenticationResult: OAuthIdSiteTokenGrantAuthenticationResult
+  authenticator: util.deprecate(OAuthIdSiteTokenGrantAuthenticator, 'OAuthIdSiteTokenGrantAuthenticator is deprecated. Use OAuthStormpathTokenAuthenticator instead.'),
+  authenticationResult: util.deprecate(OAuthIdSiteTokenGrantAuthenticationResult, 'OAuthIdSiteTokenGrantAuthenticationResult is deprecated. Use OAuthStormpathTokenAuthenticationResult instead.')
 };

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -20,6 +20,14 @@ function OAuthStormpathTokenAuthenticator(application) {
 OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(data, callback) {
   var application = this.application;
 
+  if (typeof data !== 'object') {
+    throw new Error('The \'data\' parameter must be an object.');
+  }
+
+  if (typeof callback !== 'function') {
+    throw new Error('The \'callback\' parameter must be a function.');
+  }
+
   var formData = {
     grant_type: 'stormpath_token',
     token: data.stormpath_token

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var util = require('util');
+var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
+
+function OAuthStormpathTokenAuthenticationResult(application, data){
+  OAuthStormpathTokenAuthenticationResult.super_.apply(this, arguments);
+  this.accessTokenResponse = data;
+}
+util.inherits(OAuthStormpathTokenAuthenticationResult, JwtAuthenticationResult);
+
+function OAuthStormpathTokenAuthenticator(application) {
+  if (!(this instanceof OAuthStormpathTokenAuthenticator)) {
+    return new OAuthStormpathTokenAuthenticator(application);
+  }
+
+  this.application = application;
+}
+
+OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(data, callback) {
+  var application = this.application;
+
+  var formData = {
+    grant_type: 'stormpath_token',
+    token: data.stormpath_token
+  };
+
+  var tokenHref = application.href + '/oauth/token';
+
+  application.dataStore.createResource(tokenHref, { form: formData }, function(err, tokenData) {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, new OAuthStormpathTokenAuthenticationResult(application, tokenData));
+  });
+};
+
+module.exports = {
+  authenticator: OAuthStormpathTokenAuthenticator,
+  authenticationResult: OAuthStormpathTokenAuthenticationResult
+};

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -3,6 +3,7 @@
 var passwordGrant = require('./oauth/password-grant');
 var refreshGrant = require('./oauth/refresh-grant');
 var idSiteGrant = require('./oauth/id-site-grant');
+var stormpathToken = require('./oauth/stormpath-token');
 
 module.exports = {
   ApiKey: require('./authc/ApiKey'),
@@ -15,6 +16,8 @@ module.exports = {
   OAuthRefreshTokenGrantRequestAuthenticator: refreshGrant.authenticator,
   OAuthIdSiteTokenGrantAuthenticator: idSiteGrant.authenticator,
   OAuthIdSiteTokenGrantAuthenticationResult: idSiteGrant.authenticationResult,
+  OAuthStormpathTokenAuthenticator: stormpathToken.authenticator,
+  OAuthStormpathTokenAuthenticationResult: stormpathToken.authenticationResult,
   SamlIdpUrlBuilder: require('./saml/SamlIdpUrlBuilder'),
   AssertionAuthenticationResult: require('./authc/AssertionAuthenticationResult'),
   StormpathAssertionAuthenticator: require('./authc/StormpathAssertionAuthenticator'),

--- a/test/it/helpers.js
+++ b/test/it/helpers.js
@@ -167,10 +167,39 @@ function getDefaultAccountStore(application,done){
   });
 }
 
+/**
+ * Creates a Stormpath JWT from an application and account.
+ *
+ * @function
+ *
+ * @param {Application} application - Stormpath Application to authenticate with.
+ * @param {Account} account - Stormpath account to authenticate with.
+ *
+ * @returns string - The serialized Stormpath JWT.
+ */
+function createStormpathToken(application, account, apiKey) {
+  if (!apiKey) {
+    apiKey = application.dataStore.requestExecutor.options.client.apiKey;
+  }
+
+  var payload = {
+    sub: account.href,
+    iat: new Date().getTime() / 1000,
+    iss: application.href,
+    status: 'AUTHENTICATED',
+    aud: apiKey.id
+  };
+
+  var token = common.jwt.create(payload, apiKey.secret, 'HS256');
+
+  return token.compact();
+}
+
 module.exports = {
   getDefaultAccountStore: getDefaultAccountStore,
   cleanupApplicationAndStores: cleanupApplicationAndStores,
   createApplication: createApplication,
+  createStormpathToken: createStormpathToken,
   getClient: getClient,
   uniqId: uniqId,
   fakeAccount: fakeAccount,

--- a/test/it/oauth_authenticator_it.js
+++ b/test/it/oauth_authenticator_it.js
@@ -159,6 +159,24 @@ describe('OAuthAuthenticator',function(){
     });
   });
 
+  it('should error when trying to authenticate with invalid stormpath token', function(done){
+    var authenticator = stormpath.OAuthAuthenticator(application);
+    authenticator.authenticate({
+      body: {
+        grant_type: 'stormpath_token',
+        stormpath_token: 'abc'
+      }
+    },function(err,result){
+      assert.isUndefined(result);
+
+      assert.isNotNull(err);
+      assert.equal(err.status, 400);
+      assert.equal(err.code, 10017); // 10017 = Token is invalid.
+
+      done();
+    });
+  });
+
   it('should error when trying to authenticate with invalid refresh token', function(done){
     var authenticator = stormpath.OAuthAuthenticator(application);
     authenticator.authenticate({

--- a/test/it/oauth_id_site_token_grant_it.js
+++ b/test/it/oauth_id_site_token_grant_it.js
@@ -23,11 +23,11 @@ describe('OAuthIdSiteTokenGrantAuthenticator',function(){
 
   it('should be constructable with new operator',function(){
     var authenticator = new stormpath.OAuthIdSiteTokenGrantAuthenticator(application);
-    assert.typeOf(authenticator, 'Object');
+    assert.instanceOf(authenticator, stormpath.OAuthIdSiteTokenGrantAuthenticator);
   });
 
   it('should be constructable without new operator',function(){
     var authenticator = stormpath.OAuthIdSiteTokenGrantAuthenticator(application);
-    assert.typeOf(authenticator, 'Object');
+    assert.instanceOf(authenticator, stormpath.OAuthIdSiteTokenGrantAuthenticator);
   });
 });

--- a/test/it/oauth_id_site_token_grant_it.js
+++ b/test/it/oauth_id_site_token_grant_it.js
@@ -1,4 +1,3 @@
-
 var common = require('../common');
 var helpers = require('./helpers');
 var assert = common.assert;
@@ -24,11 +23,11 @@ describe('OAuthIdSiteTokenGrantAuthenticator',function(){
 
   it('should be constructable with new operator',function(){
     var authenticator = new stormpath.OAuthIdSiteTokenGrantAuthenticator(application);
-    assert.instanceOf(authenticator, stormpath.OAuthIdSiteTokenGrantAuthenticator);
+    assert.typeOf(authenticator, 'Object');
   });
 
   it('should be constructable without new operator',function(){
-    var authenticator = new stormpath.OAuthIdSiteTokenGrantAuthenticator(application);
-    assert.instanceOf(authenticator, stormpath.OAuthIdSiteTokenGrantAuthenticator);
+    var authenticator = stormpath.OAuthIdSiteTokenGrantAuthenticator(application);
+    assert.typeOf(authenticator, 'Object');
   });
 });

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -1,0 +1,36 @@
+
+var common = require('../common');
+var helpers = require('./helpers');
+var assert = common.assert;
+
+var stormpath = require('../../');
+
+describe('OAuthStormpathTokenAuthenticator', function () {
+  var newAccount;
+  var application;
+
+  before(function(done){
+    newAccount = helpers.fakeAccount();
+
+    helpers.createApplication(function (err, app) {
+      application = app;
+      application.createAccount(newAccount, done);
+    });
+  });
+
+  after(function (done) {
+    application.delete(done);
+  });
+
+  it('should be constructable with new operator',function(){
+    var authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
+    assert.instanceOf(authenticator, stormpath.OAuthStormpathTokenAuthenticator);
+    assert.equal(authenticator.application, application);
+  });
+
+  it('should be constructable without new operator',function(){
+    var authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
+    assert.instanceOf(authenticator, stormpath.OAuthStormpathTokenAuthenticator);
+    assert.equal(authenticator.application, application);
+  });
+});

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -1,36 +1,158 @@
-
-var common = require('../common');
-var helpers = require('./helpers');
-var assert = common.assert;
+'use strict';
 
 var stormpath = require('../../');
+var common = require('../common');
+var helpers = require('./helpers');
+
+var assert = common.assert;
 
 describe('OAuthStormpathTokenAuthenticator', function () {
-  var newAccount;
+  var account;
   var application;
 
-  before(function(done){
-    newAccount = helpers.fakeAccount();
+  beforeEach(function (done) {
+    helpers.createApplication(function (err, newApplication) {
+      if (err) {
+        return done(err);
+      }
 
-    helpers.createApplication(function (err, app) {
-      application = app;
-      application.createAccount(newAccount, done);
+      application = newApplication;
+
+      application.createAccount(helpers.fakeAccount(), function (err, newAccount) {
+        if (err) {
+          return done(err);
+        }
+
+        account = newAccount;
+
+        done();
+      });
     });
   });
 
-  after(function (done) {
+  afterEach(function (done) {
     application.delete(done);
   });
 
-  it('should be constructable with new operator',function(){
-    var authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
-    assert.instanceOf(authenticator, stormpath.OAuthStormpathTokenAuthenticator);
-    assert.equal(authenticator.application, application);
+  describe('when calling OAuthStormpathTokenAuthenticator(application)', function () {
+    var instance;
+
+    beforeEach(function () {
+      instance = stormpath.OAuthStormpathTokenAuthenticator(application);
+    });
+
+    it('should return a OAuthStormpathTokenAuthenticator instance', function () {
+      assert.instanceOf(instance, stormpath.OAuthStormpathTokenAuthenticator);
+    });
+
+    it('should return a new instance', function () {
+      var differentInstance = new stormpath.OAuthStormpathTokenAuthenticator(application);
+      assert.instanceOf(differentInstance, stormpath.OAuthStormpathTokenAuthenticator);
+      assert.notEqual(instance, differentInstance);
+    });
+
+    it('should return an instance with an application property', function () {
+      assert.property(instance, 'application');
+      assert.equal(instance.application, application);
+    });
   });
 
-  it('should be constructable without new operator',function(){
-    var authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
-    assert.instanceOf(authenticator, stormpath.OAuthStormpathTokenAuthenticator);
-    assert.equal(authenticator.application, application);
+  describe('when calling new OAuthStormpathTokenAuthenticator(application)', function () {
+    var instance;
+
+    beforeEach(function () {
+      instance = new stormpath.OAuthStormpathTokenAuthenticator(application);
+    });
+
+    it('should return a OAuthStormpathTokenAuthenticator instance', function () {
+      assert.instanceOf(instance, stormpath.OAuthStormpathTokenAuthenticator);
+    });
+
+    it('should return a new instance', function () {
+      var differentInstance = new stormpath.OAuthStormpathTokenAuthenticator(application);
+      assert.instanceOf(differentInstance, stormpath.OAuthStormpathTokenAuthenticator);
+      assert.notEqual(instance, differentInstance);
+    });
+
+    it('should return an instance with an application property', function () {
+      assert.property(instance, 'application');
+      assert.equal(instance.application, application);
+    });
+  });
+
+  describe('when calling authenticate(data, callback)', function () {
+    var validToken;
+    var invalidToken;
+    var authenticator;
+
+    beforeEach(function () {
+      authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
+      validToken = helpers.createStormpathToken(application, account);
+      invalidToken = helpers.createStormpathToken(application, account, {
+        id: '92d472b3-6eeb-48b8-a342-b2df89c520e8',
+        secret: 'bcf251b9-3da8-4020-b4d9-406ee749425d'
+      });
+    });
+
+    describe('without a data parameter', function () {
+      it('should throw an invalid parameter error', function () {
+        assert.throws(function () {
+          authenticator.authenticate();
+        }, 'The \'data\' parameter must be an object.');
+      });
+    });
+
+    describe('without a callback parameter', function () {
+      it('should throw an invalid parameter error', function () {
+        assert.throws(function () {
+          authenticator.authenticate({});
+        }, 'The \'callback\' parameter must be a function.');
+      });
+    });
+
+    describe('with a stormpath_token data property', function () {
+      describe('and the token is invalid', function () {
+        it('should fail with a token invalid error', function (done) {
+          authenticator.authenticate({ stormpath_token: invalidToken }, function (err, authenticationResult) {
+            assert.ok(err);
+            assert.equal(err.name, 'ResourceError');
+            assert.equal(err.status, 400); // Bad request
+            assert.equal(err.code, 10017); // Token is invalid because verifying the signature of a JWT failed.
+            assert.equal(err.message, 'HTTP 400, Stormpath 10017 (http://docs.stormpath.com/errors/10017): Token is invalid because verifying the signature of a JWT failed.');
+            assert.notOk(authenticationResult);
+            done();
+          });
+        });
+      });
+
+      describe('and the token is valid', function () {
+        it('should succeed with a OAuthStormpathTokenAuthenticationResult result', function (done) {
+          authenticator.authenticate({ stormpath_token: validToken }, function (err, authenticationResult) {
+            assert.notOk(err);
+            assert.ok(authenticationResult);
+            assert.instanceOf(authenticationResult, stormpath.OAuthStormpathTokenAuthenticationResult);
+            assert.property(authenticationResult, 'application');
+            assert.property(authenticationResult, 'account');
+            assert.property(authenticationResult, 'accessToken');
+            assert.property(authenticationResult, 'refreshToken');
+            done();
+          });
+        });
+      });
+    });
+
+    describe('without a stormpath_token data property', function () {
+      it('should fail with a token parameter error', function (done) {
+        authenticator.authenticate({}, function (err, authenticationResult) {
+          assert.ok(err);
+          assert.equal(err.name, 'ResourceError');
+          assert.equal(err.status, 400); // Bad request
+          assert.equal(err.code, 2000); // Property value is required.
+          assert.equal(err.message, 'HTTP 400, Stormpath 2000 (http://docs.stormpath.com/errors/2000): token parameter cannot be null, empty, or blank.');
+          assert.notOk(authenticationResult);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds the `OAuthStormpathTokenGrantAuthenticator` for authenticating `stormpath_token` tokens.

Part solution of: https://github.com/stormpath/express-stormpath/issues/251
