### PR TITLE
Add Client href error handling

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -5,6 +5,7 @@ var events = require('events');
 
 var utils = require('./utils');
 var DataStore = require('./ds/DataStore');
+var InvalidHrefError = require('./error/invalid-href');
 var ObjectCallProxy = require('./proxy/ObjectCallProxy');
 
 /**
@@ -304,7 +305,7 @@ Client.prototype.getAccessToken = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/accessTokens/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Access Token href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Access Token'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/AccessToken'), args.callback);
@@ -334,7 +335,7 @@ Client.prototype.getRefreshToken = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/refreshTokens/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Refresh Token href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Refresh Token'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/RefreshToken'), args.callback);
@@ -791,7 +792,7 @@ Client.prototype.getAccount = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/accounts/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Account href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Account'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/Account'), args.callback);
@@ -821,7 +822,7 @@ Client.prototype.getApplication = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/applications/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Application href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Application'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/Application'), args.callback);
@@ -851,7 +852,7 @@ Client.prototype.getDirectory = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/directories/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Directory href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Directory'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/Directory'), args.callback);
@@ -880,7 +881,7 @@ Client.prototype.getGroup = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/groups/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Group href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Group'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/Group'), args.callback);
@@ -909,7 +910,7 @@ Client.prototype.getGroupMembership = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/groupMemberships/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Group Memebership href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Group Membership'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/GroupMembership'), args.callback);
@@ -937,7 +938,7 @@ Client.prototype.getOrganization = function getOrganization() {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
 
   if (!utils.isValidHref(args.href, '/organizations/')) {
-    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Organization href.'));
+    return args.callback(new InvalidHrefError(args.href, 'Organization'));
   }
 
   return this.getResource(args.href, args.options, require('./resource/Organization'), args.callback);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -302,9 +302,13 @@ Client.prototype.on = function () {
  */
 Client.prototype.getAccessToken = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/accessTokens/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Access Token href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/AccessToken'), args.callback);
 };
-
 
 /**
  * Retrieves a {@link RefreshToken} resource.
@@ -328,6 +332,11 @@ Client.prototype.getAccessToken = function () {
  */
 Client.prototype.getRefreshToken = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/refreshTokens/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Refresh Token href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/RefreshToken'), args.callback);
 };
 
