### PR TITLE
Add SMTP server resource support

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -758,6 +758,44 @@ Client.prototype.createOrganization = function createOrganization() {
 };
 
 /**
+ * Creates a new SMTP server resource in the current {@link Tenant}.
+ *
+ * @param {Object} server
+ * The {@link SmtpServer} resource to create.
+ *
+ * @param {ExpansionOptions} [expansionOptions]
+ * Options to expand linked resources on the returned {@link SmtpServer}.
+ *
+ * @param {Function} callback
+ * Callback function, will be called with (err, {@link SmtpServer}).
+ *
+ * @example
+ * var newSmtpServer = {
+ *   name: 'My SMTP Server',
+ *   username: 'server username',
+ *   password: 'server password',
+ *   host: 'email.example.com',
+ *   securityProtocol: 'TLS',
+ *   port: 25
+ * };
+ *
+ * client.createSmtpServer(newSmtpServer, function (err, smtpServer) {
+ *   console.log(smtpServer);
+ * });
+ */
+Client.prototype.createSmtpServer = function createSmtpServer() {
+  var args = utils.resolveArgs(arguments, ['server', 'options', 'callback']);
+
+  this.getCurrentTenant(function (err, tenant) {
+    if (err) {
+      return args.callback(err);
+    }
+
+    return tenant.createSmtpServer(args.server, args.options, args.callback);
+  });
+};
+
+/**
  * Retrieves a {@link Account} resource.
  *
  * @param {String} href
@@ -881,7 +919,6 @@ Client.prototype.getGroupMembership = function () {
   return this.getResource(args.href, args.options, require('./resource/GroupMembership'), args.callback);
 };
 
-
 /**
  * Retrieves a {@link Organization} resource.
  *
@@ -963,6 +1000,37 @@ Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
     }
 
     return tenant.getIdSites(args.options, args.callback);
+  });
+};
+
+/**
+ * Retrieves all the {@link SmtpServer} resources for the current {@link Tenant}.
+ *
+ * @param {CollectionQueryOptions} [collectionQueryOptions]
+ * Options for querying, paginating, and expanding the collection.
+ *
+ * @param {Function} callback
+ * The function to call when then the operation is complete. Will be called
+ * with the parameters (err, {@link CollectionResource}). The collection will
+ * be a list of {@link IdSiteModel} objects.
+ *
+ * @example
+ * client.getSmtpServers(function (err, smtpServers) {
+ *   smtpServers.each(function (smtpServer, next) {
+ *     console.log(smtpServer);
+ *     next();
+ *   })
+ * });
+ */
+Client.prototype.getSmtpServers = function getSmtpServers(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.getCurrentTenant(function onGetCurrentTenant(err, tenant) {
+    if (err) {
+      return args.callback(err, null);
+    }
+
+    return tenant.getSmtpServers(args.options, args.callback);
   });
 };
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1004,6 +1004,32 @@ Client.prototype.getIdSites = function getIdSites(/* [options,] callback */) {
 };
 
 /**
+ * Retrieves a {@link SmtpServer} resource.
+ *
+ * @param {String} href
+ * The href of the {@link SmtpServer}.
+ *
+ * @param {ExpansionOptions} [expansionOptions]
+ * For retrieving linked resources of the {@link SmtpServer} during
+ * this request.
+ *
+ * @param {Function} callback
+ * Callback function, will be called with (err, {@link SmtpServer}).
+ *
+ * @example
+ *
+ * var href = "https://api.stormpath.com/v1/smtpServers/4WCCtc0oCRDzQdAHVQTqjz";
+ *
+ * client.getSmtpServer(href, function (err, smtpServer) {
+ *   console.log(smtpServer);
+ * });
+ */
+Client.prototype.getSmtpServer = function () {
+  var args = utils.resolveArgs(arguments, ['href', 'options', 'callback']);
+  return this.getResource(args.href, args.options, require('./resource/SmtpServer'), args.callback);
+};
+
+/**
  * Retrieves all the {@link SmtpServer} resources for the current {@link Tenant}.
  *
  * @param {CollectionQueryOptions} [collectionQueryOptions]

--- a/lib/resource/SmtpServer.js
+++ b/lib/resource/SmtpServer.js
@@ -1,0 +1,28 @@
+'use strict';
+
+var utils = require('../utils');
+var InstanceResource = require('./InstanceResource');
+
+/**
+ * @class SmtpServer
+ *
+ * @description
+ * Encapsulates a SmtpServer resource. For full documentation of this resource, please see
+ * [REST API Reference: SMTP Server](https://docs.stormpath.com/rest/product-guide/latest/reference.html?#smtp-server).
+ *
+ * This class should not be manually constructed. It should be obtained from one of these methods:
+ * - {@link Client#getSmtpServers Client.getSmtpServers()}
+ * - {@link Tenant#getSmtpServers Tenant.getSmtpServers()}
+ *
+ * @augments {InstanceResource}
+ *
+ * @param {Object} smtpServerResource
+ * The JSON representation of this resource, retrieved the Stormpath REST API.
+ */
+function SmtpServer() {
+  SmtpServer.super_.apply(this, arguments);
+}
+
+utils.inherits(SmtpServer, InstanceResource);
+
+module.exports = SmtpServer;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -170,6 +170,23 @@ Tenant.prototype.createDirectory = function createTenantDirectory(/* dir, [optio
 };
 
 /**
+ * Creates a new SmtpServer resource.
+ *
+ * @param {Object} server
+ * The {@link SmtpServer} resource to create.
+ *
+ * @param {ExpansionOptions} [options]
+ * Options to expand linked resources on the returned {@link SmtpServer}.
+ *
+ * @param {Function} callback
+ * Callback function, will be called with (err, {@link SmtpServer}).
+ */
+Tenant.prototype.createSmtpServer = function createSmtpServer(/* server, [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['server', 'options', 'callback']);
+  this.dataStore.createResource('/smtpServers', args.options, args.server, require('./SmtpServer'), args.callback);
+};
+
+/**
  * Verifies an account-specific email verification token, obtaining the verified
  * Account and providing it to the specified callback.  This is the token that
  * is sent to the user by email, so they need to click on the link and arrive on
@@ -235,6 +252,23 @@ Tenant.prototype.getCustomData = function getCustomData(/* [options,] callback *
 Tenant.prototype.getIdSites = function getTenantIdSites(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
   return this.dataStore.getResource(this.idSites.href, args.options, require('./IdSiteModel'), args.callback);
+};
+
+/**
+ * Retrieves all the {@link SmtpServer} resources for this resource.
+ *
+ * @param {CollectionQueryOptions} [collectionQueryOptions]
+ * Options for querying, paginating, and expanding the collection.
+ *
+ * @param {Function} callback
+ * The function to call when then the operation is complete. Will be called
+ * with the parameters (err, {@link CollectionResource}). The collection will
+ * be a list of {@link SmtpServer} objects.
+ *
+ */
+Tenant.prototype.getSmtpServers = function getSmtpServers(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.smtpServers.href, args.options, require('./SmtpServer'), args.callback);
 };
 
 module.exports = Tenant;

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -12,6 +12,7 @@ var GroupMembership = require('../lib/resource/GroupMembership');
 var Directory = require('../lib/resource/Directory');
 var Tenant = require('../lib/resource/Tenant');
 var Application = require('../lib/resource/Application');
+var SmtpServer = require('../lib/resource/SmtpServer');
 var DataStore = require('../lib/ds/DataStore');
 
 function makeTestClient (options) {
@@ -1081,6 +1082,52 @@ describe('Client', function () {
       getCurrentTenantStub.should.have.been.calledThrice;
       getTenantIdSites.should.have.been.calledTwice;
       /* jshint +W030 */
+    });
+  });
+
+  describe('call to getSmtpServer', function () {
+    var sandbox, client, getResourceStub, cbSpy, href, opt;
+
+    before(function (done) {
+      sandbox = sinon.sandbox.create();
+      cbSpy = sandbox.spy();
+      opt = {};
+      href = '/smtpServers/foo';
+      client = makeTestClient({apiKey: apiKey});
+
+      client.on('error', function (err) {
+        throw err;
+      });
+
+      client.on('ready', function () {
+        getResourceStub = sandbox.stub(client._dataStore, 'getResource', function (href, options, ctor, cb) {
+          cb();
+        });
+        // call without optional param
+        client.getSmtpServer(href, cbSpy);
+        // call with optional param
+        client.getSmtpServer(href, opt, cbSpy);
+
+        done();
+      });
+    });
+
+    after(function () {
+      sandbox.restore();
+    });
+
+    it('should get account', function () {
+      /* jshint -W030 */
+      getResourceStub.should.have.been.calledTwice;
+      cbSpy.should.have.been.calledTwice;
+      /* jshint +W030 */
+
+      // call without optional param
+      getResourceStub.should.have.been
+        .calledWith(href, null, SmtpServer, cbSpy);
+      // call with optional param
+      getResourceStub.should.have.been
+        .calledWith(href, opt, SmtpServer, cbSpy);
     });
   });
 });

