### PR TITLE
Feature instantiate expanded resources

### DIFF
--- a/lib/resource/ResourceFactory.js
+++ b/lib/resource/ResourceFactory.js
@@ -1,9 +1,35 @@
 'use strict';
-
+/* jshint -W003 */
 var CollectionResource = require('./CollectionResource');
 var CustomData = require('./CustomData');
 var InstanceResource = require('./InstanceResource');
 var utils = require('../utils');
+
+
+function expandResource(expandedFields, resource, query, dataStore) {
+  if (resource instanceof CollectionResource) {
+    resource.items.forEach(function(instance) {
+      expandResource(expandedFields, instance, query, dataStore);
+    });
+
+    return resource;
+  }
+
+  expandedFields.forEach(function(fieldName) {
+    var normalizedFieldName = fieldName.charAt(0).toUpperCase() + fieldName.substr(1);
+    var expandedPath = './' + normalizedFieldName;
+
+    if (typeof resource[fieldName] !== 'undefined') {
+      try {
+        resource[fieldName] = instantiate(require(expandedPath), resource[fieldName], query, dataStore);
+      } catch (e) {
+        console.log('Invalid expand field:', fieldName);
+      }
+    }
+  });
+
+  return resource;
+}
 
 /**
  * @private
@@ -39,12 +65,20 @@ function instantiate(InstanceConstructor, data, query, dataStore) {
       resource = new Ctor(data, dataStore);
     }
 
-    if(resource.customData){
+    // Wrap any explicitly expanded data into resources, if they can be required.
+    // Assumes that the expanded field name is matched by the resource file name.
+    if (q && q.expand) {
+      var fieldNames = q.expand.split(/\s*,\s*/);
+      resource = expandResource(fieldNames, resource, q, dataStore);
+    }
+
+    if (resource.customData && !(resource.customData instanceof CustomData)) {
       resource.customData = instantiate(CustomData, resource.customData, q, dataStore);
     }
   }
   return resource;
 }
