### PR TITLE
Add `Organization.getDefaultAccountStore()` and `Organization.getDefaultGroupStore()` methods

### DIFF
--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -7,6 +7,7 @@ var Account = require('./Account');
 var CustomData = require('./CustomData');
 var IdSiteModel = require('./IdSiteModel');
 var OrganizationAccountStoreMapping = require('./OrganizationAccountStoreMapping');
+var Directory = require('./Directory');
 
 function Organization() {
   Organization.super_.apply(this, arguments);
@@ -47,6 +48,32 @@ Organization.prototype.getDefaultGroupStoreMapping = function getDefaultGroupSto
   }
 
   return this.dataStore.getResource(this.defaultGroupStoreMapping.href, args.options, OrganizationAccountStoreMapping, args.callback);
+};
+
+Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  var dataStore = this.dataStore;
+
+  return this.getDefaultAccountStoreMapping({ expand: 'accountStore' }, function (err, accountStoreMapping) {
+    if (err) {
+      return args.callback(err);
+    }
+
+    dataStore.getResource(accountStoreMapping.accountStore.href, args.options, Directory, args.callback);
+  });
+};
+
+Organization.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  var dataStore = this.dataStore;
+
+  return this.getDefaultGroupStoreMapping({ expand: 'accountStore' }, function (err, groupStoreMapping) {
+    if (err) {
+      return args.callback(err);
+    }
+
+    dataStore.getResource(groupStoreMapping.accountStore.href, args.options, Directory, args.callback);
+  });
 };
 
 Organization.prototype.getGroups = function getGroups(/* [options,] callback */) {

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -54,12 +54,12 @@ Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
   var dataStore = this.dataStore;
 
-  return this.getDefaultAccountStoreMapping({ expand: 'accountStore' }, function (err, accountStoreMapping) {
+  return this.getDefaultAccountStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
     if (err) {
       return args.callback(err);
     }
 
-    dataStore.getResource(accountStoreMapping.accountStore.href, args.options, Directory, args.callback);
+    dataStore.getResource(organizationAccountStoreMapping.accountStore.href, args.options, Directory, args.callback);
   });
 };
 
@@ -67,12 +67,12 @@ Organization.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
   var dataStore = this.dataStore;
 
-  return this.getDefaultGroupStoreMapping({ expand: 'accountStore' }, function (err, groupStoreMapping) {
+  return this.getDefaultGroupStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
     if (err) {
       return args.callback(err);
     }
 
-    dataStore.getResource(groupStoreMapping.accountStore.href, args.options, Directory, args.callback);
+    dataStore.getResource(organizationAccountStoreMapping.accountStore.href, args.options, Directory, args.callback);
   });
 };
 

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -29,7 +29,7 @@ Organization.prototype.getCustomData = function getCustomData(/* [options,] call
   return this.dataStore.getResource(this.customData.href, args.options, CustomData, args.callback);
 };
 
-Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(/* [options,] callback */) {
+Organization.prototype.getDefaultAccountStoreMapping = function getDefaultAccountStoreMapping(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   if (!this.defaultAccountStoreMapping) {
@@ -39,7 +39,7 @@ Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(
   return this.dataStore.getResource(this.defaultAccountStoreMapping.href, args.options, OrganizationAccountStoreMapping, args.callback);
 };
 
-Organization.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [options,] callback */) {
+Organization.prototype.getDefaultGroupStoreMapping = function getDefaultGroupStoreMapping(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   if (!this.defaultGroupStoreMapping) {

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -57,6 +57,10 @@ Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(
       return args.callback(err);
     }
 
+    if (!organizationAccountStoreMapping) {
+      return args.callback(null, null);
+    }
+
     organizationAccountStoreMapping.getAccountStore(args.options, args.callback);
   });
 };
@@ -67,6 +71,10 @@ Organization.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [
   return this.getDefaultGroupStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
     if (err) {
       return args.callback(err);
+    }
+
+    if (!organizationAccountStoreMapping) {
+      return args.callback(null, null);
     }
 
     organizationAccountStoreMapping.getAccountStore(args.options, args.callback);

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -7,7 +7,6 @@ var Account = require('./Account');
 var CustomData = require('./CustomData');
 var IdSiteModel = require('./IdSiteModel');
 var OrganizationAccountStoreMapping = require('./OrganizationAccountStoreMapping');
-var Directory = require('./Directory');
 
 function Organization() {
   Organization.super_.apply(this, arguments);
@@ -52,27 +51,25 @@ Organization.prototype.getDefaultGroupStoreMapping = function getDefaultGroupSto
 
 Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
-  var dataStore = this.dataStore;
 
   return this.getDefaultAccountStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
     if (err) {
       return args.callback(err);
     }
 
-    dataStore.getResource(organizationAccountStoreMapping.accountStore.href, args.options, Directory, args.callback);
+    organizationAccountStoreMapping.getAccountStore(args.options, args.callback);
   });
 };
 
 Organization.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
-  var dataStore = this.dataStore;
 
   return this.getDefaultGroupStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
     if (err) {
       return args.callback(err);
     }
 
-    dataStore.getResource(organizationAccountStoreMapping.accountStore.href, args.options, Directory, args.callback);
+    organizationAccountStoreMapping.getAccountStore(args.options, args.callback);
   });
 };
 

