### PR TITLE
Add Client.getIdSites()

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -962,7 +962,7 @@ Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
       return args.callback(err, null);
     }
 
-    return tenant.getIdSiteModels(args.options, args.callback);
+    return tenant.getIdSites(args.options, args.callback);
   });
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -947,7 +947,7 @@ Client.prototype.getOrganizations = function getOrganizations(/* [options,] call
  * be a list of {@link IdSiteModel} objects.
  *
  * @example
- * client.getIdSite(function (err, idSiteModels) {
+ * client.getIdSites(function (err, idSiteModels) {
  *   idSiteModels.each(function (idSiteModel, next) {
  *     console.log(idSiteModel);
  *     next();

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -5,6 +5,7 @@ var events = require('events');
 
 var utils = require('./utils');
 var DataStore = require('./ds/DataStore');
+var IdSiteModel = require('./IdSiteModel');
 var ObjectCallProxy = require('./proxy/ObjectCallProxy');
 
 /**
@@ -933,6 +934,11 @@ Client.prototype.getOrganizations = function getOrganizations(/* [options,] call
     }
     return tenant.getOrganizations(args.options, args.callback);
   });
+};
+
+Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.idSiteModel.href, args.options, IdSiteModel, args.callback);
 };
 
 module.exports = Client;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -957,7 +957,7 @@ Client.prototype.getOrganizations = function getOrganizations(/* [options,] call
 Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
-  return this.getCurrentTenant(function onGetCurrentTenantForGroups(err, tenant) {
+  return this.getCurrentTenant(function onGetCurrentTenant(err, tenant) {
     if (err) {
       return args.callback(err, null);
     }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -935,6 +935,25 @@ Client.prototype.getOrganizations = function getOrganizations(/* [options,] call
   });
 };
 
+/**
+ * Retrieves all the {@link IdSiteModel} resources for the current {@link Tenant}.
+ *
+ * @param {CollectionQueryOptions} [collectionQueryOptions]
+ * Options for querying, paginating, and expanding the collection.
+ *
+ * @param {Function} callback
+ * The function to call when then the operation is complete. Will be called
+ * with the parameters (err, {@link CollectionResource}). The collection will
+ * be a list of {@link IdSiteModel} objects.
+ *
+ * @example
+ * client.getIdSite(function (err, idSiteModels) {
+ *   idSiteModels.each(function (idSiteModel, next) {
+ *     console.log(idSiteModel);
+ *     next();
+ *   })
+ * });
+ */
 Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
@@ -943,7 +962,7 @@ Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
       return args.callback(err, null);
     }
 
-    return tenant.getIdSites(args.options, args.callback);
+    return tenant.getIdSiteModels(args.options, args.callback);
   });
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -5,7 +5,6 @@ var events = require('events');
 
 var utils = require('./utils');
 var DataStore = require('./ds/DataStore');