+/* jshint +W003 */
 
 module.exports = {
   instantiate: instantiate

--- a/lib/resource/ResourceFactory.js
+++ b/lib/resource/ResourceFactory.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /* jshint -W003 */
 var CollectionResource = require('./CollectionResource');
 var CustomData = require('./CustomData');
@@ -18,7 +19,7 @@ var utils = require('../utils');
 */
 function getPathForResourceName(resourceName) {
   var normalizedFieldName = resourceName.charAt(0).toUpperCase() +
-                            resourceName.substr(1);
+    resourceName.substr(1);
 
   return './' + normalizedFieldName;
 }
@@ -41,7 +42,7 @@ function getPathForResourceName(resourceName) {
 */
 function expandResource(expandedFields, resource, query, dataStore) {
   if (resource instanceof CollectionResource) {
-    resource.items.forEach(function(instance) {
+    resource.items.forEach(function (instance) {
       expandResource(expandedFields, instance, query, dataStore);
     });
 
@@ -75,36 +76,37 @@ function expandResource(expandedFields, resource, query, dataStore) {
  * @returns a new Resource memory instance
  */
 function instantiate(InstanceConstructor, data, query, dataStore) {
-
   var Ctor = utils.valueOf(InstanceConstructor, InstanceResource);
 
   if (utils.isAssignableFrom(CollectionResource, Ctor)) {
-    throw new Error("InstanceConstructor argument cannot be a CollectionResource.");
+    throw new Error('InstanceConstructor argument cannot be a CollectionResource.');
   }
 
-  var q = utils.valueOf(query);
+  if (!data) {
+    return null;
+  }
 
   var resource = null;
+  var q = utils.valueOf(query);
 
-  if (data) {
-    if (utils.isCollectionData(data)) {
-      resource = new CollectionResource(data, q, Ctor, dataStore);
-    } else {
-      resource = new Ctor(data, dataStore);
-    }
-
-    // Wrap any explicitly expanded data into resources, if they can be required.
-    // Assumes that the expanded field name is matched by the resource file name.
-    if (q && q.expand) {
-      var fieldNames = q.expand.split(/\s*,\s*/);
-      resource = expandResource(fieldNames, resource, q, dataStore);
-    }
-
-    // Expand the custom data even if it is not explicitly required to maintain backwards compatibility
-    if (resource.customData && !(resource.customData instanceof CustomData)) {
-      resource.customData = instantiate(CustomData, resource.customData, q, dataStore);
-    }
+  if (utils.isCollectionData(data)) {
+    resource = new CollectionResource(data, q, Ctor, dataStore);
+  } else {
+    resource = new Ctor(data, dataStore);
   }
+
+  // Wrap any explicitly expanded data into resources, if they can be required.
+  // Assumes that the expanded field name is matched by the resource file name.
+  if (q && q.expand) {
+    var fieldNames = q.expand.split(/\s*,\s*/);
+    resource = expandResource(fieldNames, resource, q, dataStore);
+  }
+
+  // Expand the custom data even if it is not explicitly required to maintain backwards compatibility
+  if (resource.customData && !(resource.customData instanceof CustomData)) {
+    resource.customData = instantiate(CustomData, resource.customData, q, dataStore);
+  }
+
   return resource;
 }
 /* jshint +W003 */

--- a/lib/resource/ResourceFactory.js
+++ b/lib/resource/ResourceFactory.js
@@ -5,7 +5,40 @@ var CustomData = require('./CustomData');
 var InstanceResource = require('./InstanceResource');
 var utils = require('../utils');
 
+/**
+* @private
+*
+* @description
+*
+* Computes the path to a file by its resource name. Currently only does so by
+* transforming the resource name.
+*
+* @param resourceName The string representing the name of the expanded resource
+* @return Path to the resource file
+*/
+function getPathForResourceName(resourceName) {
+  var normalizedFieldName = resourceName.charAt(0).toUpperCase() +
+                            resourceName.substr(1);
 
+  return './' + normalizedFieldName;
+}
+
+/**
+* @private
+*
+* @description
+* Given an instantiated resource or resource collection, turns all objects
+* that came from an `expand` query into resource object by instantiating them.
+* These transformations are done in-place (the original resource is modified,
+* not copied).
+*
+* @param expandedFields A list of resources that were demanded in an expand query
+* @param resource An instantiated parent resource or collection of resources
+* @param query any query that was provided to the server when acquiring the data
+* @param dataStore the dataStore used by the resource to communicate with the server. required for all resources.
+* @returns Resource with expanded fields transformed into instantied resources
+*
+*/
 function expandResource(expandedFields, resource, query, dataStore) {
   if (resource instanceof CollectionResource) {
     resource.items.forEach(function(instance) {
@@ -16,11 +49,10 @@ function expandResource(expandedFields, resource, query, dataStore) {
   }
 
   expandedFields.forEach(function(fieldName) {
-    var normalizedFieldName = fieldName.charAt(0).toUpperCase() + fieldName.substr(1);
-    var expandedPath = './' + normalizedFieldName;
+    var path = getPathForResourceName(fieldName);
 
     if (typeof resource[fieldName] !== 'undefined') {
-      resource[fieldName] = instantiate(require(expandedPath), resource[fieldName], query, dataStore);
+      resource[fieldName] = instantiate(require(path), resource[fieldName], query, dataStore);
     }
   });
 
@@ -68,7 +100,7 @@ function instantiate(InstanceConstructor, data, query, dataStore) {
       resource = expandResource(fieldNames, resource, q, dataStore);
     }
 
-    // Expand the custom data even if it is not explicitly required
+    // Expand the custom data even if it is not explicitly required to maintain backwards compatibility
     if (resource.customData && !(resource.customData instanceof CustomData)) {
       resource.customData = instantiate(CustomData, resource.customData, q, dataStore);
     }

--- a/lib/resource/ResourceFactory.js
+++ b/lib/resource/ResourceFactory.js
@@ -20,11 +20,7 @@ function expandResource(expandedFields, resource, query, dataStore) {
     var expandedPath = './' + normalizedFieldName;
 
     if (typeof resource[fieldName] !== 'undefined') {
-      try {
-        resource[fieldName] = instantiate(require(expandedPath), resource[fieldName], query, dataStore);
-      } catch (e) {
-        console.log('Invalid expand field:', fieldName);
-      }
+      resource[fieldName] = instantiate(require(expandedPath), resource[fieldName], query, dataStore);
     }
   });
 
@@ -72,6 +68,7 @@ function instantiate(InstanceConstructor, data, query, dataStore) {
       resource = expandResource(fieldNames, resource, q, dataStore);
     }
 
+    // Expand the custom data even if it is not explicitly required
     if (resource.customData && !(resource.customData instanceof CustomData)) {
       resource.customData = instantiate(CustomData, resource.customData, q, dataStore);
     }

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -259,6 +259,12 @@ describe('Resources: ', function () {
             var result = test.cbSpy.args[0];
             common.assert.instanceOf(result[1].account,Account);
           });
+
+          it('should return an expanded instance of Account', function() {
+            var result = test.cbSpy.args[0];
+            common.assert.instanceOf(result[1].account, Account);
+          });
+
           it('should return the correct account on the idSiteResult',function(){
             var result = test.cbSpy.args[0];
             common.assert.equal(result[1].account.href,accountHref);

--- a/test/sp.resource.resourceFactory_test.js
+++ b/test/sp.resource.resourceFactory_test.js
@@ -2,6 +2,9 @@ var common = require('./common');
 var _ = common._;
 
 var Tenant = require('../lib/resource/Tenant');
+var Account = require('../lib/resource/Account');
+var Group = require('../lib/resource/Group');
+var CustomData = require('../lib/resource/CustomData');
 var CollectionResource = require('../lib/resource/CollectionResource');
 
 var instantiate = require('../lib/resource/ResourceFactory').instantiate;
@@ -24,7 +27,32 @@ describe('Resources: ', function () {
       before(function () {
         data = {
           href: '',
-          items: [{href: ''}, {href: ''}],
+          items: [
+            {
+              href: '',
+              account: {
+                href: ''
+              },
+              group: {
+                href: ''
+              },
+              customData: {
+                href: ''
+              }
+            },
+            {
+              href: '',
+              account: {
+                href: ''
+              },
+              group: {
+                href: ''
+              },
+              customData: {
+                href: ''
+              }
+            }
+          ],
           offset: 0,
           limit: 5
         };
@@ -38,19 +66,78 @@ describe('Resources: ', function () {
           item.should.be.an.instanceof(Tenant);
         });
       });
+
+      describe('expand query resource initialization', function() {
+        it('should work for one expansion parameter', function() {
+          instantiate(Tenant, data, {expand: 'account'});
+
+          _.each(data.items, function(item) {
+            item.account.should.be.an.instanceof(Account);
+            item.group.should.not.be.an.instanceof(Group);
+          });
+        });
+
+        it('should work for a comma-delimited list of parameters', function() {
+          instantiate(Tenant, data, {expand: 'account,group'});
+
+          _.each(data.items, function(item) {
+            item.account.should.be.an.instanceof(Account);
+            item.group.should.be.an.instanceof(Group);
+          });
+        });
+
+        it('should expand the customData field even if not specified in expand (backwards compatibility)', function() {
+          instantiate(Tenant, data);
+
+          _.each(data.items, function(item) {
+            item.customData.should.be.an.instanceof(CustomData);
+          });
+        });
+      });
     });
+
 
     describe('if data is a resource', function(){
       var data;
 
       before(function () {
-        data = {href: ''};
+        data = {
+          href: '',
+          account: {
+            href: ''
+          },
+          group: {
+            href: ''
+          },
+          customData: {
+            href: ''
+          }
+        };
       });
 
       it('should return wrapped obj', function(){
         var coll = instantiate(Tenant, data);
 
         coll.should.be.an.instanceof(Tenant);
+      });
+
+      describe('expand query resource initialization', function() {
+        it('should work for one expansion parameter', function() {
+          var coll = instantiate(Tenant, data, {expand: 'account'});
+          coll.account.should.be.an.instanceof(Account);
+          coll.group.should.not.be.an.instanceof(Group);
+        });
+
+        it('should work for a comma-delimited list of parameters', function() {
+          var coll = instantiate(Tenant, data, {expand: 'account,group'});
+          coll.account.should.be.an.instanceof(Account);
+          coll.group.should.be.an.instanceof(Group);
+        });
+
+        it('should expand the customData field even if not specified in expand (backwards compatibility)', function() {
+          var coll = instantiate(Tenant, data);
+          coll.customData.should.be.an.instanceof(CustomData);
+        });
       });
     });
   });


### PR DESCRIPTION
Implements resource expansion upon object creation through a `ResourceFactory`. When a resource is queried or created, and a valid `{expand: 'some,resource,names'}` key-value pair is attached to the query, these resources will be replaced with an appropriated Resource class instance containing the same data. When call yields a `CollectionResource` instead of a single resource, each instance in the collection will undergo this process.

Usage example:
```
var group; // Retrieved via getGroups() or created earlier

group.getAccountMemberships({expand: 'account'}, function(err, memberships) {
  if (err) {
    throw err;
  }
  
  memberships.each(function(membership, next) {
     var account = membership.account;
     
     console.log(account instanceof Account); // logs `true`

     account.getAccessTokens(function(err, accessTokens) {
       console.log('User', account.username, 'has', accessTokens.items.length, 'access tokens');
       next();
     });
  }, function() {
    console.log('Accounts memberships processed');
  });
});
```

Fixes #103 

I do need your opinion on something, however: I've only written the unit tests for this feature (and did some manual testing to ensure that it works). Do you think I should be adding integration tests for all resource instances that (can) use the `expand` property, i.e. their methods that do? This would certainly be beneficial, but would have to be an extra chuck of code that is maintained and updated every time the API updates (as the current code will continue working even if another `expand` option is added one day).