### PR TITLE
Fix clicking issue in apidocs sidebar menu

### DIFF
--- a/docs/template/static/scripts/toc.js
+++ b/docs/template/static/scripts/toc.js
@@ -75,7 +75,7 @@
       if (target.prop('tagName').toLowerCase() !== "a") {
         target = target.parent();
       }
-      var elScrollToId = target.attr('href').replace(/^#/, '') + ANCHOR_PREFIX;
+      var elScrollToId = target.closest('a').attr('href').replace(/^#/, '') + ANCHOR_PREFIX;
       var $el = $(document.getElementById(elScrollToId));
 
       var offsetTop = Math.min(maxScrollTo, elOffset($el));


### PR DESCRIPTION
Fixes the issue when clicking in the apidocs sidebar menu.

#### How to verify

1. Checkout the branch.
2. Run `$ npm run docs`.
3. Run `open apidocs/stormpath/0.18.5/Account.html`
4. Click around in the menu to the right.
5. Verify that the menu scrolls when you both click directly on the sub menu text (e.g. `getGroupMemberships`) and outside. Alternate between clicking on menu items to verify that it works as expected.

Fixes #518