### PR TITLE
Add ability to invalidate the cache of an InstanceResource

### DIFF
--- a/lib/resource/InstanceResource.js
+++ b/lib/resource/InstanceResource.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var async = require('async');
+
 var Resource = require('./Resource');
 var utils = require('../utils');
 
@@ -53,6 +55,53 @@ InstanceResource.prototype.save = function saveResource(callback) {
 
 InstanceResource.prototype.delete = function deleteResource(callback) {
   this.dataStore.deleteResource(this, callback);
+};
+
+InstanceResource.prototype.invalidateCache = function invalidateResource(callback) {
+  var self = this;
+
+  var tasks = [];
+  var visited = {};
+
+  function makeInvalidationTask(href) {
+    return function (itemCallback) {
+      // Swallow any errors. For cache invalidation those aren't that
+      // important and will also break the async.parallel() flow.
+      self.dataStore._evict(href, function () {
+        itemCallback();
+      });
+    };
+  }
+
+  function walkBuildInvalidationTasks(source) {
+    var rootHref = source.href;
+
+    if (rootHref in visited) {
+      return;
+    }
+
+    visited[rootHref] = null;
+    tasks.push(makeInvalidationTask(source.href));
+
+    for (var key in source) {
+      var item = source[key];
+
+      if (!item || !item.href) {
+        continue;
+      }
+
+      // Only walk child resources.
+      if (item.href.indexOf(rootHref) === 0) {
+        walkBuildInvalidationTasks(item);
+      }
+    }
+  }
+
+  if (this.href) {
+    walkBuildInvalidationTasks(this);
+  }
+
+  async.parallel(tasks, callback);
 };
 
 module.exports = InstanceResource;

--- a/lib/resource/InstanceResource.js
+++ b/lib/resource/InstanceResource.js
@@ -57,7 +57,7 @@ InstanceResource.prototype.delete = function deleteResource(callback) {
   this.dataStore.deleteResource(this, callback);
 };
 
-InstanceResource.prototype.invalidateCache = function invalidateResource(callback) {
+InstanceResource.prototype.invalidate = function invalidateResource(callback) {
   var self = this;
 
   var tasks = [];


### PR DESCRIPTION
Adds the method `InstanceResource.invalidateCache()` which invalidates the cache for the instance resource and all of its child HREFs.

#### How to verify

1. Checkout this branch.
2. Link it (`$ npm link`).
3. Checkout the branch of [this PR](https://github.com/stormpath/express-stormpath/pull/377).
4. Link it (`$ npm link`).
5. Link to this branch (`$ npm link stormpath`).
5. Checkout the [Stormpath React example project](https://github.com/stormpath/stormpath-express-react-example).
6. Link to the `express-stormpath` branch that we checked out (`$ npm link express-stormpath`).
7. Open up `server.js`.
8. Use the configuration from [this gist](https://gist.github.com/typerandom/85a0e908d08c49e96199).
9. Start the server (`$ npm start`).
10. Navigate to `/login`.
11. Login as an existing user.
12. Navigate to `/me`.
13. Verify that the custom data is loaded and looks as expected.
14. Open up the [Stormpath Console](https://api.stormpath.com/).
15. In the Stormpath Console, navigate to the account you just logged in with.
16. Add a new field to the custom data and set it to any value that you like (something recognizable).
17. Navigate to `/me`.
18. Verify that the custom data is the same as before you updated it in the Stormpath Console.
19. Click the logout link in the Stormpath React example app.
20. Navigate to `/login` and login as the same user as you did in step 11.
21. Navigate to `/me`.
22. Verify that the result consists with the custom data that you previoiusly set in the Stormpath Console (step 16).

Part solution of https://github.com/stormpath/express-stormpath/issues/278.