--- a/test/sp.resource.organization_test.js
+++ b/test/sp.resource.organization_test.js
@@ -8,7 +8,7 @@ var Organization = require('../lib/resource/Organization');
 var sandbox = sinon.sandbox.create();
 
 /*jshint -W030 */
-describe.only('resource/Organization.js', function () {
+describe('resource/Organization.js', function () {
   afterEach(function () {
     sandbox.restore();
   });
@@ -380,6 +380,144 @@ describe.only('resource/Organization.js', function () {
         it('should return the value from the callback', function () {
           returnValue.should.equal(callbackReturn);
         });
+      });
+    });
+
+    describe('.getDefaultAccountStore(options, callback)', function () {
+      var returnValue;
+      var getDefaultAccountStoreMappingReturn;
+      var fakeAccountStoreMapping;
+
+      beforeEach(function () {
+        getDefaultAccountStoreMappingReturn = 'ce6869a2-fa0c-44fc-a2d4-684f20274184';
+
+        fakeAccountStoreMapping = {
+          accountStore: {
+            href: 'c5e16996-cd90-4f1f-8fbf-2eb61dd8a6e5'
+          }
+        };
+
+        sandbox.stub(organization, 'getDefaultAccountStoreMapping', function (options, callback) {
+          callback(null, fakeAccountStoreMapping);
+
+          return getDefaultAccountStoreMappingReturn;
+        });
+
+        returnValue = organization.getDefaultAccountStore(options, callbackSpy);
+      });
+
+      it('should pass the options to dataStore.getResource', function () {
+        getResourceStub.should.have.been.calledOnce;
+        getResourceStub.args[0][1].should.equal(options);
+      });
+
+      it('should pass the callback to dataStore.getResource', function () {
+        getResourceStub.args[0][3].should.equal(callbackSpy);
+      });
+
+      it('should return the value from getDefaultAccountStoreMapping()', function () {
+        returnValue.should.equal(getDefaultAccountStoreMappingReturn);
+      });
+    });
+
+    describe('.getDefaultAccountStore(callback)', function () {
+      var returnValue;
+      var getDefaultAccountStoreMappingReturn;
+      var fakeAccountStoreMapping;
+
+      beforeEach(function () {
+        getDefaultAccountStoreMappingReturn = 'd5f67a2e-322c-4202-8126-f6250c7013f9';
+
+        fakeAccountStoreMapping = {
+          accountStore: {
+            href: '06ffdca9-0384-4963-971c-1ec47ddbbbe0'
+          }
+        };
+
+        sandbox.stub(organization, 'getDefaultAccountStoreMapping', function (options, callback) {
+          callback(null, fakeAccountStoreMapping);
+
+          return getDefaultAccountStoreMappingReturn;
+        });
+
+        returnValue = organization.getDefaultAccountStore(callbackSpy);
+      });
+
+      it('should pass the callback to dataStore.getResource', function () {
+        getResourceStub.args[0][3].should.equal(callbackSpy);
+      });
+
+      it('should return the value from getDefaultAccountStoreMapping()', function () {
+        returnValue.should.equal(getDefaultAccountStoreMappingReturn);
+      });
+    });
+
+    describe('.getDefaultGroupStore(options, callback)', function () {
+      var returnValue;
+      var getDefaultGroupStoreMappingReturn;
+      var fakeGroupStoreMapping;
+
+      beforeEach(function () {
+        getDefaultGroupStoreMappingReturn = '1f38e9a1-3c7e-43c9-8cac-c44d396a7934';
+
+        fakeGroupStoreMapping = {
+          accountStore: {
+            href: '0871adfa-17ee-4a56-aded-d27f19879435'
+          }
+        };
+
+        sandbox.stub(organization, 'getDefaultGroupStoreMapping', function (options, callback) {
+          callback(null, fakeGroupStoreMapping);
+
+          return getDefaultGroupStoreMappingReturn;
+        });
+
+        returnValue = organization.getDefaultGroupStore(options, callbackSpy);
+      });
+
+      it('should pass the options to dataStore.getResource', function () {
+        getResourceStub.should.have.been.calledOnce;
+        getResourceStub.args[0][1].should.equal(options);
+      });
+
+      it('should pass the callback to dataStore.getResource', function () {
+        getResourceStub.args[0][3].should.equal(callbackSpy);
+      });
+
+      it('should return the value from getDefaultGroupStoreMapping()', function () {
+        returnValue.should.equal(getDefaultGroupStoreMappingReturn);
+      });
+    });
+
+    describe('.getDefaultGroupStore(callback)', function () {
+      var returnValue;
+      var getDefaultGroupStoreMappingReturn;
+      var fakeGroupStoreMapping;
+
+      beforeEach(function () {
+        getDefaultGroupStoreMappingReturn = '9ae8777b-551d-43ba-870a-f2d7f1e36494';
+
+        fakeGroupStoreMapping = {
+          accountStore: {
+            href: '687ed043-277b-482a-8cbb-8b72bc84b7a1'
+          }
+        };
+
+        sandbox.stub(organization, 'getDefaultGroupStoreMapping', function (options, callback) {
+          callback(null, fakeGroupStoreMapping);
+
+          return getDefaultGroupStoreMappingReturn;
+        });
+
+        returnValue = organization.getDefaultGroupStore(callbackSpy);
+      });
+
+      it('should pass the callback to dataStore.getResource', function () {
+        getResourceStub.args[0][3].should.equal(callbackSpy);
+      });
+
+      it('should return the value from getDefaultGroupStoreMapping()', function () {
+        returnValue.should.equal(getDefaultGroupStoreMappingReturn);
       });
     });
 

--- a/test/sp.resource.organization_test.js
+++ b/test/sp.resource.organization_test.js
@@ -387,18 +387,19 @@ describe('resource/Organization.js', function () {
       var returnValue;
       var getDefaultAccountStoreMappingReturn;
       var fakeAccountStoreMapping;
+      var fakeError;
 
       beforeEach(function () {
         getDefaultAccountStoreMappingReturn = 'ce6869a2-fa0c-44fc-a2d4-684f20274184';
 
         fakeAccountStoreMapping = {
-          accountStore: {
-            href: 'c5e16996-cd90-4f1f-8fbf-2eb61dd8a6e5'
-          }
+          getAccountStore: sandbox.spy()
         };
 
+        fakeError = null;
+
         sandbox.stub(organization, 'getDefaultAccountStoreMapping', function (options, callback) {
-          callback(null, fakeAccountStoreMapping);
+          callback(fakeError, fakeAccountStoreMapping);
 
           return getDefaultAccountStoreMappingReturn;
         });
@@ -406,17 +407,35 @@ describe('resource/Organization.js', function () {
         returnValue = organization.getDefaultAccountStore(options, callbackSpy);
       });
 
-      it('should pass the options to dataStore.getResource', function () {
-        getResourceStub.should.have.been.calledOnce;
-        getResourceStub.args[0][1].should.equal(options);
+      it('should pass the options to organizationAccountStoreMapping.getAccountStore()', function () {
+        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
+
+        accountStoreSpy.should.have.been.calledOnce;
+        accountStoreSpy.args[0][0].should.equal(options);
       });
 
-      it('should pass the callback to dataStore.getResource', function () {
-        getResourceStub.args[0][3].should.equal(callbackSpy);
+      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
+        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
+
+        accountStoreSpy.should.have.been.calledOnce;
+        accountStoreSpy.args[0][1].should.equal(callbackSpy);
       });
 
       it('should return the value from getDefaultAccountStoreMapping()', function () {
         returnValue.should.equal(getDefaultAccountStoreMappingReturn);
+      });
+
+      describe('when getDefaultAccountStoreMapping() returns an error', function () {
+        beforeEach(function () {
+          fakeError = '0bb3f89b-9f47-4b0a-9820-803e876932cd';
+
+          organization.getDefaultAccountStore(options, callbackSpy);
+        });
+
+        it('should invoke the callback with the error', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(fakeError);
+        });
       });
     });
 
@@ -424,50 +443,68 @@ describe('resource/Organization.js', function () {
       var returnValue;
       var getDefaultAccountStoreMappingReturn;
       var fakeAccountStoreMapping;
+      var fakeError;
 
       beforeEach(function () {
-        getDefaultAccountStoreMappingReturn = 'd5f67a2e-322c-4202-8126-f6250c7013f9';
+        getDefaultAccountStoreMappingReturn = '368f2329-e199-4020-b0e2-5fa00ffa2ad8';
 
         fakeAccountStoreMapping = {
-          accountStore: {
-            href: '06ffdca9-0384-4963-971c-1ec47ddbbbe0'
-          }
+          getAccountStore: sandbox.spy()
         };
 
+        fakeError = null;
+
         sandbox.stub(organization, 'getDefaultAccountStoreMapping', function (options, callback) {
-          callback(null, fakeAccountStoreMapping);
+          callback(fakeError, fakeAccountStoreMapping);
 
           return getDefaultAccountStoreMappingReturn;
         });
 
-        returnValue = organization.getDefaultAccountStore(callbackSpy);
+        returnValue = organization.getDefaultAccountStore(options, callbackSpy);
       });
 
-      it('should pass the callback to dataStore.getResource', function () {
-        getResourceStub.args[0][3].should.equal(callbackSpy);
+      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
+        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
+
+        accountStoreSpy.should.have.been.calledOnce;
+        accountStoreSpy.args[0][1].should.equal(callbackSpy);
       });
 
       it('should return the value from getDefaultAccountStoreMapping()', function () {
         returnValue.should.equal(getDefaultAccountStoreMappingReturn);
+      });
+
+      describe('when getDefaultAccountStoreMapping() returns an error', function () {
+        beforeEach(function () {
+          fakeError = 'f7ae7b90-5604-448f-b6da-9432a2c37117';
+
+          organization.getDefaultAccountStore(options, callbackSpy);
+        });
+
+        it('should invoke the callback with the error', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(fakeError);
+        });
       });
     });
 
     describe('.getDefaultGroupStore(options, callback)', function () {
       var returnValue;
       var getDefaultGroupStoreMappingReturn;
-      var fakeGroupStoreMapping;
+      var fakeAccountStoreMapping;
+      var fakeError;
 
       beforeEach(function () {
-        getDefaultGroupStoreMappingReturn = '1f38e9a1-3c7e-43c9-8cac-c44d396a7934';
+        getDefaultGroupStoreMappingReturn = '605430a2-7680-45aa-af6c-217cab68438f';
 
-        fakeGroupStoreMapping = {
-          accountStore: {
-            href: '0871adfa-17ee-4a56-aded-d27f19879435'
-          }
+        fakeAccountStoreMapping = {
+          getAccountStore: sandbox.spy()
         };
 
+        fakeError = null;
+
         sandbox.stub(organization, 'getDefaultGroupStoreMapping', function (options, callback) {
-          callback(null, fakeGroupStoreMapping);
+          callback(fakeError, fakeAccountStoreMapping);
 
           return getDefaultGroupStoreMappingReturn;
         });
@@ -475,36 +512,55 @@ describe('resource/Organization.js', function () {
         returnValue = organization.getDefaultGroupStore(options, callbackSpy);
       });
 
-      it('should pass the options to dataStore.getResource', function () {
-        getResourceStub.should.have.been.calledOnce;
-        getResourceStub.args[0][1].should.equal(options);
+      it('should pass the options to organizationAccountStoreMapping.getAccountStore()', function () {
+        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
+
+        accountStoreSpy.should.have.been.calledOnce;
+        accountStoreSpy.args[0][0].should.equal(options);
       });
 
-      it('should pass the callback to dataStore.getResource', function () {
-        getResourceStub.args[0][3].should.equal(callbackSpy);
+      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
+        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
+
+        accountStoreSpy.should.have.been.calledOnce;
+        accountStoreSpy.args[0][1].should.equal(callbackSpy);
       });
 
-      it('should return the value from getDefaultGroupStoreMapping()', function () {
+      it('should return the value from getDefaultAccountStoreMapping()', function () {
         returnValue.should.equal(getDefaultGroupStoreMappingReturn);
+      });
+
+      describe('when getDefaultGroupStoreMapping() returns an error', function () {
+        beforeEach(function () {
+          fakeError = 'd981c015-006f-4f9a-ad62-4d23ae60f36d';
+
+          organization.getDefaultGroupStore(options, callbackSpy);
+        });
+
+        it('should invoke the callback with the error', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(fakeError);
+        });
       });
     });
 
     describe('.getDefaultGroupStore(callback)', function () {
       var returnValue;
       var getDefaultGroupStoreMappingReturn;
-      var fakeGroupStoreMapping;
+      var fakeAccountStoreMapping;
+      var fakeError;
 
       beforeEach(function () {
-        getDefaultGroupStoreMappingReturn = '9ae8777b-551d-43ba-870a-f2d7f1e36494';
+        getDefaultGroupStoreMappingReturn = '88bdc0fe-8e85-4cd8-b3fe-a933c32a725f';
 
-        fakeGroupStoreMapping = {
-          accountStore: {
-            href: '687ed043-277b-482a-8cbb-8b72bc84b7a1'
-          }
+        fakeAccountStoreMapping = {
+          getAccountStore: sandbox.spy()
         };
 
+        fakeError = null;
+
         sandbox.stub(organization, 'getDefaultGroupStoreMapping', function (options, callback) {
-          callback(null, fakeGroupStoreMapping);
+          callback(fakeError, fakeAccountStoreMapping);
 
           return getDefaultGroupStoreMappingReturn;
         });
@@ -512,12 +568,28 @@ describe('resource/Organization.js', function () {
         returnValue = organization.getDefaultGroupStore(callbackSpy);
       });
 
-      it('should pass the callback to dataStore.getResource', function () {
-        getResourceStub.args[0][3].should.equal(callbackSpy);
+      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
+        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
+
+        accountStoreSpy.should.have.been.calledOnce;
+        accountStoreSpy.args[0][1].should.equal(callbackSpy);
       });
 
-      it('should return the value from getDefaultGroupStoreMapping()', function () {
+      it('should return the value from getDefaultAccountStoreMapping()', function () {
         returnValue.should.equal(getDefaultGroupStoreMappingReturn);
+      });
+
+      describe('when getDefaultGroupStoreMapping() returns an error', function () {
+        beforeEach(function () {
+          fakeError = 'f7796c82-97a7-46ff-8b89-39c08faa89e9';
+
+          organization.getDefaultGroupStore(callbackSpy);
+        });
+
+        it('should invoke the callback with the error', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(fakeError);
+        });
       });
     });
 

--- a/test/sp.resource.organization_test.js
+++ b/test/sp.resource.organization_test.js
@@ -8,7 +8,7 @@ var Organization = require('../lib/resource/Organization');
 var sandbox = sinon.sandbox.create();
 
 /*jshint -W030 */
-describe('resource/Organization.js', function () {
+describe.only('resource/Organization.js', function () {
   afterEach(function () {
     sandbox.restore();
   });
@@ -227,22 +227,22 @@ describe('resource/Organization.js', function () {
       });
     });
 
-    describe('.getDefaultAccountStore(options, callback)', function () {
+    describe('.getDefaultAccountStoreMapping(options, callback)', function () {
       it('should pass the options to dataStore.getResource', function () {
-        organization.getDefaultAccountStore(options, callbackSpy);
+        organization.getDefaultAccountStoreMapping(options, callbackSpy);
 
         getResourceStub.should.have.been.calledOnce;
         getResourceStub.args[0][1].should.equal(options);
       });
 
       it('should pass the callback to dataStore.getResource', function () {
-        organization.getDefaultAccountStore(options, callbackSpy);
+        organization.getDefaultAccountStoreMapping(options, callbackSpy);
 
         getResourceStub.args[0][3].should.equal(callbackSpy);
       });
 
       it('should return the value from dataStore.getResource', function () {
-        var returnValue = organization.getDefaultAccountStore(options, callbackSpy);
+        var returnValue = organization.getDefaultAccountStoreMapping(options, callbackSpy);
 
         returnValue.should.equal(getResourceReturn);
       });
@@ -252,7 +252,7 @@ describe('resource/Organization.js', function () {
 
         beforeEach(function () {
           organization.defaultAccountStoreMapping = undefined;
-          returnValue = organization.getDefaultAccountStore(options, callbackSpy);
+          returnValue = organization.getDefaultAccountStoreMapping(options, callbackSpy);
         });
 
         it('should invoke the callback', function () {
@@ -269,15 +269,15 @@ describe('resource/Organization.js', function () {
       });
     });
 
-    describe('.getDefaultAccountStore(callback)', function () {
+    describe('.getDefaultAccountStoreMapping(callback)', function () {
       it('should pass the callback to dataStore.getResource', function () {
-        organization.getDefaultAccountStore(callbackSpy);
+        organization.getDefaultAccountStoreMapping(callbackSpy);
 
         getResourceStub.args[0][3].should.equal(callbackSpy);
       });
 
       it('should return the value from dataStore.getResource', function () {
-        var returnValue = organization.getDefaultAccountStore(callbackSpy);
+        var returnValue = organization.getDefaultAccountStoreMapping(callbackSpy);
 
         returnValue.should.equal(getResourceReturn);
       });
@@ -289,7 +289,7 @@ describe('resource/Organization.js', function () {
           sandbox.restore();
 
           organization.defaultAccountStoreMapping = undefined;
-          returnValue = organization.getDefaultAccountStore(callbackSpy);
+          returnValue = organization.getDefaultAccountStoreMapping(callbackSpy);
         });
 
         it('should invoke the callback', function () {
@@ -306,22 +306,22 @@ describe('resource/Organization.js', function () {
       });
     });
 
-    describe('.getDefaultGroupStore(options, callback)', function () {
+    describe('.getDefaultGroupStoreMapping(options, callback)', function () {
       it('should pass the options to dataStore.getResource', function () {
-        organization.getDefaultGroupStore(options, callbackSpy);
+        organization.getDefaultGroupStoreMapping(options, callbackSpy);
 
         getResourceStub.should.have.been.calledOnce;
         getResourceStub.args[0][1].should.equal(options);
       });
 
       it('should pass the callback to dataStore.getResource', function () {
-        organization.getDefaultGroupStore(options, callbackSpy);
+        organization.getDefaultGroupStoreMapping(options, callbackSpy);
 
         getResourceStub.args[0][3].should.equal(callbackSpy);
       });
 
       it('should return the value from dataStore.getResource', function () {
-        var returnValue = organization.getDefaultGroupStore(options, callbackSpy);
+        var returnValue = organization.getDefaultGroupStoreMapping(options, callbackSpy);
 
         returnValue.should.equal(getResourceReturn);
       });
@@ -331,7 +331,7 @@ describe('resource/Organization.js', function () {
 
         beforeEach(function () {
           organization.defaultGroupStoreMapping = undefined;
-          returnValue = organization.getDefaultGroupStore(options, callbackSpy);
+          returnValue = organization.getDefaultGroupStoreMapping(options, callbackSpy);
         });
 
         it('should invoke the callback', function () {
@@ -348,15 +348,15 @@ describe('resource/Organization.js', function () {
       });
     });
 
-    describe('.getDefaultGroupStore(callback)', function () {
+    describe('.getDefaultGroupStoreMapping(callback)', function () {
       it('should pass the callback to dataStore.getResource', function () {
-        organization.getDefaultGroupStore(callbackSpy);
+        organization.getDefaultGroupStoreMapping(callbackSpy);
 
         getResourceStub.args[0][3].should.equal(callbackSpy);
       });
 
       it('should return the value from dataStore.getResource', function () {
-        var returnValue = organization.getDefaultGroupStore(callbackSpy);
+        var returnValue = organization.getDefaultGroupStoreMapping(callbackSpy);
 
         returnValue.should.equal(getResourceReturn);
       });
@@ -366,7 +366,7 @@ describe('resource/Organization.js', function () {
 
         beforeEach(function () {
           organization.defaultGroupStoreMapping = undefined;
-          returnValue = organization.getDefaultGroupStore(callbackSpy);
+          returnValue = organization.getDefaultGroupStoreMapping(callbackSpy);
         });
 
         it('should invoke the callback', function () {

--- a/test/sp.resource.organization_test.js
+++ b/test/sp.resource.organization_test.js
@@ -437,6 +437,19 @@ describe('resource/Organization.js', function () {
           callbackSpy.should.have.been.calledWithExactly(fakeError);
         });
       });
+
+      describe('when getDefaultAccountStoreMapping() returns null', function () {
+        beforeEach(function () {
+          fakeAccountStoreMapping = null;
+
+          organization.getDefaultAccountStore(options, callbackSpy);
+        });
+
+        it('should invoke the callback with null, null', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(null, null);
+        });
+      });
     });
 
     describe('.getDefaultAccountStore(callback)', function () {
@@ -484,6 +497,19 @@ describe('resource/Organization.js', function () {
         it('should invoke the callback with the error', function () {
           callbackSpy.should.have.been.calledOnce;
           callbackSpy.should.have.been.calledWithExactly(fakeError);
+        });
+      });
+
+      describe('when getDefaultAccountStoreMapping() returns null', function () {
+        beforeEach(function () {
+          fakeAccountStoreMapping = null;
+
+          organization.getDefaultAccountStore(callbackSpy);
+        });
+
+        it('should invoke the callback with null, null', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(null, null);
         });
       });
     });
@@ -542,6 +568,19 @@ describe('resource/Organization.js', function () {
           callbackSpy.should.have.been.calledWithExactly(fakeError);
         });
       });
+
+      describe('when getDefaultGroupStoreMapping() returns null', function () {
+        beforeEach(function () {
+          fakeAccountStoreMapping = null;
+
+          organization.getDefaultGroupStore(options, callbackSpy);
+        });
+
+        it('should invoke the callback with null, null', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(null, null);
+        });
+      });
     });
 
     describe('.getDefaultGroupStore(callback)', function () {
@@ -589,6 +628,19 @@ describe('resource/Organization.js', function () {
         it('should invoke the callback with the error', function () {
           callbackSpy.should.have.been.calledOnce;
           callbackSpy.should.have.been.calledWithExactly(fakeError);
+        });
+      });
+
+      describe('when getDefaultGroupStoreMapping() returns null', function () {
+        beforeEach(function () {
+          fakeAccountStoreMapping = null;
+
+          organization.getDefaultGroupStore(callbackSpy);
+        });
+
+        it('should invoke the callback with null, null', function () {
+          callbackSpy.should.have.been.calledOnce;
+          callbackSpy.should.have.been.calledWithExactly(null, null);
         });
       });
     });


### PR DESCRIPTION
This PR implements the comment from PR #340:

> * `Organization.getDefaultAccountStore()` and `Organization.getDefaultGroupStore()` will return the account store that is identified by the mapping.  When doing the first step of fetching the mapping, use the option to expand the account store.  This will get that resource cached locally, so that when you make the next request to get the account store, it will already be cached.
> * `Organization.getDefaultAccountStoreMapping()` and `Organization.getDefaultGroupStoreMapping()` need to be implemented and will return the account store mapping.  
> – @robertjd 

### How to verify

1. Checkout this branch
2. Create a new file called `org.js` in the root
3. Paste this content into the file:
  ```javascript
'use strict';

var stormpath = require('./lib');

var apiKey = new stormpath.ApiKey(
  '<KEY ID>',
  '<KEY SECRET>'
);

var client = new stormpath.Client({ apiKey: apiKey });
var organizationHref = 'https://api.stormpath.com/v1/organizations/<id>';

client.getOrganization(organizationHref, function(err, organization) {
  organization.getDefaultAccountStore(function (err, accountStore) {
    console.log('account store:', err, accountStore);
  });

  organization.getDefaultGroupStore(function (err, groupStore) {
    console.log('group store:', err, groupStore);
  });
});
```
4. Insert your own key id and secret
5. Also insert an *Organization* href
6. Run `node org.js`
7. Verify that the output is correct (should be the *Directories* that are the default account and group stores)