### PR TITLE
Don't cache created accounts

### DIFF
--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -231,7 +231,23 @@ Application.prototype.getAccount = function getAccount(/* providerData, [options
 
 Application.prototype.createAccount = function createApplicationAccount(/* account, [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['account', 'options', 'callback']);
-  return this.dataStore.createResource(this.accounts.href, args.options, args.account, require('./Account'), args.callback);
+  var dataStore = this.dataStore;
+
+  return dataStore.createResource(this.accounts.href, args.options, args.account, require('./Account'), function (err, createdAccount) {
+    var callbackArguments = arguments;
+
+    if (err) {
+      return args.callback(err);
+    }
+
+    dataStore._evict(createdAccount.href, function (err) {
+      if (err) {
+        return args.callback(err);
+      }
+
+      args.callback.apply(null, callbackArguments);
+    });
+  });
 };
 
 Application.prototype.getGroups = function getApplicationGroups(/* [options,] callback */) {

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -240,6 +240,10 @@ Application.prototype.createAccount = function createApplicationAccount(/* accou
       return args.callback(err);
     }
 
+    if (!createdAccount || !createdAccount.href) {
+      return args.callback.apply(null, callbackArguments);
+    }
+
     dataStore._evict(createdAccount.href, function (err) {
       if (err) {
         return args.callback(err);

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -743,10 +743,10 @@ describe('Resources: ', function () {
 
           // call without optional param
           createResourceStub.should.have.been
-            .calledWith(app.accounts.href, null, acc, Account, cbSpy);
+            .calledWith(app.accounts.href, null, acc, Account);
           // call with optional param
           createResourceStub.should.have.been
-            .calledWith(app.accounts.href, opt, acc, Account, cbSpy);
+            .calledWith(app.accounts.href, opt, acc, Account);
         });
       });
     });


### PR DESCRIPTION
This PR solves the problem with accounts still being unverified even though they actually were verified. The proposed solution is to not cache created accounts, and thus getting a fresh resource at login.

Fixes #433.

### Discussion

Is this the right way to go? We could be more specific and cache all accounts unless they're unverified.

### How to verify

1. Turn on Email Verification on your Application
2. Checkout `master`
3. Save this Gist as `test.js` in the root: https://gist.github.com/timothyej/29271aaf85fbb8c88346b76f7a230087
4. Replace `var stormpath = require('stormpath');` with `var stormpath = require('./lib');`
5. Run `node test.js`
6. Verify that the returned account has its status set to `UNVERIFIED`
7. Checkout this branch and run `node test.js` again
8. Verify that the account this time has its status set to `ENABLED`