### PR TITLE
Add ApiKey.getAccount() method

### DIFF
--- a/lib/resource/ApiKey.js
+++ b/lib/resource/ApiKey.js
@@ -6,37 +6,38 @@ var InstanceResource = require('./InstanceResource');
 var utils = require('../utils');
 
 /**
-* @class ApiKey
-*
-* @extends {InstanceResource}
-*
-* @description
-*
-* Encapsulates an Api Key resource of an {@link Account}. For full
-* documentation of this resource, please see
-* [REST API Reference: Account API Keys](https://docs.stormpath.com/rest/product-guide/latest/reference.html?#account-api-keys).
-*
-* These keys can be used to authenticate requests to your web framework.
-* For a high-level overview of this feature, please read [Using Stormpath for
-* API Authentication](https://docs.stormpath.com/guides/api-key-management). If
-* you are using [Express-Stormath](http://docs.stormpath.com/nodejs/express/latest),
-* please read the [Authentication Section](http://docs.stormpath.com/nodejs/express/latest/authentication.html).
-*
-* This class should not be manually constructed. It should be obtained from one
-* of these methods:
-*
-* - {@link Account#getApiKeys Account.getApiKeys()}
-* - {@link Application#getApiKey Application.getApiKey()}
-*
-* @param {Object} apiKeyResource
-*
-* The JSON representation of this resource, retrieved the Stormpath REST API.
-*/
+ * @class ApiKey
+ *
+ * @extends {InstanceResource}
+ *
+ * @description
+ *
+ * Encapsulates an Api Key resource of an {@link Account}. For full
+ * documentation of this resource, please see
+ * [REST API Reference: Account API Keys](https://docs.stormpath.com/rest/product-guide/latest/reference.html?#account-api-keys).
+ *
+ * These keys can be used to authenticate requests to your web framework.
+ * For a high-level overview of this feature, please read [Using Stormpath for
+ * API Authentication](https://docs.stormpath.com/guides/api-key-management). If
+ * you are using [Express-Stormath](http://docs.stormpath.com/nodejs/express/latest),
+ * please read the [Authentication Section](http://docs.stormpath.com/nodejs/express/latest/authentication.html).
+ *
+ * This class should not be manually constructed. It should be obtained from one
+ * of these methods:
+ *
+ * - {@link Account#getApiKeys Account.getApiKeys()}
+ * - {@link Application#getApiKey Application.getApiKey()}
+ *
+ * @param {Object} apiKeyResource
+ *
+ * The JSON representation of this resource, retrieved the Stormpath REST API.
+ */
 function ApiKey() {
   ApiKey.super_.apply(this, arguments);
 }
 
 utils.inherits(ApiKey, InstanceResource);
+
 
 ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {
   var salt = this.apiKeyMetaData.encryptionKeySalt;
@@ -83,6 +84,15 @@ ApiKey.prototype._decrypt = function _decrypt(callback) {
   }
 };
 
+/**
+ * Retrieves the account resource associated with the ApiKey.
+ *
+ * @param {ExpansionOptions} [options]
+ * For retrieving linked resources of the {@link Account} during this request.
+ *
+ * @param {Function} Callback
+ * Callback function, will be called with (err, {@link Account account}).
+ */
 ApiKey.prototype.getAccount = function () {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
   return this.dataStore.getResource(this.account.href, args.options, require('./Account'), args.callback);

--- a/lib/resource/ApiKey.js
+++ b/lib/resource/ApiKey.js
@@ -6,38 +6,37 @@ var InstanceResource = require('./InstanceResource');
 var utils = require('../utils');
 
 /**
- * @class ApiKey
- *
- * @extends {InstanceResource}
- *
- * @description
- *
- * Encapsulates an Api Key resource of an {@link Account}. For full
- * documentation of this resource, please see
- * [REST API Reference: Account API Keys](https://docs.stormpath.com/rest/product-guide/latest/reference.html?#account-api-keys).
- *
- * These keys can be used to authenticate requests to your web framework.
- * For a high-level overview of this feature, please read [Using Stormpath for
- * API Authentication](https://docs.stormpath.com/guides/api-key-management). If
- * you are using [Express-Stormath](http://docs.stormpath.com/nodejs/express/latest),
- * please read the [Authentication Section](http://docs.stormpath.com/nodejs/express/latest/authentication.html).
- *
- * This class should not be manually constructed. It should be obtained from one
- * of these methods:
- *
- * - {@link Account#getApiKeys Account.getApiKeys()}
- * - {@link Application#getApiKey Application.getApiKey()}
- *
- * @param {Object} apiKeyResource
- *
- * The JSON representation of this resource, retrieved the Stormpath REST API.
- */
+* @class ApiKey
+*
+* @extends {InstanceResource}
+*
+* @description
+*
+* Encapsulates an Api Key resource of an {@link Account}. For full
+* documentation of this resource, please see
+* [REST API Reference: Account API Keys](https://docs.stormpath.com/rest/product-guide/latest/reference.html?#account-api-keys).
+*
+* These keys can be used to authenticate requests to your web framework.
+* For a high-level overview of this feature, please read [Using Stormpath for
+* API Authentication](https://docs.stormpath.com/guides/api-key-management). If
+* you are using [Express-Stormath](http://docs.stormpath.com/nodejs/express/latest),
+* please read the [Authentication Section](http://docs.stormpath.com/nodejs/express/latest/authentication.html).
+*
+* This class should not be manually constructed. It should be obtained from one
+* of these methods:
+*
+* - {@link Account#getApiKeys Account.getApiKeys()}
+* - {@link Application#getApiKey Application.getApiKey()}
+*
+* @param {Object} apiKeyResource
+*
+* The JSON representation of this resource, retrieved the Stormpath REST API.
+*/
 function ApiKey() {
   ApiKey.super_.apply(this, arguments);
 }
 
 utils.inherits(ApiKey, InstanceResource);
-
 
 ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {
   var salt = this.apiKeyMetaData.encryptionKeySalt;
@@ -82,6 +81,11 @@ ApiKey.prototype._decrypt = function _decrypt(callback) {
   }else{
     process.nextTick(callback.bind(null,null,self));
   }
+};
+
+ApiKey.prototype.getAccount = function () {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.account.href, args.options, require('./Account'), args.callback);
 };
 
 module.exports = ApiKey;

--- a/test/sp.resource.apikey_test.js
+++ b/test/sp.resource.apikey_test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var assert = require('assert');
+var sinon = require('sinon');
+
+var ApiKey = require('../lib/resource/ApiKey');
+var Account = require('../lib/resource/Account');
+
+describe('resource', function() {
+  describe('ApiKey', function() {
+    var apiKey, sandbox, cbSpy, getAccountStub, account;
+
+    before(function(done) {
+      sandbox = sinon.sandbox.create();
+      cbSpy = sandbox.spy();
+
+      apiKey = new ApiKey({
+        id: 'id',
+        secret: 'secret'
+      });
+
+      account = new Account({
+        givenName: 'm',
+        surname: 'd',
+        email: 'md@mailinator.com',
+        password: 'Test64!',
+      });
+
+      getAccountStub = sandbox.stub(apiKey, 'getAccount', function(cb) {
+        return cb(account);
+      });
+
+      done();
+    });
+
+    after(function () {
+      sandbox.restore();
+    });
+
+    it('should provide a getAccount method', function() {
+      assert(typeof apiKey.getAccount === 'function');
+    });
+
+    describe('getAccount', function() {
+      it('should return an Account object', function() {
+        assert(account instanceof Account);
+        apiKey.getAccount(cbSpy);
+        sinon.assert.calledOnce(getAccountStub);
+      });
+    });
+  });
+});

--- a/test/sp.resource.apikey_test.js
+++ b/test/sp.resource.apikey_test.js
@@ -7,11 +7,12 @@ var uuid = require('uuid');
 var ApiKey = require('../lib/resource/ApiKey');
 var DataStore = require('../lib/ds/DataStore');
 
-describe.only('resource', function() {
+describe('resource', function() {
   describe('ApiKey', function() {
-    var sandbox, cbSpy, apiKey, getResourceStub;
+    var clientApiKeySecret, sandbox, cbSpy, apiKey, getResourceStub;
 
     before(function(done) {
+      clientApiKeySecret = uuid();
       sandbox = sinon.sandbox.create();
       cbSpy = sandbox.spy();
 
@@ -23,10 +24,16 @@ describe.only('resource', function() {
         }
       });
 
-      var clientApiKeySecret = uuid();
-      apiKey.dataStore = new DataStore({client:{apiKey: {id: '1', secret: clientApiKeySecret}}});
+      apiKey.dataStore = new DataStore({
+        client: {
+          apiKey: {
+            id: '1',
+            secret: clientApiKeySecret
+          }
+        }
+      });
 
-      getResourceStub = sinon.stub(apiKey.dataStore,'getResource',function(){
+      getResourceStub = sinon.stub(apiKey.dataStore, 'getResource', function() {
         var args = Array.prototype.slice.call(arguments);
         var href = args.shift();
         var callback = args.pop();
@@ -36,7 +43,7 @@ describe.only('resource', function() {
       done();
     });
 
-    after(function () {
+    after(function() {
       sandbox.restore();
     });
 
@@ -46,14 +53,14 @@ describe.only('resource', function() {
 
     describe('getAccount', function() {
       it('should return an Account object', function(done) {
-        apiKey.getAccount(function(err, acc) {
+        apiKey.getAccount(function(err, account) {
           if (err) {
             return done(err);
           }
 
-          assert(acc.href === '/boom');
+          assert(account.href === '/boom');
           assert(getResourceStub.calledOnce);
-          
+
           done();
         });
       });


### PR DESCRIPTION
This adds a getAccount method for the ApiKey resource. It can be used like this:

```
client.getApplication(applicationHref, function (err, application) {
  application.getApiKey("$ID", function(err, apiKey){
    apiKey.getAccount(function(err, account){
      console.log(account);
    });
  });
});
```

I also (finally) wrote unit tests, and plopped them in test/sp.resource.apikey_test.js. Feel free to recommend changes/change stuff- I am happy to refactor!! 