### PR TITLE
Fix .save() named function in Group.js

### DIFF
--- a/lib/resource/Group.js
+++ b/lib/resource/Group.js
@@ -31,7 +31,7 @@ Group.prototype.getAccountMemberships = function getGroupAccountMemberships(/* [
   return this.dataStore.getResource(this.accountMemberships.href, args.options, require('./GroupMembership'), args.callback);
 };
 
-Group.prototype.save = function saveAccount(){
+Group.prototype.save = function saveGroup(){
   var self = this;
   var args = arguments;
   self._applyCustomDataUpdatesIfNecessary(function(){


### PR DESCRIPTION
Prototype function `group.save()` points to an incorrectly named `saveAccount` function.

This is trivial and only affects stack traces.