### PR TITLE
Fix issue when comparing config loaders of different node module versions

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2,7 +2,6 @@
 
 var async = require('async');
 var events = require('events');
-var stormpathConfig = require('stormpath-config');
 
 var utils = require('./utils');
 var DataStore = require('./ds/DataStore');
@@ -34,7 +33,7 @@ function Client(config) {
   var configLoader = null;
 
   // If the config is a config loader, then use that.
-  if (config instanceof stormpathConfig.Loader) {
+  if (utils.isConfigLoader(config)) {
     configLoader = config;
   // Just use our default client config loader.
   } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,6 +6,7 @@ var Buffer = require('buffer').Buffer;
 /* jshint +W079 */
 var util = require('util');
 
+var stormpathConfig = require('stormpath-config');
 var uuid = require('node-uuid');
 
 function shallowCopy(src, dest) {
@@ -17,6 +18,18 @@ function shallowCopy(src, dest) {
   }
 
   return dest;
+}
+
+function isConfigLoader(value) {
+  if (value instanceof stormpathConfig.Loader) {
+    return true;
+  }
+
+  if (value && value.constructor && value.constructor.name === 'ConfigLoader') {
+    return true;
+  }
+
+  return false;
 }
 
 function take(source, fromRight) {
@@ -181,6 +194,7 @@ function isNumber(val){
 }
 
 module.exports = {
+  isConfigLoader: isConfigLoader,
   resolveArgs: resolveArgs,
   nowEpochSeconds: nowEpochSeconds,
   inherits: util.inherits,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "properties-parser": "~0.3.1",
     "redis": "~2.5.1",
     "request": "~2.72.0",
-    "stormpath-config": "0.0.22",
+    "stormpath-config": "0.0.23",
     "underscore": "~1.5.2",
     "underscore.string": "~3.2.3"
   },


### PR DESCRIPTION
Fixes the issue where the module versions being used in the Express SDK and Stormpath Node SDK are out of sync and `stormpath-config` module versions differ.

##### How to verify

Will be added soon.

Fixes https://github.com/stormpath/express-stormpath/issues/467
Fixes https://github.com/stormpath/express-stormpath/issues/463