### PR TITLE
Adding Browserify support

### DIFF
--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -9,6 +9,10 @@ var stormpathPath = '~/.stormpath';
 
 // Create a default client config loader.
 module.exports = function (extendWithConfig) {
+  // If in a browser, do the minimal to load config. Since this is only used in IAM-UI, 
+  // no need to validate. 
+  if(window) return new stormpathConfig.Loader([new strategy.ExtendConfigStrategy(extendWithConfig)])
+  
   return new stormpathConfig.Loader([
     // Load default configuration.
     new strategy.LoadFileConfigStrategy(path.join(__dirname, '/config.yml'), true),

--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -12,7 +12,7 @@ module.exports = function (extendWithConfig) {
   // If in a browser, do the minimal to load config. Since this is only used in IAM-UI, 
   // no need to validate. 
   /* jshint browser: true */
-  if(window) {
+  if(typeof(window) !== 'undefined') {
     return new stormpathConfig.Loader([new strategy.ExtendConfigStrategy(extendWithConfig)]);
   }
   

--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -11,7 +11,10 @@ var stormpathPath = '~/.stormpath';
 module.exports = function (extendWithConfig) {
   // If in a browser, do the minimal to load config. Since this is only used in IAM-UI, 
   // no need to validate. 
-  if(window) return new stormpathConfig.Loader([new strategy.ExtendConfigStrategy(extendWithConfig)])
+  /* jshint browser: true */
+  if(window) {
+    return new stormpathConfig.Loader([new strategy.ExtendConfigStrategy(extendWithConfig)]);
+  }
   
   return new stormpathConfig.Loader([
     // Load default configuration.


### PR DESCRIPTION
Fixes #529. 

Seems to actually work well, from my testing. The only thing *not* working, from what I can tell so far is the `/tenants/current` endpoint, but it looks like it's because the proxy isn't forwarding a needed header (since I can reproduce in Paw)