### PR TITLE
Add requestId and request context to resource errors

### DIFF
--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -84,7 +84,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
     }
 
     if (response.statusCode > 399) {
-      return callback(new ResourceError(body || {status:response.statusCode}), null);
+      return callback(new ResourceError(body || {status:response.statusCode}, {url: req.uri, method: req.method}), null);
     }
 
     if (response.statusCode === 201){

--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -77,6 +77,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
   this.requestAuthenticator.authenticate(options);
 
   request(options, function onRequestResult(err, response, body) {
+    var responseContext = this;
     if (err) {
       var wrapper = new Error('Unable to execute http request ' + req.method + ' ' + req.uri + ': ' + err.message);
       wrapper.inner = err;
@@ -84,7 +85,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
     }
 
     if (response.statusCode > 399) {
-      return callback(new ResourceError(body || {status:response.statusCode}, {url: req.uri, method: req.method}), null);
+      return callback(new ResourceError(body || {status:response.statusCode}, {url: responseContext.href, method: req.method}), null);
     }
 
     if (response.statusCode === 201){

--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -78,6 +78,7 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
 
   request(options, function onRequestResult(err, response, body) {
     var responseContext = this;
+
     if (err) {
       var wrapper = new Error('Unable to execute http request ' + req.method + ' ' + req.uri + ': ' + err.message);
       wrapper.inner = err;
@@ -97,8 +98,6 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
     }else{
       callback(null, body);
     }
-
-
   });
 };
 

--- a/lib/error/ResourceError.js
+++ b/lib/error/ResourceError.js
@@ -2,8 +2,10 @@
 
 var utils = require('./../utils');
 
-function ResourceError(responseBody) {
+function ResourceError(responseBody, requestData) {
   Error.captureStackTrace(this, this.constructor);
+
+  requestData = requestData || {};
 
   this.name = this.constructor.name;
   this.status = responseBody.status;
@@ -11,6 +13,9 @@ function ResourceError(responseBody) {
   this.userMessage = responseBody.message;
   this.developerMessage = responseBody.developerMessage;
   this.moreInfo = responseBody.moreInfo;
+  this.requestId = responseBody.requestId;
+  this.url = requestData.url;
+  this.method = requestData.method;
   this.stack = '';
 
   this.message = 'HTTP ' + this.status +

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -107,6 +107,7 @@ describe('ds:', function () {
           err.should.be.an.instanceof(ResourceError);
           expect(body).to.be.null;
           cbSpy.should.have.been.calledOnce;
+          expect(err.url).to.equal(mockHost + uri);
           done();
         }
         cbSpy = sinon.spy(cb);


### PR DESCRIPTION
Adding more information to our error objects.  The requestId is a new value that comes down on REST API responses.  The requested URL and method are generally useful for debugging.  I specifically chose URL (not URI) because we deal with canonical Stormpath resource URLs in this request executor.