-var IdSiteModel = require('./IdSiteModel');
 var ObjectCallProxy = require('./proxy/ObjectCallProxy');
 
 /**
@@ -938,7 +937,14 @@ Client.prototype.getOrganizations = function getOrganizations(/* [options,] call
 
 Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
-  return this.dataStore.getResource(this.idSiteModel.href, args.options, IdSiteModel, args.callback);
+
+  return this.getCurrentTenant(function onGetCurrentTenantForGroups(err, tenant) {
+    if (err) {
+      return args.callback(err, null);
+    }
+
+    return tenant.getIdSites(args.options, args.callback);
+  });
 };
 
 module.exports = Client;

--- a/lib/resource/IdSiteModel.js
+++ b/lib/resource/IdSiteModel.js
@@ -12,7 +12,7 @@ var InstanceResource = require('./InstanceResource');
  *
  * This class should not be manually constructed. It should be obtained from one of these methods:
  * - {@link Organization#getIdSiteModel Organization.getIdSiteModel()}
- * - {@link Tenant#getIdSiteModels Tenant.getIdSiteModels()}
+ * - {@link Tenant#getIdSites Tenant.getIdSites()}
  *
  * @augments {InstanceResource}
  *

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -220,10 +220,21 @@ Tenant.prototype.getCustomData = function getCustomData(/* [options,] callback *
   return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
-// TODO comment me
-Tenant.prototype.getIdSites = function getTenantIdSites(/* [options,] callback */) {
+/**
+ * Retrieves all the {@link IdSiteModel} resources for this resource.
+ *
+ * @param {CollectionQueryOptions} [collectionQueryOptions]
+ * Options for querying, paginating, and expanding the collection.
+ *
+ * @param {Function} callback
+ * The function to call when then the operation is complete. Will be called
+ * with the parameters (err, {@link CollectionResource}). The collection will
+ * be a list of {@link IdSiteModel} objects.
+ *
+ */
+Tenant.prototype.getIdSiteModels = function getTenantIdSiteModels(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
-  return this.dataStore.getResource(this.customData.href, args.options, require('./IdSiteModel'), args.callback);
+  return this.dataStore.getResource(this.idSites.href, args.options, require('./IdSiteModel'), args.callback);
 };
 
 module.exports = Tenant;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -220,4 +220,10 @@ Tenant.prototype.getCustomData = function getCustomData(/* [options,] callback *
   return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
+// TODO comment me
+Tenant.prototype.getIdSites = function getTenantIdSites(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.customData.href, args.options, require('./IdSiteModel'), args.callback);
+};
+
 module.exports = Tenant;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -232,7 +232,7 @@ Tenant.prototype.getCustomData = function getCustomData(/* [options,] callback *
  * be a list of {@link IdSiteModel} objects.
  *
  */
-Tenant.prototype.getIdSiteModels = function getTenantIdSiteModels(/* [options,] callback */) {
+Tenant.prototype.getIdSites = function getTenantIdSites(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
   return this.dataStore.getResource(this.idSites.href, args.options, require('./IdSiteModel'), args.callback);
 };

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -9,6 +9,7 @@ var Client = require('../lib/Client');
 var Account = require('../lib/resource/Account');
 var Group = require('../lib/resource/Group');
 var GroupMembership = require('../lib/resource/GroupMembership');
+var IdSiteModel = require('../lib/resource/IdSiteModel');
 var Directory = require('../lib/resource/Directory');
 var Tenant = require('../lib/resource/Tenant');
 var Application = require('../lib/resource/Application');
@@ -1018,6 +1019,52 @@ describe('Client', function () {
       // call with optional param
       getResourceStub.should.have.been
         .calledWith(href, opt, GroupMembership, cbSpy);
+    });
+  });
+
+  describe('call to get id sites', function () {
+    var sandbox, client, getResourceStub, cbSpy, href, opt;
+    before(function (done) {
+      sandbox = sinon.sandbox.create();
+      cbSpy = sandbox.spy();
+      opt = {};
+      href = '/boom!';
+
+      client = makeTestClient({apiKey: apiKey});
+
+      client.on('error', function (err) {
+        throw err;
+      });
+
+      client.on('ready', function () {
+        getResourceStub = sandbox.stub(client._dataStore, 'getResource', function (href, options, ctor, cb) {
+          cb();
+        });
+
+        // call without optional param
+        client.getIdSites(href, cbSpy);
+        // call with optional param
+        client.getIdSites(href, opt, cbSpy);
+
+        done();
+      });
+    });
+    after(function () {
+      sandbox.restore();
+    });
+
+    it('should get group', function () {
+      /* jshint -W030 */
+      getResourceStub.should.have.been.calledTwice;
+      cbSpy.should.have.been.calledTwice;
+      /* jshint +W030 */
+
+      // call without optional param
+      getResourceStub.should.have.been
+        .calledWith(href, null, IdSiteModel, cbSpy);
+      // call with optional param
+      getResourceStub.should.have.been
+        .calledWith(href, opt, IdSiteModel, cbSpy);
     });
   });
 });

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -9,7 +9,6 @@ var Client = require('../lib/Client');
 var Account = require('../lib/resource/Account');
 var Group = require('../lib/resource/Group');
 var GroupMembership = require('../lib/resource/GroupMembership');
-var IdSiteModel = require('../lib/resource/IdSiteModel');
 var Directory = require('../lib/resource/Directory');
 var Tenant = require('../lib/resource/Tenant');
 var Application = require('../lib/resource/Application');
