### PR TITLE
Fixing the base URL option.

### DIFF
--- a/docs/app/views/client.md
+++ b/docs/app/views/client.md
@@ -89,6 +89,17 @@ var client = new stormpath.Client(options);
       <td>Options object that must have at least an <code>apiKey</code> field.</td>
     </tr>
     <tr>
+      <td><code>options.baseUrl</code></td>
+      <td><code>string</code></td>
+      <td>optional</td>
+      <td>
+        The base URL for the Stormpath API.  The default is
+        `https://api.stormpath.com/v1`.  Shared Enterprise Cloud customers
+        should use `https://enterprise.stormpath.io/v1`.  Private deployments
+        should use their custom base URL.
+      </td>
+    </tr>
+    <tr>
       <td><code>options.cacheOptions</code></td>
       <td><code>object</code></td>
       <td>optional</td>

--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -1,10 +1,10 @@
 'use strict';
 
 var os = require('os');
+var url = require('url');
 
 var request = require('request');
 
-var _ = require('../underscore');
 var ResourceError = require('../error/ResourceError');
 var authc = require('../authc');
 var packageJson = require('../../package.json');
@@ -35,18 +35,6 @@ function RequestExecutor(options) {
 }
 utils.inherits(RequestExecutor, Object);
 
-RequestExecutor.prototype.qualify = function qualify(uri){
-  if (!uri || _(uri).startsWith('http')) {
-    return uri;
-  }
-
-  if (_(uri).startsWith('/')) {
-    return this.baseUrl + uri;
-  }
-
-  return this.baseUrl + '/' + uri;
-};
-
 /**
  * Executes an HTTP request based on the request object passed in.  Request object properties:
  * <ul>
@@ -71,10 +59,11 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
   // Don't override the defaults: ensure that the options arg is request-specific.
   var options = utils.shallowCopy(this.options, {});
 
-  req.method = req.method || 'GET';
+  req.method = req.method || 'GET';
 
   options.method = req.method;
-  options.uri = this.qualify(req.uri);
+  options.baseUrl = this.baseUrl;
+  options.uri = url.parse(req.uri.replace(options.baseUrl,'')).path;
 
   if (req.query) {
     options.qs = req.query;


### PR DESCRIPTION
Previously, if you defined a custom base URL you would get an exception because the request library was being passed a `baseUrl` and a `uri`, both as fully-qualified URLs.  But it wants
the `uri` to be a relative path if the `baseUrl` is defined.

This commit fixes the problem, but always passing `uri` as a path, and doing a string replace on the passed `uri` to ensure that the base path is always set to the one that is configured by options.

IT tests are happy, small fixes for the usage of nock in our unit tests.