### PR TITLE
Fix omitted Account.save() error

### DIFF
--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -78,8 +78,20 @@ Account.prototype.save = function saveAccount(){
     var lastArg = args.length > 0 ? args[args.length - 1] : null;
     var originalCallback = typeof lastArg === 'function' ? args.pop() : function nop() {};
 
-    args.push(function newCallback() {
-      self.dataStore._evict(self.customData.href, originalCallback);
+    args.push(function newCallback(err) {
+      var newCallbackArgs = arguments;
+
+      if (err) {
+        return originalCallback(err);
+      }
+
+      self.dataStore._evict(self.customData.href, function (err) {
+        if (err) {
+          return originalCallback(err);
+        }
+
+        originalCallback.apply(null, newCallbackArgs);
+      });
     });
   }
 

--- a/test/it/account_it.js
+++ b/test/it/account_it.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var assert = require('assert');
-
 var helpers = require('./helpers');
+var common = require('../common');
+
+var assert = common.assert;
 
 var AccessToken = require('../../lib/resource/AccessToken');
 var RefreshToken = require('../../lib/resource/RefreshToken');
@@ -64,6 +65,28 @@ describe('Account', function() {
           assert(collection.items[0] instanceof RefreshToken);
           done();
         }
+      });
+    });
+  });
+
+  describe('when save() is called', function () {
+    describe('with invalid data', function () {
+      var account;
+
+      beforeEach(function () {
+        account = fixture.account;
+      });
+
+      it('should return an error', function (done) {
+        account.password = '1';
+        account.save(function (err) {
+          assert.isNotNull(err);
+          assert.equal(err.name, 'ResourceError');
+          assert.equal(err.status, 400);
+          assert.equal(err.code, 2007);
+          assert.equal(err.userMessage, 'Account password minimum length not satisfied.');
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Fixes so that when Account.save() is called, the error from the underlying data store is forwarded to the original callback.

##### How to verify

1. First, verify that you are able to reproduce the steps in the #403 issue.
2. Checkout and link this branch.
3. Rerun the reproduce steps in #403.
4. Verify that the the text `Got error: Account password minimum length not satisfied.` is written to console.

Fixes #403.