### PR TITLE
Fix: Handle thrown JWT errors

### DIFF
--- a/lib/jwt/jwt-authenticator.js
+++ b/lib/jwt/jwt-authenticator.js
@@ -36,39 +36,43 @@ JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){
 
   var secret = self.application.dataStore.requestExecutor.options.client.apiKey.secret;
 
-  njwt.verify(token,secret,function(err,jwt){
-    if(err){
-      err.statusCode = 401;
-      cb(err);
-    }else{
-      if(self.localValidation){
-        cb(null, new JwtAuthenticationResult(self.application,{
-          jwt: token,
-          expandedJwt: jwt,
-          localValidation: true,
-          account: {
-            href: jwt.body.sub
-          }
-        }));
-      }else if(jwt.header.kid){
-        // If the KID exists, this was issued by our API
-        var href = self.application.href + '/authTokens/' + token;
-        self.application.dataStore.getResource(href,function(err,response){
-          if(err){
-            cb(err);
-          }else{
-            cb(null, new JwtAuthenticationResult(self.application,response));
-          }
-        });
+  try {
+    njwt.verify(token,secret,function(err,jwt){
+      if(err){
+        err.statusCode = 401;
+        cb(err);
       }else{
+        if(self.localValidation){
+          cb(null, new JwtAuthenticationResult(self.application,{
+            jwt: token,
+            expandedJwt: jwt,
+            localValidation: true,
+            account: {
+              href: jwt.body.sub
+            }
+          }));
+        }else if(jwt.header.kid){
+          // If the KID exists, this was issued by our API
+          var href = self.application.href + '/authTokens/' + token;
+          self.application.dataStore.getResource(href,function(err,response){
+            if(err){
+              cb(err);
+            }else{
+              cb(null, new JwtAuthenticationResult(self.application,response));
+            }
+          });
+        }else{
 
-        // If there is no KID, this means it was
-        // issued by the SDK (not the API) so we have
-        // to do remote validation in a different way
-        throw new Error('not yet implemented - please use application.authenticateApiRequest() instead');
+          // If there is no KID, this means it was
+          // issued by the SDK (not the API) so we have
+          // to do remote validation in a different way
+          throw new Error('not yet implemented - please use application.authenticateApiRequest() instead');
+        }
       }
-    }
-  });
+    });
+  } catch (err) {
+    cb(err);
+  }
 
   return this;
 };

--- a/lib/oauth/refresh-grant.js
+++ b/lib/oauth/refresh-grant.js
@@ -37,7 +37,11 @@ OAuthRefreshTokenGrantAuthenticator.prototype.authenticate = function authentica
       if(err){
         return callback(err);
       }
-      callback(null,new OAuthRefreshTokenGrantAuthenticationResult(application,data));
+      try {
+        callback(null,new OAuthRefreshTokenGrantAuthenticationResult(application,data));
+      } catch (err) {
+        callback(err);
+      }
     });
   }
 };


### PR DESCRIPTION
Fixes an issue where `njwt.verify()` throws an error that isn't being handled, and therefore crashes the server.

##### How to verify
1. Checkout this branch.
2. Run `$ npm link` to make the `stormpath` module available for linking.
3. Checkout master in `express-stormpath`.
4. Run `$ npm link` to make the `express-stormpath` module available for linking.
5. Run `$ npm link stormpath` to link to the `stormpath` module with our patch.
6. Create an new Node.js server using [this gist](https://gist.github.com/typerandom/8e97e235aaeac1fae840) (in a new directory).
7. Run `$ npm link express-stormpath` to link to the `express-stormpath` module.
8. Start the server.
9. Once `Server listening on http://localhost:3000/` is shown, navigate to [http://localhost:3000/](http://localhost:3000/).
10. Refresh the page multiple times and assert that the messag "Invalid refresh token cookie set" is being shown.
11. Assert that the server is still running and that there are no console errors.

Fixes https://github.com/stormpath/express-stormpath/issues/275