### PR TITLE
keepalive

### DIFF
--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -74,6 +74,8 @@ RequestExecutor.prototype.execute = function executeRequest(req, callback) {
     options.json = true; // All Stormpath resources are JSON
   }
 
+  options.forever = true;
+
   this.requestAuthenticator.authenticate(options);
 
   request(options, function onRequestResult(err, response, body) {


### PR DESCRIPTION
Because we are performing a lot of handshaking and multiple SSL urls in my testing adding this option to keepalive the connection shaved 5 seconds off initial startup time.