### PR TITLE
Document request options for client.createApplication

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -479,8 +479,16 @@ Client.prototype.getApplications = function () {
  * @param {Object} application
  * The {@link Application} resource to create.
  *
- * @param {ExpansionOptions} [expansionOptions]
- * Options to expand linked resources on the returned {@link Application}.
+ * @param {Object} [requestOptions]
+ * Query parameters for this request. These can be any of the {@link ExpansionOptions},
+ * e.g. to retrieve linked resources of the {@link Application} during this request, or one
+ * of the other options listed below.
+ *
+ * @param {Boolean|String} [requestOptions.createDirectory]
+ * Set this to `true` to have a a new {@link Directory} automatically created along with the Application.
+ * The generated Directory’s name will reflect the new Application’s name as best as is possible,
+ * guaranteeing that it is unique compared to any of your existing Directories. If you would like
+ * a different name, simply put the value you would like instead of `true`.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link Application}).

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -493,13 +493,27 @@ Client.prototype.getApplications = function () {
  * @param {Function} callback
  * Callback function, will be called with (err, {@link Application}).
  *
- * @example
+ * @example <caption>Create a new application.</caption>
  * var newApplication = {
  *   name: 'Todo Application'
  * }
  *
  * client.createApplication(newApplication, function (err, application) {
  *   console.log(application);
+ * });
+ *
+ * @example <caption>Create a new application and new directory at the same time.</caption>
+ *
+ * var newApplication = {
+ *   name: 'Todo Application'
+ * };
+ *
+ * var options = {
+ *   createDirectory: 'Primary Accounts'
+ * };
+ *
+ * client.createApplication(newApplication, options, function(err, application) {
+ *   console.log(err, application);
  * });
  */
 Client.prototype.createApplication = function () {

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -98,8 +98,16 @@ Tenant.prototype.getOrganizations = function getTenantOrganizations(/* [options,
  * @param {Object} application
  * The {@link Application} resource to create.
  *
- * @param {ExpansionOptions} [options]
- * Options to expand linked resources on the returned {@link Application}.
+ * @param {Object} [requestOptions]
+ * Query parameters for this request. These can be any of the {@link ExpansionOptions},
+ * e.g. to retrieve linked resources of the {@link Application} during this request, or one
+ * of the other options listed below.
+ *
+ * @param {Boolean|String} [requestOptions.createDirectory]
+ * Set this to `true` to have a a new {@link Directory} automatically created along with the Application.
+ * The generated Directory’s name will reflect the new Application’s name as best as is possible,
+ * guaranteeing that it is unique compared to any of your existing Directories. If you would like
+ * a different name, simply put the value you would like instead of `true`.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link Application}).


### PR DESCRIPTION
Documents the request options for the `client.createApplication` method.

#### How to verify

Read the new docs and verify that they document the additional options for `client.createApplication()` properly.

Fixes #542 