### PR TITLE
Remove sub requirement in StormpathAssertionAuthenticator

### DIFF
--- a/lib/authc/StormpathAssertionAuthenticator.js
+++ b/lib/authc/StormpathAssertionAuthenticator.js
@@ -44,7 +44,6 @@ function StormpathAssertionAuthenticator(application) {
  * @param {String} tokenRequest.stormpath_token
  * The Stormpath Token, from the ID Site or SAML callback.  This is a compacted JWT string.
  *
- *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link AssertionAuthenticationResult}).
  *
@@ -62,7 +61,6 @@ function StormpathAssertionAuthenticator(application) {
  *     console.log(account.email + ' has authenticated');
  *   });
  * });
- *
  */
 StormpathAssertionAuthenticator.prototype.authenticate = function authenticate(stormpathToken, callback) {
   var dataStore = this.dataStore;
@@ -76,21 +74,21 @@ StormpathAssertionAuthenticator.prototype.authenticate = function authenticate(s
       return callback(jwt.body.err);
     }
 
+    var account = null;
+
     // For Stormpath mapped JWT fields, see:
     // https://docs.stormpath.com/rest/product-guide/latest/005_auth_n.html#step-5-stormpath-response-with-jwt
-    var accountHref = jwt.body.sub;
-
-    if (!accountHref) {
-      return callback(new Error('Stormpath Account HREF (sub) in JWT not provided.'));
+    if (jwt.body.sub) {
+      account = {
+        href: jwt.body.sub
+      };
     }
 
     callback(null, new AssertionAuthenticationResult(
       dataStore, {
         stormpath_token: stormpathToken,
         expandedJwt: jwt,
-        account: {
-          href: accountHref
-        }
+        account: account
       }
     ));
   });

--- a/test/it/stormpath_assertion_authenticator_it.js
+++ b/test/it/stormpath_assertion_authenticator_it.js
@@ -87,15 +87,15 @@ describe('StormpathAssertionAuthenticator', function () {
         });
       });
 
-      it('fails when valid token is passed but missing account href (sub)', function (done) {
+      it('succeeds when passed a valid token without an account href (sub)', function (done) {
         var validEmptyToken = jwt.create({}, secret)
           .setExpiration(expireAt)
           .compact();
 
         authenticator.authenticate(validEmptyToken, function (err, result) {
-          assert.isOk(err);
-          assert.isNotOk(result);
-          assert.equal(err.message, 'Stormpath Account HREF (sub) in JWT not provided.');
+          assert.isNotOk(err);
+          assert.isOk(result);
+          assert.isNull(result.account);
           done();
         });
       });


### PR DESCRIPTION
Fixes so that if a `sub` isn't provided in the JWT being authenticated with the `StormpathAssertionAuthenticator`, it simply returns `null`.

#### How to verify

Use the `StormpathAssertionAuthenticator` and pass in a JWT that does not have a `sub`. Verify that the authentication result returned has the account set to `null`.

Fixes #547