### PR TITLE
Fix: local validation forced on client-credential tokens

### DIFF
--- a/lib/jwt/jwt-authenticator.js
+++ b/lib/jwt/jwt-authenticator.js
@@ -43,17 +43,20 @@ JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){
         err.statusCode = 401;
         cb(err);
       }else{
-        if(self.localValidation){
-          cb(null, new JwtAuthenticationResult(self.application,{
-            jwt: token,
-            expandedJwt: jwt,
-            localValidation: true,
-            account: {
-              href: jwt.body.sub
-            }
-          }));
-        }else if(jwt.header.kid){
-          // If the KID exists, this was issued by our API
+
+        // If the KID exists, this was issued by our API from a password grant
+
+        if(jwt.header.kid){
+          if(self.localValidation){
+            return cb(null, new JwtAuthenticationResult(self.application,{
+              jwt: token,
+              expandedJwt: jwt,
+              localValidation: true,
+              account: {
+                href: jwt.body.sub
+              }
+            }));
+          }
           var href = self.application.href + '/authTokens/' + token;
           self.application.dataStore.getResource(href,function(err,response){
             if(err){
@@ -64,9 +67,9 @@ JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){
           });
         }else{
 
-          // If there is no KID, this means it was
-          // issued by the SDK (not the API) so we have
-          // to do remote validation in a different way
+          // If there is no KID, this means it was issued by the SDK (not the
+          // API) from a client credentials grant so we have to do remote
+          // validation in a different way.
           var authenticator = new OauthAccessTokenAuthenticator(self.application, token);
           authenticator.authenticate(cb);
         }


### PR DESCRIPTION
New PR, #425 was against a not-pushed commit on master.

If local validation was specified for the JwtAuthenticator, it would also force the client-credential-based tokens through the JwtAuthenticationResult, which will cause an error with getAccount() because the href will be the API Key ID of the account, not the HREF of the account.