--- a/test/sp.resource.tenant_test.js
+++ b/test/sp.resource.tenant_test.js
@@ -8,6 +8,7 @@ var Tenant = require('../lib/resource/Tenant');
 var Application = require('../lib/resource/Application');
 var Directory = require('../lib/resource/Directory');
 var IdSiteModel = require('../lib/resource/IdSiteModel');
+var SmtpServer = require('../lib/resource/SmtpServer');
 var DataStore = require('../lib/ds/DataStore');
 
 describe('Resources: ', function () {
@@ -187,6 +188,86 @@ describe('Resources: ', function () {
         // call with optional param
         createResourceStub.should.have.been
           .calledWith(createDirPath, opt, app, Directory, cbSpy);
+      });
+    });
+
+    describe('when calling .createSmtpServer()', function () {
+      var options;
+      var cbSpy;
+      var tenant;
+      var sandbox;
+      var smtpServer;
+      var createResourceStub;
+      var createSmtpServerPath;
+
+      before(function () {
+        options = {};
+        sandbox = sinon.sandbox.create();
+        createSmtpServerPath = '/smtpServers';
+        smtpServer = {name: '2dd1dfc4-08fa-4c1c-a721-af95f1bfe556'};
+        tenant = new Tenant({applications: {href: 'boom!'}}, dataStore);
+
+        createResourceStub = sandbox.stub(dataStore, 'createResource', function (arg1, arg2, arg3, arg4, callback) {
+          callback();
+        });
+
+        cbSpy = sandbox.spy();
+
+        tenant.createSmtpServer(smtpServer, cbSpy);
+        tenant.createSmtpServer(smtpServer, options, cbSpy);
+      });
+
+      after(function () {
+        sandbox.restore();
+      });
+
+      it('should call createResource with the /smtpServers path', function () {
+        /* jshint -W030 */
+        createResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        createResourceStub.should.have.been.calledWith(createSmtpServerPath, null, smtpServer, SmtpServer, cbSpy);
+        createResourceStub.should.have.been.calledWith(createSmtpServerPath, options, smtpServer, SmtpServer, cbSpy);
+      });
+    });
+
+    describe('when calling .getSmtpServers()', function () {
+      var sandbox, tenant, getResourceStub, opts, cbSpy;
+
+      before(function () {
+        sandbox = sinon.sandbox.create();
+
+        opts = {};
+
+        tenant = new Tenant({
+          smtpServers: {
+            href: 'boom!'
+          }
+        }, dataStore);
+
+        getResourceStub = sandbox.stub(dataStore, 'getResource', function (href, options, ctor, cb) {
+          cb();
+        });
+
+        cbSpy = sandbox.spy();
+
+        tenant.getSmtpServers(opts, cbSpy);
+        tenant.getSmtpServers(cbSpy);
+      });
+
+      after(function () {
+        sandbox.restore();
+      });
+
+      it('should call getResource with the smtpServers href', function () {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        getResourceStub.should.have.been.calledWith('boom!', null, SmtpServer, cbSpy);
+        getResourceStub.should.have.been.calledWith('boom!', opts, SmtpServer, cbSpy);
       });
     });
 


### PR DESCRIPTION
Add support for the retrieving all and creating new `/smtpServers` resources.

#### How to verify

Test the new methods using the sample application below. The SMTP credentials below should be valid but it's only for a SMTP server sandbox, so they aren't sensitive in any way.

```javascript
var stormpath = require('stormpath');

var client = new stormpath.Client();

var newSmtpServer = {
  name: 'My New SMTP Server!',
  host: 'mailtrap.io',
  username: '35082bfcb8b319',
  password: 'f2d06c51a4b88f',
  port: 25
};

client.createSmtpServer(newSmtpServer, function (err, smtpServer) {
  // Only break on the error if isn't already created (code 13003).
  if (err && err.code !== 13003) {
    return console.error('Error!', err);
  }

  client.getSmtpServers(function (err, smtpServers) {
    if (err) {
        return console.error('Error!', err);
    }

    smtpServers.each(function (server, next) {
      console.log('Found SMTP server!', server);
      next();
    });
  });
});
```

Fixes #528 