### PR TITLE
Set user agent header on every request

### DIFF
--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -26,9 +26,6 @@ function RequestExecutor(options) {
   this.requestAuthenticator = authc.getAuthenticator(options);
 
   options.headers = options.headers || {};
-
-  // Set the user agent appropriately.
-  options.headers['User-Agent'] = options.userAgent ? options.userAgent + ' ' + USER_AGENT_VALUE : USER_AGENT_VALUE;
   options.json = true;
 
   this.options = options;
@@ -64,6 +61,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
   options.method = req.method;
   options.baseUrl = this.baseUrl;
   options.uri = url.parse(req.uri.replace(options.baseUrl,'')).path;
+  options.headers['User-Agent'] = options.userAgent ? options.userAgent + ' ' + USER_AGENT_VALUE : USER_AGENT_VALUE;
 
   if (req.query) {
     options.qs = req.query;

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -41,10 +41,6 @@ describe('ds:', function () {
         it('should store options', function () {
           reqExec.options.client.apiKey.should.be.equal(apiKey);
         });
-        it('should set headers user agent as stormpath-sdk', function () {
-          reqExec.options.headers['User-Agent'].should
-            .match(/stormpath-sdk-node/i);
-        });
       });
 
     });
@@ -67,6 +63,23 @@ describe('ds:', function () {
 
       it('should throw if called without req.uri', function () {
         exec({}).should.throw(/request.uri field is required/i);
+      });
+
+      it('should call request with custom user agent', function (done) {
+        var uri = '/';
+        var res = {test: 'boom'};
+
+        var nockOptions = {
+          reqheaders: {
+            'User-Agent': function (headerValue) {
+              return (headerValue || '').match(/stormpath-sdk-node/i) !== null;
+            }
+          }
+        };
+
+        nock(mockHost, nockOptions).get(uri).reply(200, res);
+
+        reqExec.execute({uri: uri}, done);
       });
 
       it('should return response', function (done) {


### PR DESCRIPTION
Fixes so that the user agent is resolved/set on each request. This enables us to change the config and provide a different user agent in runtime.

#### How to verify

1. Checkout this branch.
2. Create a new test application using [this gist](https://gist.github.com/typerandom/de31c20ac1701ffc5a9e) that you link to this branch.
2. Set the `userAgent` config of `new stormpath.Client()` to something of e.g. `foo/1.2.3`.
3. Add a `console.log(options)` underneath line `64` in `lib/ds/RequestExecutor.js`.
4. Run the test application.
5. Assert that the `options.headers` object contains a `User-Agent` with the value that you've set.