### PR TITLE
Fixing expand-home-dir reference [issue 421]

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "benchmark": "^2.0.0",
     "chai": "~3.5.0",
     "coveralls": "^2.11.4",
-    "expand-home-dir": "0.0.2",
+    "expand-home-dir": "^0.0.3",
     "fake-fs": "^0.5.0",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.13",


### PR DESCRIPTION
I have increased the version number to a valid entry for expand-home-dir, plus specified that the latest version from that version forward should be used in case the developer of that module does the same thing again (i.e. remove 0.0.3 when publishing 0.0.4).