@@ -772,7 +781,7 @@ Client.prototype.createOrganization = function createOrganization() {
  *
  * @example
  *
- * var href = "https://api.stormpath.com/v1/getAccounts/4WCCtc0oCRDzQdAHVQTqjz";
+ * var href = "https://api.stormpath.com/v1/accounts/4WCCtc0oCRDzQdAHVQTqjz";
  *
  * client.getAccount(href, function (err, account) {
  *   console.log(account);
@@ -780,6 +789,11 @@ Client.prototype.createOrganization = function createOrganization() {
  */
 Client.prototype.getAccount = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/accounts/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Account href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/Account'), args.callback);
 };
 
@@ -805,6 +819,11 @@ Client.prototype.getAccount = function () {
  */
 Client.prototype.getApplication = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/applications/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Application href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/Application'), args.callback);
 };
 
@@ -830,6 +849,11 @@ Client.prototype.getApplication = function () {
  */
 Client.prototype.getDirectory = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/directories/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Directory href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/Directory'), args.callback);
 };
 
@@ -854,6 +878,11 @@ Client.prototype.getDirectory = function () {
  */
 Client.prototype.getGroup = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/groups/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Group href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/Group'), args.callback);
 };
 
@@ -878,9 +907,13 @@ Client.prototype.getGroup = function () {
  */
 Client.prototype.getGroupMembership = function () {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/groupMemberships/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Group Memebership href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/GroupMembership'), args.callback);
 };
-
 
 /**
  * Retrieves a {@link Organization} resource.
@@ -902,6 +935,11 @@ Client.prototype.getGroupMembership = function () {
  */
 Client.prototype.getOrganization = function getOrganization() {
   var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+
+  if (!utils.isValidHref(args.href, '/organizations/')) {
+    return args.callback(new Error('Argument \'href\' (' + args.href + ') is not a valid Organization href.'));
+  }
+
   return this.getResource(args.href, args.options, require('./resource/Organization'), args.callback);
 };
 

--- a/lib/ds/DataStore.js
+++ b/lib/ds/DataStore.js
@@ -291,10 +291,15 @@ DataStore.prototype.exec = function executeRequest(callback){
   var ctor = _this._request.InstanceCtor;
 
   function doRequest(){
-    _this.requestExecutor.execute(request, function onGetResourceRequestResult(err, body) {
-      _this._wrapGetResourceResponse(err, body, ctor, query, callback);
-    });
+    try {
+      _this.requestExecutor.execute(request, function onGetResourceRequestResult(err, body) {
+        _this._wrapGetResourceResponse(err, body, ctor, query, callback);
+      });
+    } catch (err) {
+      callback(err);
+    }
   }
+
   if (
     ( (Object.keys(query).length > 0 ) ||
       utils.isAssignableFrom(ctor,require('../resource/CollectionResource'))

--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -52,11 +52,16 @@ utils.inherits(RequestExecutor, Object);
  * Called with (networkErr, resourceResponseBody).
  */
 RequestExecutor.prototype.execute = function executeRequest(req, callback) {
-  if (!req) {
-    throw new Error('Request argument is required.');
+  if (!callback) {
+    throw new Error('Argument \'callback\' required. Unable to execute request.');
   }
+
+  if (!req) {
+    return callback(new Error('Request argument is required.'));
+  }
+
   if (!req.uri) {
-    throw new Error('request.uri field is required.');
+    return callback(new Error('request.uri field is required.'));
   }
 
   // Don't override the defaults: ensure that the options arg is request-specific.

--- a/lib/error/invalid-href.js
+++ b/lib/error/invalid-href.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Produces an Erorr object with a message that indicates which resource type has
+ * violated an href validation.
+ *
+ * @param      {string}  href          The href that was passed into a resource getter.
+ * @param      {string}  resourceName  The human readable name of the expected resource type.
+ * @return     {Error}   A simple error with the message
+ */
+function InvalidHrefError(href, resourceName){
+  var message = 'Argument \'href\' (' + href + ') is not a valid ' + resourceName +' href.';
+  return new Error(message);
+}
+
+module.exports = InvalidHrefError;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,6 +8,7 @@ var util = require('util');
 
 var stormpathConfig = require('stormpath-config');
 var uuid = require('node-uuid');
+var url = require('url');
 
 function shallowCopy(src, dest) {
 
@@ -201,6 +202,42 @@ function isNumber(val){
   return (typeof val === 'number') && numberRegExp.test(val,10);
 }
 
+function isValidHref(href, subPath) {
+  var path;
+
+  if (typeof href !== 'string') {
+    return false;
+  }
+
+  if (href.indexOf('/') === 0) {
+    path = href;
+  } else {
+    var parsedUrl;
+
+    try {
+      parsedUrl = url.parse(href);
+    } catch (err) {
+      return false;
+    }
+
+    if (!parsedUrl.protocol || !parsedUrl.host || !parsedUrl.path) {
+      return false;
+    }
+
+    if (parsedUrl.protocol.indexOf('http') !== 0) {
+      return false;
+    }
+
+    path = parsedUrl.path;
+  }
+
+  if (subPath && path.indexOf(subPath) === -1) {
+    return false;
+  }
+
+  return true;
+}
+
 module.exports = {
   isConfigLoader: isConfigLoader,
   resolveArgs: resolveArgs,
@@ -208,6 +245,7 @@ module.exports = {
   inherits: util.inherits,
   isAssignableFrom: isAssignableFrom,
   isCollectionData: isCollectionData,
+  isValidHref: isValidHref,
   shallowCopy: shallowCopy,
   valueOf: valueOf,
   isNumber: isNumber,

--- a/test/it/client_it.js
+++ b/test/it/client_it.js
@@ -154,7 +154,7 @@ describe('Client', function() {
     });
     it('should handle errors',function(done){
       client.getOrganization('bad href',function(err){
-        assert(err.status === 404);
+        assert(err.message === 'Argument \'href\' (bad href) is not a valid Organization href.');
         done();
       });
     });

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -800,7 +800,9 @@ describe('Client', function () {
     before(function (done) {
       sandbox = sinon.sandbox.create();
       cbSpy = sandbox.spy();
-      opt = {};href = '/boom!';
+      opt = {};
+      href = 'http://boom!/accounts/';
+
       client = makeTestClient({apiKey: apiKey});
 
       client.on('error', function (err) {
@@ -844,7 +846,8 @@ describe('Client', function () {
     before(function (done) {
       sandbox = sinon.sandbox.create();
       cbSpy = sandbox.spy();
-      opt = {};href = '/boom!';
+      opt = {};
+      href = 'http://boom!/applications/';
       client = makeTestClient({apiKey: apiKey});
 
       client.on('error', function (err) {
@@ -890,7 +893,7 @@ describe('Client', function () {
     before(function (done) {
       sandbox = sinon.sandbox.create();
       cbSpy = sandbox.spy();
-      opt = {};href = '/boom!';
+      opt = {};href = 'http://boom!/directories/';
       client = makeTestClient({apiKey: apiKey});
 
       client.on('error', function (err) {
@@ -936,7 +939,7 @@ describe('Client', function () {
     before(function (done) {
       sandbox = sinon.sandbox.create();
       cbSpy = sandbox.spy();
-      opt = {};href = '/boom!';
+      opt = {};href = 'http://boom!/groups/';
       client = makeTestClient({apiKey: apiKey});
 
       client.on('error', function (err) {
@@ -981,7 +984,7 @@ describe('Client', function () {
     before(function (done) {
       sandbox = sinon.sandbox.create();
       cbSpy = sandbox.spy();
-      opt = {};href = '/boom!';
+      opt = {};href = 'http://boom!/groupMemberships/';
 
       client = makeTestClient({apiKey: apiKey});
 

--- a/test/sp.ds.requestExecutor_test.js
+++ b/test/sp.ds.requestExecutor_test.js
@@ -47,22 +47,29 @@ describe('ds:', function () {
     describe('call to execute', function () {
       var reqExec;
       var mockHost = 'http://example.com';
-      function exec(req, cb) {
-        return function () {
-          reqExec.execute(req, cb);
-        };
-      }
 
       before(function () {
         reqExec = new RequestExecutor({client: {apiKey: apiKey}, baseUrl: mockHost });
       });
 
-      it('should throw if called without req', function () {
-        exec().should.throw(/Request argument is required/i);
+      it('should throw if called without callback', function () {
+        reqExec.execute.should.throw('Argument \'callback\' required. Unable to execute request.');
       });
 
-      it('should throw if called without req.uri', function () {
-        exec({}).should.throw(/request.uri field is required/i);
+      it('should return error if called without req', function (done) {
+        reqExec.execute(null, function (err) {
+          expect(err).to.exist;
+          expect(err.message).to.equal('Request argument is required.');
+          done();
+        });
+      });
+
+      it('should return error if called without req.uri', function (done) {
+        reqExec.execute({}, function (err) {
+          expect(err).to.exist;
+          expect(err.message).to.equal('request.uri field is required.');
+          done();
+        });
       });
 
       it('should call request with custom user agent', function (done) {


### PR DESCRIPTION
Improves the Client prototype by validating methods requiring a href to be a valid href.

#### How to verify

Using the code below and the `master` branch, verify that you receive the verbose `request.uri field is required` error as seen in issue #516. Then using the `add-client-error-handling` branch, use the same code and verify that you receive the error `Argument 'href' (undefined) is not a valid Application href`. If `STORMPATH_APPLICATION_HREF` is set in your environment, then simply set the variable `applicationHref` to `undefined` to replicate the error.

```javascript
var stormpath = require('stormpath');

var apiKey = new stormpath.ApiKey(
  process.env['STORMPATH_CLIENT_APIKEY_ID'],
  process.env['STORMPATH_CLIENT_APIKEY_SECRET']
);

var client = new stormpath.Client({
  apiKey: apiKey
});

var applicationHref = process.env['STORMPATH_APPLICATION_HREF'];

client.getApplication(applicationHref, function(err, application) {
  if (err) {
    return console.error(err);
  }

  console.log('Got application!', application);
});
```

**Note:** The code above is the same that you end up with when you go through the Node.js quickstart in the [Stormpath console](https://api.stormpath.com/ui2/index.html#/quickstart/none/nodejs/backend/project-type/existing).

#### Discussion

As you can see in the code I've added some sanity checking on the hrefs being provided. E.g. a call to `getApplication()` must now provide a href which is a valid URI and has a path containing `/applications/`. The question I'm wondering is, what do you think of this, and are there cases (resources) where we don't want to be so strict about the URI being passed?

Fixes #516