### PR TITLE
Fix organization.save() for custom data

### DIFF
--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -95,9 +95,7 @@ Account.prototype.save = function saveAccount(){
     });
   }
 
-  self._applyCustomDataUpdatesIfNecessary(function(){
-    Account.super_.prototype.save.apply(self, args);
-  });
+  Account.super_.prototype.save.apply(self, args);
 };
 
 module.exports = Account;

--- a/lib/resource/DirectoryChildResource.js
+++ b/lib/resource/DirectoryChildResource.js
@@ -8,22 +8,6 @@ function DirectoryChildResource() {
 }
 utils.inherits(DirectoryChildResource, InstanceResource);
 
-DirectoryChildResource.prototype._applyCustomDataUpdatesIfNecessary = function applyCustomDataUpdatesIfNecessary(cb){
-  if (!this.customData){
-    return cb();
-  }
-
-  if (this.customData._hasReservedFields()){
-    this.customData = this.customData._deleteReservedFields();
-  }
-
-  if (this.customData._hasRemovedProperties()){
-    return this.customData._deleteRemovedProperties(cb);
-  }
-
-  return cb();
-};
-
 DirectoryChildResource.prototype._createGroupMembership = function createGroupMembership(account, group, options, callback) {
   var href = '/groupMemberships';
 

--- a/lib/resource/Group.js
+++ b/lib/resource/Group.js
@@ -31,12 +31,4 @@ Group.prototype.getAccountMemberships = function getGroupAccountMemberships(/* [
   return this.dataStore.getResource(this.accountMemberships.href, args.options, require('./GroupMembership'), args.callback);
 };
 
-Group.prototype.save = function saveAccount(){
-  var self = this;
-  var args = arguments;
-  self._applyCustomDataUpdatesIfNecessary(function(){
-    Group.super_.prototype.save.apply(self, args);
-  });
-};
-
 module.exports = Group;

--- a/lib/resource/InstanceResource.js
+++ b/lib/resource/InstanceResource.js
@@ -49,8 +49,27 @@ InstanceResource.prototype.get = function getResource() {
   this.dataStore.getResource(val.href, query, ctor, callback);
 };
 
+InstanceResource.prototype._applyCustomDataUpdatesIfNecessary = function applyCustomDataUpdatesIfNecessary(cb){
+  if (!this.customData){
+    return cb();
+  }
+
+  if (this.customData._hasReservedFields()){
+    this.customData = this.customData._deleteReservedFields();
+  }
+
+  if (this.customData._hasRemovedProperties()){
+    return this.customData._deleteRemovedProperties(cb);
+  }
+
+  return cb();
+};
+
 InstanceResource.prototype.save = function saveResource(callback) {
-  this.dataStore.saveResource(this, callback);
+  var self = this;
+  self._applyCustomDataUpdatesIfNecessary(function () {
+    self.dataStore.saveResource(self, callback);
+  });
 };
 
 InstanceResource.prototype.delete = function deleteResource(callback) {

--- a/test/sp.resource.instanceResource_test.js
+++ b/test/sp.resource.instanceResource_test.js
@@ -165,6 +165,7 @@ describe('Resources: ', function () {
 
     describe('call to save()', function(){
       var sandbox, cb,  saveResourceSpy;
+
       before(function(){
         cb = function(){};
         sandbox = sinon.sandbox.create();
@@ -172,6 +173,7 @@ describe('Resources: ', function () {
 
         instanceResource.save(cb);
       });
+
       after(function(){
         sandbox.restore();
       });
@@ -181,6 +183,59 @@ describe('Resources: ', function () {
         saveResourceSpy.should.have.been.calledOnce;
         /* jshint +W030 */
         saveResourceSpy.should.have.been.calledWith(instanceResource, cb);
+      });
+
+      describe('with custom data', function () {
+        var hasReservedFieldsSpy;
+        var hasRemovedPropertiesSpy;
+        var deleteReservedFieldsSpy;
+        var deleteRemovedPropertiesSpy;
+
+        before(function () {
+          var customDataMock = {
+            _hasReservedFields: function () {},
+            _hasRemovedProperties: function () {},
+            _deleteReservedFields: function () {},
+            _deleteRemovedProperties: function () {}
+          };
+
+          hasReservedFieldsSpy = sandbox.stub(customDataMock, '_hasReservedFields').returns(true);
+          hasRemovedPropertiesSpy = sandbox.stub(customDataMock, '_hasRemovedProperties').returns(true);
+          deleteReservedFieldsSpy = sandbox.stub(customDataMock, '_deleteReservedFields').returns(customDataMock);
+          deleteRemovedPropertiesSpy = sandbox.stub(customDataMock, '_deleteRemovedProperties');
+
+          instanceResource.customData = customDataMock;
+          instanceResource.save();
+        });
+
+        after(function () {
+          delete instanceResource['customData'];
+          sandbox.restore();
+        });
+
+        it('should call customData._hasReservedFields()', function () {
+          /* jshint -W030 */
+          hasReservedFieldsSpy.should.have.been.calledOnce;
+          /* jshint +W030 */
+        });
+
+        it('should call customData._deleteReservedFields()', function () {
+          /* jshint -W030 */
+          hasReservedFieldsSpy.should.have.been.calledOnce;
+          /* jshint +W030 */
+        });
+
+        it('should call customData._hasRemovedProperties()', function () {
+          /* jshint -W030 */
+          hasRemovedPropertiesSpy.should.have.been.calledOnce;
+          /* jshint +W030 */
+        });
+
+        it('should call customData._deleteRemovedProperties()', function () {
+          /* jshint -W030 */
+          deleteRemovedPropertiesSpy.should.have.been.calledOnce;
+          /* jshint +W030 */
+        });
       });
     });
 


### PR DESCRIPTION
Fixes the issue where protected custom data fields weren't removed before saving the Organization.

#### How to verify

1. Create a new app using [this gist](https://gist.github.com/typerandom/376a13f3e7ddc40aeac9d3c1c110f5a9).
2. Test the app against the Node SDK's master branch.
3. Verify that you get the error described in #455.
2. Test the app against this branch (`fix-organization-custom-data-save`).
5. Verify that every thing works and the custom data for the specified organization is updated.

Fixes #455 