### PR TITLE
Add stormpath_social oauth grant type support

### DIFF
--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -7,6 +7,7 @@ var OAuthRefreshTokenGrantRequestAuthenticator = require('../oauth/refresh-grant
 var OAuthIdSiteTokenGrantAuthenticator = require('../oauth/id-site-grant').authenticator;
 var OAuthStormpathTokenAuthenticator = require('../oauth/stormpath-token').authenticator;
 var OAuthClientCredentialsAuthenticator = require('./client-credentials').authenticator;
+var OAuthStormpathSocialAuthenticator = require('../oauth/stormpath-social').authenticator;
 
 function retrieveAuthTokenFromRequest(req) {
   var authHeader = req && req.headers && req.headers.authorization;
@@ -70,6 +71,9 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
         break;
       case 'client_credentials':
         authenticator = new OAuthClientCredentialsAuthenticator(this.application);
+        break;
+      case 'stormpath_social':
+        authenticator = new OAuthStormpathSocialAuthenticator(this.application);
     }
   }
 

--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -1,0 +1,138 @@
+'use strict';
+
+var util = require('util');
+var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
+
+/**
+ * @class
+ *
+ * @augments {JwtAuthenticationResult}
+ *
+ * @description
+ *
+ * Encapsulates the access token response from an application's `/oauth/token`
+ * endpoint, when making a `stormpath_social` grant request.
+ *
+ * This class allows you to access the response data and get the account
+ * that was authenticated.
+ *
+ * This class should not be manually constructed. It should be obtained from one
+ * of these methods:
+ *
+ * - {@link OAuthStormpathSocialAuthenticator#authenticate OAuthStormpathSocialAuthenticator.authenticate()}.
+ *
+ * @param {Application} application
+ * The Stormpath Application that you want tokens issued for.
+ *
+ * @param {AccessTokenResponse} accessTokenResponse
+ * The access token response from the Stormpath REST API.
+ *
+ */
+function OAuthStormpathSocialAuthenticationResult(application, data){
+  OAuthStormpathSocialAuthenticationResult.super_.apply(this, arguments);
+  this.accessTokenResponse = data;
+}
+util.inherits(OAuthStormpathSocialAuthenticationResult, JwtAuthenticationResult);
+
+/**
+ * @class
+ *
+ * @description
+ *
+ * Creates an authenticator that can be used to exchange a Stormpath Social grant (authorization code or access token)
+ * for an access token and refresh token pair. A Stormpath Social grant (authorization code or access token)
+ * is provided when a user gains authorization from an OAuth provider or redirected from OAuth provider callback.
+ *
+ * The authenticator is bound to a Stormpath Application, so the authentication
+ * attempt will be bound to the account stores that are mapped to this application.
+ * To configure the access and refresh token expiration times for the application,
+ * see {@link OAuthPolicy}.
+ *
+ * @param {Application} application The Stormpath Application to authenticate against.
+ *
+ * @example
+ * var appHref = 'https://api.stormpath.com/v1/applications/3WIeKpaEjPHfLmy6GIvbwv';
+ *
+ * client.getApplication(appHref, function(err, application) {
+ *   var authenticator = new stormpath.OAuthStormpathSocialAuthenticator(application);*
+ * });
+ */
+function OAuthStormpathSocialAuthenticator(application) {
+  if (!(this instanceof OAuthStormpathSocialAuthenticator)) {
+    return new OAuthStormpathSocialAuthenticator(application);
+  }
+
+  this.application = application;
+}
+
+/**
+ * Exchange the Stormpath Social authorization code or access token for an Access and Refresh token.
+ *
+ * @param {Object} data
+ * An object to encapsulate the request.
+ *
+ * @param {String} [data.providerId]
+ * The identity of the provider to exchange a access token or authorization code for. E.g. 'facebook', 'google' or 'github'.
+ *
+ * @param {String} [data.accessToken]
+ * The provider access token.
+ *
+ * @param {String} [data.code]
+ * The provider authorization code.
+ *
+ * @param {Function} callback
+ * Callback function, will be called with (err, {@link OAuthStormpathSocialAuthenticationResult}).
+ *
+ * @example
+ *
+ * var data = {
+ *   code: ''
+ * };
+ *
+ * authenticator.authenticate(data, function(err, authResult) {
+ *   authResult.getAccount(function(err, account){
+ *     console.log('The access token for %s is %s', account.email, authResult.accessTokenResponse.access_token);
+ *   });
+ * });
+ */
+OAuthStormpathSocialAuthenticator.prototype.authenticate = function authenticate(data, callback) {
+  var application = this.application;
+
+  if (typeof data !== 'object') {
+    throw new Error('The \'data\' parameter must be an object.');
+  }
+
+  if (typeof data.providerId !== 'string') {
+    throw new Error('The \'data.providerId\' parameter must be a string.');
+  }
+
+  if (!data.code && !data.accessToken) {
+    throw new Error('One of the parameters \'data.code\' or \'data.accessToken\' must be provided.');
+  }
+
+  if (typeof callback !== 'function') {
+    throw new Error('The \'callback\' parameter must be a function.');
+  }
+
+  var formData = {
+    grant_type: 'stormpath_social',
+    providerId: data.providerId,
+    code: data.code,
+    accessToken: data.accessToken
+  };
+
+  var tokenHref = application.href + '/oauth/token';
+
+  application.dataStore.createResource(tokenHref, { form: formData }, function(err, tokenData) {
+    if (err) {
+      return callback(err);
+    }
+
+    callback(null, new OAuthStormpathSocialAuthenticationResult(application, tokenData));
+  });
+};
+
+module.exports = {
+  authenticator: OAuthStormpathSocialAuthenticator,
+  authenticationResult: OAuthStormpathSocialAuthenticationResult
+};