@@ -1024,7 +1023,7 @@ describe('Client', function () {
 
   describe('call to get id sites', function () {
     var sandbox, cbSpy, err, app, client, tenant, getCurrentTenantStub,
-        getTennantIdSites, returnError;
+        getTennantIdSiteModels, returnError;
 
     before(function (done) {
       sandbox = sinon.sandbox.create();
@@ -1048,7 +1047,7 @@ describe('Client', function () {
           cb(null, tenant);
         });
 
-        getTennantIdSites = sandbox.stub(tenant, 'getIdSites', function(options, cb) {
+        getTennantIdSiteModels = sandbox.stub(tenant, 'getIdSiteModels', function(options, cb) {
           cb();
         });
 
@@ -1065,12 +1064,12 @@ describe('Client', function () {
       client.getIdSites(cbSpy);
       client.getIdSites({}, cbSpy);
 
-      getTennantIdSites.should.have.been.calledWith(null, cbSpy);
-      getTennantIdSites.should.have.been.calledWith({}, cbSpy);
+      getTennantIdSiteModels.should.have.been.calledWith(null, cbSpy);
+      getTennantIdSiteModels.should.have.been.calledWith({}, cbSpy);
 
       /* jshint -W030 */
       getCurrentTenantStub.should.have.been.calledTwice;
-      getTennantIdSites.should.have.been.calledTwice;
+      getTennantIdSiteModels.should.have.been.calledTwice;
       /* jshint +W030 */
     });
 
@@ -1080,7 +1079,7 @@ describe('Client', function () {
       cbSpy.should.have.been.calledWith(err);
       /* jshint -W030 */
       getCurrentTenantStub.should.have.been.calledThrice;
-      getTennantIdSites.should.have.been.calledTwice;
+      getTennantIdSiteModels.should.have.been.calledTwice;
       /* jshint +W030 */
     });
   });

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -1023,7 +1023,7 @@ describe('Client', function () {
 
   describe('call to get id sites', function () {
     var sandbox, cbSpy, err, app, client, tenant, getCurrentTenantStub,
-        getTennantIdSiteModels, returnError;
+        getTennantIdSites, returnError;
 
     before(function (done) {
       sandbox = sinon.sandbox.create();
@@ -1047,7 +1047,7 @@ describe('Client', function () {
           cb(null, tenant);
         });
 
-        getTennantIdSiteModels = sandbox.stub(tenant, 'getIdSiteModels', function(options, cb) {
+        getTennantIdSites = sandbox.stub(tenant, 'getIdSites', function(options, cb) {
           cb();
         });
 
@@ -1064,12 +1064,12 @@ describe('Client', function () {
       client.getIdSites(cbSpy);
       client.getIdSites({}, cbSpy);
 
-      getTennantIdSiteModels.should.have.been.calledWith(null, cbSpy);
-      getTennantIdSiteModels.should.have.been.calledWith({}, cbSpy);
+      getTennantIdSites.should.have.been.calledWith(null, cbSpy);
+      getTennantIdSites.should.have.been.calledWith({}, cbSpy);
 
       /* jshint -W030 */
       getCurrentTenantStub.should.have.been.calledTwice;
-      getTennantIdSiteModels.should.have.been.calledTwice;
+      getTennantIdSites.should.have.been.calledTwice;
       /* jshint +W030 */
     });
 
@@ -1079,7 +1079,7 @@ describe('Client', function () {
       cbSpy.should.have.been.calledWith(err);
       /* jshint -W030 */
       getCurrentTenantStub.should.have.been.calledThrice;
-      getTennantIdSiteModels.should.have.been.calledTwice;
+      getTennantIdSites.should.have.been.calledTwice;
       /* jshint +W030 */
     });
   });

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -1023,7 +1023,7 @@ describe('Client', function () {
 
   describe('call to get id sites', function () {
     var sandbox, cbSpy, err, app, client, tenant, getCurrentTenantStub,
-        getTennantIdSites, returnError;
+        getTenantIdSites, returnError;
 
     before(function (done) {
       sandbox = sinon.sandbox.create();
@@ -1047,7 +1047,7 @@ describe('Client', function () {
           cb(null, tenant);
         });
 
-        getTennantIdSites = sandbox.stub(tenant, 'getIdSites', function(options, cb) {
+        getTenantIdSites = sandbox.stub(tenant, 'getIdSites', function(options, cb) {
           cb();
         });
 
@@ -1064,12 +1064,12 @@ describe('Client', function () {
       client.getIdSites(cbSpy);
       client.getIdSites({}, cbSpy);
 
-      getTennantIdSites.should.have.been.calledWith(null, cbSpy);
-      getTennantIdSites.should.have.been.calledWith({}, cbSpy);
+      getTenantIdSites.should.have.been.calledWith(null, cbSpy);
+      getTenantIdSites.should.have.been.calledWith({}, cbSpy);
 
       /* jshint -W030 */
       getCurrentTenantStub.should.have.been.calledTwice;
-      getTennantIdSites.should.have.been.calledTwice;
+      getTenantIdSites.should.have.been.calledTwice;
       /* jshint +W030 */
     });
 
@@ -1079,7 +1079,7 @@ describe('Client', function () {
       cbSpy.should.have.been.calledWith(err);
       /* jshint -W030 */
       getCurrentTenantStub.should.have.been.calledThrice;
-      getTennantIdSites.should.have.been.calledTwice;
+      getTenantIdSites.should.have.been.calledTwice;
       /* jshint +W030 */
     });
   });

--- a/test/sp.resource.tenant_test.js
+++ b/test/sp.resource.tenant_test.js
@@ -7,6 +7,7 @@ var Account = require('../lib/resource/Account');
 var Tenant = require('../lib/resource/Tenant');
 var Application = require('../lib/resource/Application');
 var Directory = require('../lib/resource/Directory');
+var IdSiteModel = require('../lib/resource/IdSiteModel');
 var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
@@ -262,6 +263,45 @@ describe('Resources: ', function () {
           assert.notEqual(tenantResult[0],null);
           assert.equal(tenantResult[1],null);
         });
+      });
+    });
+
+    describe('call to get id sites', function () {
+      var sandbox, tenant, getResourceStub, opts, cbSpy;
+
+      before(function () {
+        sandbox = sinon.sandbox.create();
+
+        opts = {};
+
+        tenant = new Tenant({
+          idSites: {
+            href: 'boom!'
+          }
+        }, dataStore);
+
+        getResourceStub = sandbox.stub(dataStore, 'getResource', function (href, options, ctor, cb) {
+          cb();
+        });
+
+        cbSpy = sandbox.spy();
+
+        tenant.getIdSiteModels(opts, cbSpy);
+        tenant.getIdSiteModels(cbSpy);
+      });
+
+      after(function () {
+        sandbox.restore();
+      });
+
+      it('should process calls with and without params correctly', function () {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        getResourceStub.should.have.been.calledWith('boom!', null, IdSiteModel, cbSpy);
+        getResourceStub.should.have.been.calledWith('boom!', opts, IdSiteModel, cbSpy);
       });
     });
   });

--- a/test/sp.resource.tenant_test.js
+++ b/test/sp.resource.tenant_test.js
@@ -286,8 +286,8 @@ describe('Resources: ', function () {
 
         cbSpy = sandbox.spy();
 
-        tenant.getIdSiteModels(opts, cbSpy);
-        tenant.getIdSiteModels(cbSpy);
+        tenant.getIdSites(opts, cbSpy);
+        tenant.getIdSites(cbSpy);
       });
 
       after(function () {


### PR DESCRIPTION
Add support for getting a list of Tenant's Id Sites, as well as a helper directly on `Client`, as well as tests for these features.

Usage example:
```
var stormpath = require('stormpath');

var client = new stormpath.Client();

function doneCallback(err, idSites) {
   if (!err) {
      console.log('Loaded ID sites for tenant');
   }
}

function idSitePrintIterator(idSite, next) {
  console.log('Loaded ID site with href:', idSite.href);
  next();
}

function onGetIdSites(err, idSites) {
  if (err) {
    return console.log('Error:', err);
  }

  idSites.each(idSitePrintIterator, doneCallback);
}

client.getIdSites(onGetIdSites);
```

Fixes #424 

Count not drag the card as I am not a collaborator.