### PR TITLE
JwtAuthenticator can process client_credentials tokens

### DIFF
--- a/lib/jwt/jwt-authenticator.js
+++ b/lib/jwt/jwt-authenticator.js
@@ -2,6 +2,7 @@
 
 var njwt = require('njwt');
 
+var OauthAccessTokenAuthenticator = require('../authc/OauthAccessTokenAuthenticator');
 var ApiAuthRequestError = require('../error/ApiAuthRequestError');
 var JwtAuthenticationResult = require('./jwt-authentication-result');
 
@@ -66,7 +67,8 @@ JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){
           // If there is no KID, this means it was
           // issued by the SDK (not the API) so we have
           // to do remote validation in a different way
-          throw new Error('not yet implemented - please use application.authenticateApiRequest() instead');
+          var authenticator = new OauthAccessTokenAuthenticator(self.application, token);
+          authenticator.authenticate(cb);
         }
       }
     });


### PR DESCRIPTION
This is part of the fix for [express-stormpath/261](https://github.com/stormpath/express-stormpath/issues/261).  This will allow us to use the JwtAuthenticator as the underlying call for stormpath.authenticateApiRequest, for both access token types.