--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -39,11 +39,11 @@ util.inherits(OAuthStormpathSocialAuthenticationResult, JwtAuthenticationResult)
  *
  * @description
  *
- * Creates an authenticator that can be used to exchange a Stormpath Social grant (authorization code or access token)
- * for an access token and refresh token pair. A Stormpath Social grant (authorization code or access token)
- * is provided when a user gains authorization from an OAuth provider or redirected from OAuth provider callback.
+ * Creates an authenticator that can be used to exchange an authorization code or access token, obtained from
+ * a social provider, for a Stormpath Access Token and Refresh Token.  The new tokens will be issued by the
+ * given Stormpath Application.
  *
- * The authenticator is bound to a Stormpath Application, so the authentication
+ * The authenticator is bound to the Stormpath Application, so the authentication
  * attempt will be bound to the account stores that are mapped to this application.
  * To configure the access and refresh token expiration times for the application,
  * see {@link OAuthPolicy}.
@@ -54,7 +54,7 @@ util.inherits(OAuthStormpathSocialAuthenticationResult, JwtAuthenticationResult)
  * var appHref = 'https://api.stormpath.com/v1/applications/3WIeKpaEjPHfLmy6GIvbwv';
  *
  * client.getApplication(appHref, function(err, application) {
- *   var authenticator = new stormpath.OAuthStormpathSocialAuthenticator(application);*
+ *   var authenticator = new stormpath.OAuthStormpathSocialAuthenticator(application);
  * });
  */
 function OAuthStormpathSocialAuthenticator(application) {
@@ -66,27 +66,45 @@ function OAuthStormpathSocialAuthenticator(application) {
 }
 
 /**
- * Exchange the Stormpath Social authorization code or access token for an Access and Refresh token.
+ * Exchange an authorization code or access token, provided by a social provier, for a Stormpath Access Token and Refresh token.
  *
  * @param {Object} authenticationRequest
  * An object to encapsulate the request.
  *
  * @param {String} [authenticationRequest.providerId]
- * The identity of the provider to exchange a access token or authorization code for. E.g. 'facebook', 'google' or 'github'.
+ * The identity of the provider that provided the code or access token, e.g. `facebook`, `google`, `github`, `linkedin`.
  *
  * @param {String} [authenticationRequest.accessToken]
- * The provider access token.
+ * The access token, obtained from the provider.
  *
  * @param {String} [authenticationRequest.code]
- * The provider authorization code.
+ * The authorization code, obtained from the provider.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link OAuthStormpathSocialAuthenticationResult}).
  *
  * @example
  *
+ * // Authorization Code example, with code obtained from Google login callback
+ *
  * var authenticationRequest = {
- *   code: ''
+ *   providerId: 'google',
+ *   code: '5LvvqjEJl9zhoAbkNj9vFUgOBsePjpm7XY'
+ * };
+ *
+ * authenticator.authenticate(authenticationRequest, function(err, authResult) {
+ *   authResult.getAccount(function(err, account){
+ *     console.log('The access token for %s is %s', account.email, authResult.accessTokenResponse.access_token);
+ *   });
+ * });
+ *
+ * @example
+ *
+ * // Access Token example, with code obtained from Facebook login pop-up
+ *
+ * var authenticationRequest = {
+ *   providerId: 'facebook',
+ *   accessToken: 'Sb8BvqbpxxzqjEJl9QlzKDfxfdf2d5d1NMerEAHPMqYfeoZB0CIimgBhk1DK6KFZAOF5xJB6grrrgcuOZAnekyxxURTsPaiIQ9exmzv'
  * };
  *
  * authenticator.authenticate(authenticationRequest, function(err, authResult) {

--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -68,16 +68,16 @@ function OAuthStormpathSocialAuthenticator(application) {
 /**
  * Exchange the Stormpath Social authorization code or access token for an Access and Refresh token.
  *
- * @param {Object} data
+ * @param {Object} authenticationRequest
  * An object to encapsulate the request.
  *
- * @param {String} [data.providerId]
+ * @param {String} [authenticationRequest.providerId]
  * The identity of the provider to exchange a access token or authorization code for. E.g. 'facebook', 'google' or 'github'.
  *
- * @param {String} [data.accessToken]
+ * @param {String} [authenticationRequest.accessToken]
  * The provider access token.
  *
- * @param {String} [data.code]
+ * @param {String} [authenticationRequest.code]
  * The provider authorization code.
  *
  * @param {Function} callback
@@ -85,29 +85,31 @@ function OAuthStormpathSocialAuthenticator(application) {
  *
  * @example
  *
- * var data = {
+ * var authenticationRequest = {
  *   code: ''
  * };
  *
- * authenticator.authenticate(data, function(err, authResult) {
+ * authenticator.authenticate(authenticationRequest, function(err, authResult) {
  *   authResult.getAccount(function(err, account){
  *     console.log('The access token for %s is %s', account.email, authResult.accessTokenResponse.access_token);
  *   });
  * });
  */
-OAuthStormpathSocialAuthenticator.prototype.authenticate = function authenticate(data, callback) {
+OAuthStormpathSocialAuthenticator.prototype.authenticate = function authenticate(authenticationRequest, callback) {
   var application = this.application;
 
-  if (typeof data !== 'object') {
-    throw new Error('The \'data\' parameter must be an object.');
+  console.log('authenticationRequest',authenticationRequest);
+
+  if (typeof authenticationRequest !== 'object') {
+    throw new Error('The \'authenticationRequest\' parameter must be an object.');
   }
 
-  if (typeof data.providerId !== 'string') {
-    throw new Error('The \'data.providerId\' parameter must be a string.');
+  if (typeof authenticationRequest.providerId !== 'string') {
+    throw new Error('The \'authenticationRequest.providerId\' parameter must be a string.');
   }
 
-  if (!data.code && !data.accessToken) {
-    throw new Error('One of the parameters \'data.code\' or \'data.accessToken\' must be provided.');
+  if (!authenticationRequest.code && !authenticationRequest.accessToken) {
+    throw new Error('One of the parameters \'authenticationRequest.code\' or \'authenticationRequest.accessToken\' must be provided.');
   }
 
   if (typeof callback !== 'function') {
@@ -116,9 +118,9 @@ OAuthStormpathSocialAuthenticator.prototype.authenticate = function authenticate
 
   var formData = {
     grant_type: 'stormpath_social',
-    providerId: data.providerId,
-    code: data.code,
-    accessToken: data.accessToken
+    providerId: authenticationRequest.providerId,
+    code: authenticationRequest.code,
+    accessToken: authenticationRequest.accessToken
   };
 
   var tokenHref = application.href + '/oauth/token';

--- a/lib/stormpath.js
+++ b/lib/stormpath.js
@@ -5,6 +5,7 @@ var refreshGrant = require('./oauth/refresh-grant');
 var idSiteGrant = require('./oauth/id-site-grant');
 var stormpathToken = require('./oauth/stormpath-token');
 var clientCredentialsGrant = require('./oauth/client-credentials');
+var stormpathSocial = require('./oauth/stormpath-social');
 
 module.exports = {
   ApiKey: require('./authc/ApiKey'),
@@ -18,6 +19,7 @@ module.exports = {
   OAuthIdSiteTokenGrantAuthenticator: idSiteGrant.authenticator,
   OAuthIdSiteTokenGrantAuthenticationResult: idSiteGrant.authenticationResult,
   OAuthStormpathTokenAuthenticator: stormpathToken.authenticator,
+  OAuthStormpathSocialAuthenticator: stormpathSocial.authenticator,
   OAuthStormpathTokenAuthenticationResult: stormpathToken.authenticationResult,
   OAuthClientCredentialsAuthenticator: clientCredentialsGrant.authenticator,
   OAuthClientCredentialsAuthenticationResult: clientCredentialsGrant.authenticationResult,

--- a/test/it/helpers.js
+++ b/test/it/helpers.js
@@ -148,6 +148,28 @@ function createApplication(callback) {
   }
 }
 
+/**
+ * Create a new Stormpath Directory for usage in tests.
+ *
+ * @function
+ *
+ * @param {Object} options - Options for the Stormpath directory to create.
+ * @param {Function} callback - A callback to run when done.
+ */
+function createDirectory(options, callback) {
+  if (!options) {
+    options = {};
+  }
+
+  if (!options.name) {
+    options.name = pkg.name + ':' + getFriendlyCallerName() + ':' + testRunId + ':' + uuid.v4();
+  }
+
+  getClient(function (client) {
+    client.createDirectory(options, callback);
+  });
+}
+
 function fakeDirectory(){
   return {
     name: uniqId()
@@ -204,6 +226,7 @@ module.exports = {
   getDefaultAccountStore: getDefaultAccountStore,
   cleanupApplicationAndStores: cleanupApplicationAndStores,
   createApplication: createApplication,
+  createDirectory: createDirectory,
   createStormpathToken: createStormpathToken,
   getClient: getClient,
   uniqId: uniqId,

--- a/test/it/oauth_stormpath_socal_it.js
+++ b/test/it/oauth_stormpath_socal_it.js
@@ -1,0 +1,229 @@
+'use strict';
+
+var stormpath = require('../../');
+var common = require('../common');
+var helpers = require('./helpers');
+
+var assert = common.assert;
+
+describe('OAuthStormpathSocialAuthenticator', function () {
+  var account;
+  var application;
+  var validProviderId;
+
+  before(function (done) {
+    helpers.createApplication(function (err, newApplication) {
+      if (err) {
+        return done(err);
+      }
+
+      application = newApplication;
+      validProviderId = 'google';
+
+      helpers.createDirectory({
+        provider: {
+          providerId: validProviderId,
+          clientId: '3f389cd1-9b02-49c3-8a73-735d3e05e369',
+          clientSecret: '4064ee95-bf0f-4342-a062-43571d8eb392',
+          redirectUri: 'http://decdd275-7f3a-4289-9d41-075295d01451'
+        }
+      }, function (err, directory) {
+        if (err) {
+          return done(err);
+        }
+
+        application.createAccountStoreMapping({
+          accountStore: {
+            href: directory.href
+          }
+        }, function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          application.createAccount(helpers.fakeAccount(), function (err, newAccount) {
+            if (err) {
+              return done(err);
+            }
+
+            account = newAccount;
+
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  after(function (done) {
+    helpers.cleanupApplicationAndStores(application, done);
+  });
+
+  describe('when calling OAuthStormpathSocialAuthenticator(application)', function () {
+    var instance;
+
+    beforeEach(function () {
+      instance = stormpath.OAuthStormpathSocialAuthenticator(application);
+    });
+
+    it('should return a OAuthStormpathSocialAuthenticator instance', function () {
+      assert.instanceOf(instance, stormpath.OAuthStormpathSocialAuthenticator);
+    });
+
+    it('should return a new instance', function () {
+      var differentInstance = new stormpath.OAuthStormpathSocialAuthenticator(application);
+      assert.instanceOf(differentInstance, stormpath.OAuthStormpathSocialAuthenticator);
+      assert.notEqual(instance, differentInstance);
+    });
+
+    it('should return an instance with an application property', function () {
+      assert.property(instance, 'application');
+      assert.equal(instance.application, application);
+    });
+  });
+
+  describe('when calling new OAuthStormpathSocialAuthenticator(application)', function () {
+    var instance;
+
+    beforeEach(function () {
+      instance = new stormpath.OAuthStormpathSocialAuthenticator(application);
+    });
+
+    it('should return a OAuthStormpathSocialAuthenticator instance', function () {
+      assert.instanceOf(instance, stormpath.OAuthStormpathSocialAuthenticator);
+    });
+
+    it('should return a new instance', function () {
+      var differentInstance = new stormpath.OAuthStormpathSocialAuthenticator(application);
+      assert.instanceOf(differentInstance, stormpath.OAuthStormpathSocialAuthenticator);
+      assert.notEqual(instance, differentInstance);
+    });
+
+    it('should return an instance with an application property', function () {
+      assert.property(instance, 'application');
+      assert.equal(instance.application, application);
+    });
+  });
+
+  describe('when calling authenticate(data, callback)', function () {
+    var invalidProviderId;
+    var authenticator;
+
+    beforeEach(function () {
+      invalidProviderId = 'ab369d04-eca4-4d65-8412-a1e61b44d58e';
+      authenticator = new stormpath.OAuthStormpathSocialAuthenticator(application);
+    });
+
+    describe('without a data parameter', function () {
+      it('should throw an invalid parameter error', function () {
+        assert.throws(function () {
+          authenticator.authenticate();
+        }, 'The \'data\' parameter must be an object.');
+      });
+    });
+
+    describe('without a data.providerId parameter', function () {
+      it('should throw an invalid parameter error', function () {
+        assert.throws(function () {
+          authenticator.authenticate({});
+        }, 'The \'data.providerId\' parameter must be a string.');
+      });
+    });
+
+    describe('without a data.code or a data.accessToken parameter', function () {
+      it('should throw an invalid parameter error', function () {
+        assert.throws(function () {
+          authenticator.authenticate({
+            providerId: invalidProviderId
+          });
+        }, 'One of the parameters \'data.code\' or \'data.accessToken\' must be provided.');
+      });
+    });
+
+    describe('without a callback parameter', function () {
+      var invalidCode;
+
+      beforeEach(function () {
+        invalidCode = '87b9760f-eb74-4f17-aa89-b333c7eb51a2';
+      });
+
+      it('should throw an invalid parameter error', function () {
+        assert.throws(function () {
+          authenticator.authenticate({
+            providerId: invalidProviderId,
+            code: invalidCode
+          });
+        }, 'The \'callback\' parameter must be a function.');
+      });
+    });
+
+    describe('with an invalid data.providerId parameter', function () {
+      var invalidCode;
+
+      beforeEach(function () {
+        invalidCode = '520c541f-bbf2-4075-bc54-148f888d4e95';
+      });
+
+      it('should fail with a directory request error', function (done) {
+        authenticator.authenticate({
+          providerId: invalidProviderId,
+          code: invalidCode
+        }, function (err, authenticationResult) {
+          assert.ok(err);
+          assert.equal(err.name, 'ResourceError');
+          assert.equal(err.status, 400); // Bad request
+          assert.equal(err.code, 2003); // The specified property value is unsupported.
+          assert.equal(err.developerMessage, 'account providerId is an unsupported value.');
+          assert.notOk(authenticationResult);
+          done();
+        });
+      });
+    });
+
+    describe('with an invalid data.code parameter', function () {
+      var invalidCode;
+
+      beforeEach(function () {
+        invalidCode = 'd8185a16-4d99-4b04-bd00-fb37cd39dabd';
+      });
+
+      it('should fail with a directory request error', function (done) {
+        authenticator.authenticate({
+          providerId: validProviderId,
+          code: invalidCode
+        }, function (err, authenticationResult) {
+          assert.ok(err);
+          assert.equal(err.name, 'ResourceError');
+          assert.equal(err.status, 400); // Bad request
+          assert.equal(err.code, 7200); // Stormpath was not able to complete the request to the Social Login site.
+          assert.include(err.developerMessage, 'Stormpath was not able to complete the request to Google');
+          assert.notOk(authenticationResult);
+          done();
+        });
+      });
+    });
+
+    describe('with an invalid data.accessToken paramter', function () {
+      var invalidAccessToken;
+
+      beforeEach(function () {
+        invalidAccessToken = '3d0e7394-2896-4c04-9042-9f7adfa48961';
+      });
+
+      it('should fail with a directory request error', function (done) {
+        authenticator.authenticate({
+          providerId: validProviderId,
+          accessToken: invalidAccessToken
+        }, function (err, authenticationResult) {
+          assert.ok(err);
+          assert.equal(err.name, 'ResourceError');
+          assert.equal(err.status, 400); // Bad request
+          assert.equal(err.code, 7200); // Stormpath was not able to complete the request to the Social Login site.
+          assert.include(err.developerMessage, 'Stormpath was not able to complete the request to Google');
+          assert.notOk(authenticationResult);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/it/oauth_stormpath_socal_it.js
+++ b/test/it/oauth_stormpath_socal_it.js
@@ -105,7 +105,7 @@ describe('OAuthStormpathSocialAuthenticator', function () {
     });
   });
 
-  describe('when calling authenticate(data, callback)', function () {
+  describe('when calling authenticate(authenticationRequest, callback)', function () {
     var invalidProviderId;
     var authenticator;
 
@@ -114,29 +114,29 @@ describe('OAuthStormpathSocialAuthenticator', function () {
       authenticator = new stormpath.OAuthStormpathSocialAuthenticator(application);
     });
 
-    describe('without a data parameter', function () {
+    describe('without a authenticationRequest parameter', function () {
       it('should throw an invalid parameter error', function () {
         assert.throws(function () {
           authenticator.authenticate();
-        }, 'The \'data\' parameter must be an object.');
+        }, 'The \'authenticationRequest\' parameter must be an object.');
       });
     });
 
-    describe('without a data.providerId parameter', function () {
+    describe('without a authenticationRequest.providerId parameter', function () {
       it('should throw an invalid parameter error', function () {
         assert.throws(function () {
           authenticator.authenticate({});
-        }, 'The \'data.providerId\' parameter must be a string.');
+        }, 'The \'authenticationRequest.providerId\' parameter must be a string.');
       });
     });
 
-    describe('without a data.code or a data.accessToken parameter', function () {
+    describe('without a authenticationRequest.code or a authenticationRequest.accessToken parameter', function () {
       it('should throw an invalid parameter error', function () {
         assert.throws(function () {
           authenticator.authenticate({
             providerId: invalidProviderId
           });
-        }, 'One of the parameters \'data.code\' or \'data.accessToken\' must be provided.');
+        }, 'One of the parameters \'authenticationRequest.code\' or \'authenticationRequest.accessToken\' must be provided.');
       });
     });
 
@@ -157,7 +157,7 @@ describe('OAuthStormpathSocialAuthenticator', function () {
       });
     });
 
-    describe('with an invalid data.providerId parameter', function () {
+    describe('with an invalid authenticationRequest.providerId parameter', function () {
       var invalidCode;
 
       beforeEach(function () {
@@ -180,7 +180,7 @@ describe('OAuthStormpathSocialAuthenticator', function () {
       });
     });
 
-    describe('with an invalid data.code parameter', function () {
+    describe('with an invalid authenticationRequest.code parameter', function () {
       var invalidCode;
 
       beforeEach(function () {
@@ -203,7 +203,7 @@ describe('OAuthStormpathSocialAuthenticator', function () {
       });
     });
 
-    describe('with an invalid data.accessToken paramter', function () {
+    describe('with an invalid authenticationRequest.accessToken paramter', function () {
       var invalidAccessToken;
 
       beforeEach(function () {


### PR DESCRIPTION
Adds support for the `stormpath_social` OAuth grant type by adding a new authenticator for it.
#### How to verify
1. Checkout and link this branch.
2. Use the application below with a valid Google authorization code (an authorization code that you received from a Google OAuth redirect).
   Use the application below:
   
   ``` javascript
   var stormpath = require('stormpath');
   
   var client = new stormpath.Client();
   
   var applicationHref = 'https://api.stormpath.com/v1/applications/5MNUu5eAdO4e9K7pd9xlfu';
   
   client.getApplication(applicationHref, function (err, application) {
     if (err) {
       return console.error(err);
     }
   
     var authenticator = new stormpath.OAuthAuthenticator(application);
   
     var authRequest = {
       body: {
         grant_type: 'stormpath_social',
         providerId: 'google',
         code: '(YOUR GOOGLE AUTHORIZATION CODE TO TEST)'
       }
     };
   
     authenticator.authenticate(authRequest, function (err, authResult) {
       if (err) {
         return console.error(err);
       }
   
       console.log('Authenticated with result!', authResult);
     });
   });
   ```
3. You should now see something like the following in the terminal: 
   
   ``` javascript
   Authenticated with result! OAuthStormpathSocialAuthenticationResult {
   accessToken:
   Jwt {
    header:
     JwtHeader {
       typ: 'JWT',
       alg: 'HS256',
       kid: '(redacted)',
       stt: 'access' },
    body:
     JwtBody {
       jti: '(redacted)',
       iat: 1474739602,
       iss: 'https://api.stormpath.com/v1/applications/(redacted)',
       sub: 'https://api.stormpath.com/v1/accounts/(redacted)',
       exp: 1474743202,
       rti: '(redacted)' },
    toString: [Function] },
   refreshToken:
   Jwt {
    header:
     JwtHeader {
       typ: 'JWT',
       alg: 'HS256',
       kid: '(redacted)',
       stt: 'refresh' },
    body:
     JwtBody {
       jti: '(redacted)',
       iat: 1474739602,
       iss: 'https://api.stormpath.com/v1/applications/(redacted)',
       sub: 'https://api.stormpath.com/v1/accounts/(redacted)',
       exp: 1474826002 },
    toString: [Function] },
   tokenType: 'Bearer',
   expiresIn: 3600,
   stormpathAccessTokenHref: 'https://api.stormpath.com/v1/accessTokens/(redacted)',
   application:
   Application {
    href: 'https://api.stormpath.com/v1/applications/(redacted)',
    name: 'Testing',
    description: '',
    status: 'ENABLED',
    createdAt: '2015-11-02T18:58:22.005Z',
    modifiedAt: '2016-07-21T00:51:25.865Z',
    authorizedCallbackUris: [],
    tenant: { href: 'https://api.stormpath.com/v1/tenants/(redacted)' },
    defaultAccountStoreMapping: { href: 'https://api.stormpath.com/v1/accountStoreMappings/(redacted)' },
    defaultGroupStoreMapping: { href: 'https://api.stormpath.com/v1/accountStoreMappings/(redacted)' },
    customData:
     CustomData {
       href: 'https://api.stormpath.com/v1/applications/(redacted)/customData' },
    oAuthPolicy: { href: 'https://api.stormpath.com/v1/oAuthPolicies/(redacted)' },
    samlPolicy: { href: 'https://api.stormpath.com/v1/samlPolicies/(redacted)' },
    accountLinkingPolicy: { href: 'https://api.stormpath.com/v1/accountLinkingPolicies/(redacted)' },
    accounts: { href: 'https://api.stormpath.com/v1/applications/(redacted)/accounts' },
    groups: { href: 'https://api.stormpath.com/v1/applications/(redacted)/groups' },
    accountStoreMappings: { href: 'https://api.stormpath.com/v1/applications/(redacted)/accountStoreMappings' },
    loginAttempts: { href: 'https://api.stormpath.com/v1/applications/(redacted)/loginAttempts' },
    passwordResetTokens: { href: 'https://api.stormpath.com/v1/applications/(redacted)/passwordResetTokens' },
    apiKeys: { href: 'https://api.stormpath.com/v1/applications/(redacted)/apiKeys' },
    verificationEmails: { href: 'https://api.stormpath.com/v1/applications/(redacted)/verificationEmails' },
    authTokens: { href: 'https://api.stormpath.com/v1/applications/(redacted)/authTokens' },
    idSiteModel: { href: 'https://api.stormpath.com/v1/applications/(redacted)/idSiteModel' } },
   account: { href: 'https://api.stormpath.com/v1/accounts/(redacted)' },
   accessTokenResponse:
   InstanceResource {
    access_token: '(redacted)',
    refresh_token: '(redacted)',
    token_type: 'Bearer',
    expires_in: 3600,
    stormpath_access_token_href: 'https://api.stormpath.com/v1/accessTokens/(redacted)' } }
   ```
#### Discussion

The tests does currently not cover if access/refresh tokens can be issued. They merely test if we can call the`/oauth/token` endpoint with `grant_type` set to `stormpath_social` and if the request fail if the parameters that the endpoint require is not present. So should we add any more tests here or be happy as it is? We could mock the call to the datastore in order to fake the access/refresh token response.

Fixes #525 
