### PR TITLE
OAuth authenticator scope factory

### DIFF
--- a/lib/jwt/jwt-authentication-result.js
+++ b/lib/jwt/jwt-authentication-result.js
@@ -104,7 +104,7 @@ function JwtAuthenticationResult(application,data) {
    * @type {Jwt}
    */
 
-  if(this.accessToken) {
+  if(this.accessToken){
     this.accessToken = nJwt.verify(this.accessToken, apiKey.secret);
     this.account = {
       href: this.accessToken.body.sub
@@ -123,7 +123,7 @@ function JwtAuthenticationResult(application,data) {
    * @type {Jwt}
    */
 
-  if(this.refreshToken) {
+  if(this.refreshToken){
     this.refreshToken = nJwt.verify(this.refreshToken, apiKey.secret);
   }
 }

--- a/lib/jwt/jwt-authentication-result.js
+++ b/lib/jwt/jwt-authentication-result.js
@@ -61,9 +61,9 @@ var nJwt = require('njwt');
  * @param {AccessTokenResponse} accessTokenResponse
  * The access token response from the Stormpath REST API.
  */
-function JwtAuthenticationResult(application,data) {
+function JwtAuthenticationResult(application, data) {
   if (!(this instanceof JwtAuthenticationResult)) {
-    return new JwtAuthenticationResult(application,data);
+    return new JwtAuthenticationResult(application, data);
   }
 
   /**
@@ -79,11 +79,11 @@ function JwtAuthenticationResult(application,data) {
     on this object - but convert underscores to camelcase because
     that's the node way bro.
    */
-  Object.keys(data).reduce(function(a,key){
-    var newKey = key.replace(/_([A-Za-z])/g, function (g) { return g[1].toUpperCase(); });
+  Object.keys(data).reduce(function(a, key) {
+    var newKey = key.replace(/_([A-Za-z])/g, function(g) { return g[1].toUpperCase(); });
     a[newKey] = data[key];
     return a;
-  },this);
+  }, this);
 
   /*
     Assign application after the key reduction above,
@@ -104,7 +104,7 @@ function JwtAuthenticationResult(application,data) {
    * @type {Jwt}
    */
 
-  if(this.accessToken){
+  if (this.accessToken) {
     this.accessToken = nJwt.verify(this.accessToken, apiKey.secret);
     this.account = {
       href: this.accessToken.body.sub
@@ -123,7 +123,7 @@ function JwtAuthenticationResult(application,data) {
    * @type {Jwt}
    */
 
-  if(this.refreshToken){
+  if (this.refreshToken) {
     this.refreshToken = nJwt.verify(this.refreshToken, apiKey.secret);
   }
 }

--- a/lib/jwt/jwt-authentication-result.js
+++ b/lib/jwt/jwt-authentication-result.js
@@ -61,9 +61,9 @@ var nJwt = require('njwt');
  * @param {AccessTokenResponse} accessTokenResponse
  * The access token response from the Stormpath REST API.
  */
-function JwtAuthenticationResult(application, data) {
+function JwtAuthenticationResult(application,data) {
   if (!(this instanceof JwtAuthenticationResult)) {
-    return new JwtAuthenticationResult(application, data);
+    return new JwtAuthenticationResult(application,data);
   }
 
   /**
@@ -79,11 +79,11 @@ function JwtAuthenticationResult(application, data) {
     on this object - but convert underscores to camelcase because
     that's the node way bro.
    */
-  Object.keys(data).reduce(function(a, key) {
-    var newKey = key.replace(/_([A-Za-z])/g, function(g) { return g[1].toUpperCase(); });
+  Object.keys(data).reduce(function(a,key){
+    var newKey = key.replace(/_([A-Za-z])/g, function (g) { return g[1].toUpperCase(); });
     a[newKey] = data[key];
     return a;
-  }, this);
+  },this);
 
   /*
     Assign application after the key reduction above,
@@ -104,7 +104,7 @@ function JwtAuthenticationResult(application, data) {
    * @type {Jwt}
    */
 
-  if (this.accessToken) {
+  if(this.accessToken) {
     this.accessToken = nJwt.verify(this.accessToken, apiKey.secret);
     this.account = {
       href: this.accessToken.body.sub
@@ -123,7 +123,7 @@ function JwtAuthenticationResult(application, data) {
    * @type {Jwt}
    */
 
-  if (this.refreshToken) {
+  if(this.refreshToken) {
     this.refreshToken = nJwt.verify(this.refreshToken, apiKey.secret);
   }
 }

--- a/lib/jwt/jwt-authentication-result.js
+++ b/lib/jwt/jwt-authentication-result.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var nJwt = require('njwt');
+var utils = require('../utils');
 
 /**
  * @typedef {Object} AccessTokenResponse
@@ -139,13 +140,17 @@ JwtAuthenticationResult.prototype.expandedJwt = null;
  *
  * @description Get the account resource of the account that has authenticated.
  *
- * @param  {Function} callback
+ * @param {ExpansionOptions} options
+ * Options for expanding the fetched {@link Account} resource.
  *
+ * @param  {Function} callback
  * The callback to call with the parameters (err, {@link Account}).
  */
-JwtAuthenticationResult.prototype.getAccount = function getAccount(callback) {
+JwtAuthenticationResult.prototype.getAccount = function getAccount(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
   // Workaround because I don't have access to a stormpath client.
-  this.application.dataStore.getResource(this.account.href, require('../resource/Account'), callback);
+  this.application.dataStore.getResource(this.account.href, args.options, require('../resource/Account'), args.callback);
 };
 
 module.exports = JwtAuthenticationResult;

--- a/lib/jwt/jwt-authenticator.js
+++ b/lib/jwt/jwt-authenticator.js
@@ -105,6 +105,16 @@ JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){
 
         if(jwt.header.kid){
           if(self.localValidation){
+            // Transfers all body fields to `claims` to maintain consistency
+            // with remote results. Does not remove the body as to preserve
+            // backwards compatibility.
+            jwt.claims = {};
+            Object.keys(jwt.body).forEach(function(key) {
+              if (jwt.body.hasOwnProperty(key)) {
+                jwt.claims[key] = jwt.body[key];
+              }
+            });
+
             return cb(null, new JwtAuthenticationResult(self.application,{
               jwt: token,
               expandedJwt: jwt,

--- a/lib/jwt/jwt-authenticator.js
+++ b/lib/jwt/jwt-authenticator.js
@@ -119,6 +119,23 @@ JwtAuthenticator.prototype.authenticate = function authenticate(token,cb){
             if(err){
               cb(err);
             }else{
+              // Preserve scope
+              if (jwt.body.scope) {
+                return njwt.verify(response.jwt, secret, function(err, newJwt) {
+                  if (err) {
+                    cb(err);
+                  }
+
+                  // Copy the scope on the authorized token
+                  newJwt.body.scope = jwt.body.scope;
+                  newJwt.setSigningKey(secret);
+                  response.jwt = newJwt.compact();
+                  response.expandedJwt.claims.scope = jwt.body.scope;
+
+                  cb(null, new JwtAuthenticationResult(self.application,response));
+                });
+              }
+
               cb(null, new JwtAuthenticationResult(self.application,response));
             }
           });

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -57,14 +57,14 @@ function OAuthClientCredentialsAuthenticationResult(application, accessTokenResp
 util.inherits(OAuthClientCredentialsAuthenticationResult, JwtAuthenticationResult);
 
 /**
-* @function
-*
-* @description
-* Get the access token resource for the authenticated account.
-*
-* @param {Function} callback
-* The callback to call with the parameters (err, {@link AccessToken})
-*/
+ * @function
+ *
+ * @description
+ * Get the access token resource for the authenticated account.
+ *
+ * @param {Function} callback
+ * The callback to call with the parameters (err, {@link AccessToken})
+ */
 OAuthClientCredentialsAuthenticationResult.prototype.getAccessToken = function getAccessToken(callback) {
   var href = this.accessTokenResponse.stormpath_access_token_href;
 

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var util = require('util');
-
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
+var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
 /**
  * @class
@@ -95,9 +95,13 @@ function OAuthClientCredentialsAuthenticator(application) {
     return new OAuthClientCredentialsAuthenticator(application);
   }
 
+  OAuthClientCredentialsAuthenticator.super_.apply(this, arguments);
+
   this.application = application;
 
 }
+
+util.inherits(OAuthClientCredentialsAuthenticator, ScopeFactoryAuthenticator);
 
 /**
  * Formats and validates the object wrapping the api key into the format accepted by
@@ -117,7 +121,8 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
   return {
     client_id: formData.apiKey.id,
     client_secret: formData.apiKey.secret,
-    grant_type: 'client_credentials'
+    grant_type: 'client_credentials',
+    scope: formData.scope
   };
 };
 
@@ -159,6 +164,7 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
  */
 OAuthClientCredentialsAuthenticator.prototype.authenticate = function authenticate(authenticationRequest, callback) {
   var application = this.application;
+  var self = this;
 
   if (typeof authenticationRequest !== 'object') {
     throw new Error('The \'authenticationRequest\' parameter must be an object.');
@@ -171,12 +177,12 @@ OAuthClientCredentialsAuthenticator.prototype.authenticate = function authentica
   var href = application.href + '/oauth/token';
   var apiData = this._formatRequestBody(authenticationRequest);
 
-  application.dataStore.createResource(href, {form: apiData}, function(err, authenticationRequest) {
+  application.dataStore.createResource(href, {form: apiData}, function(err, tokenData) {
     if (err) {
       return callback(err);
     }
 
-    callback(null, new OAuthClientCredentialsAuthenticationResult(application, authenticationRequest));
+    self._createAuthResult(application, apiData, tokenData, OAuthClientCredentialsAuthenticationResult, callback);
   });
 };
 

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -188,7 +188,7 @@ OAuthClientCredentialsAuthenticator.prototype.authenticate = function authentica
       return callback(err);
     }
 
-    self._createAuthResult(application, apiData, tokenData, OAuthClientCredentialsAuthenticationResult, callback);
+    self.scopeAuthResult(application, apiData, tokenData, OAuthClientCredentialsAuthenticationResult, callback);
   });
 };
 

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var util = require('util');
+var util = require('../utils');
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
 var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
@@ -123,8 +123,7 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
   return {
     client_id: formData.apiKey.id,
     client_secret: formData.apiKey.secret,
-    grant_type: 'client_credentials',
-    scope: formData.scope
+    grant_type: 'client_credentials'
   };
 };
 
@@ -182,13 +181,14 @@ OAuthClientCredentialsAuthenticator.prototype.authenticate = function authentica
 
   var href = application.href + '/oauth/token';
   var apiData = this._formatRequestBody(authenticationRequest);
+  var scopeFactoryData = util.extend({}, apiData, {scope: authenticationRequest.scope});
 
   application.dataStore.createResource(href, {form: apiData}, function(err, tokenData) {
     if (err) {
       return callback(err);
     }
 
-    self.scopeAuthResult(application, apiData, tokenData, OAuthClientCredentialsAuthenticationResult, callback);
+    self.scopeAuthResult(application, scopeFactoryData, tokenData, OAuthClientCredentialsAuthenticationResult, callback);
   });
 };
 

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -74,6 +74,8 @@ OAuthClientCredentialsAuthenticationResult.prototype.getAccessToken = function g
 /**
  * @class
  *
+ * @augments ScopeFactoryAuthenticator
+ *
  * @description
  *
  * Creates an authenticator that can be used to exchange a client api key for an access token.
@@ -140,6 +142,10 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
  *
  * @param {String} ClientCredentialsRequest.apiKey.secret
  * The client secret for the api key for the account that is attempting to authenticate.
+ *
+ * @param {String} ClientCredentialsRequest.scope
+ * Optional scope that can be attached to the request. See {@link ScopeFactoryAuthenticator}
+ * for more details.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link OAuthClientCredentialsAuthenticationResult}).

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -130,19 +130,19 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
 /**
  * @function
  *
- * @param {Object} ClientCredentialsRequest
+ * @param {Object} clientCredentialsRequest
  * An object with the client credentials grant request properties.
  *
- * @param {Object} ClientCredentialsRequest.apiKey
+ * @param {Object} clientCredentialsRequest.apiKey
  * The api key object of the account that is attempting to authenticate.
  *
- * @param {String} ClientCredentialsRequest.apiKey.id
+ * @param {String} clientCredentialsRequest.apiKey.id
  * The client id for the api key for the account that is attempting to authenticate.
  *
- * @param {String} ClientCredentialsRequest.apiKey.secret
+ * @param {String} clientCredentialsRequest.apiKey.secret
  * The client secret for the api key for the account that is attempting to authenticate.
  *
- * @param {String} ClientCredentialsRequest.scope
+ * @param {String} [clientCredentialsRequest.scope]
  * User-requested scope that will be passed to the scope factory, if configured.
  * See {@link ScopeFactoryAuthenticator} for more details.
  *
@@ -151,14 +151,14 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
  *
  * @example
  *
- * var authenticationRequest = {
+ * var clientCredentialsRequest = {
  *   apiKey: {
  *    id: 'WuQvJFCj+MNHy/MldQp/dVu9WjCc7EYl0yjR7fUp2ym',
  *    secret: '7HB3CD9YN5YXKFWRQEUIPMGZ1'
  *   };
  * };
  *
- * authenticator.authenticate(authenticationRequest, function(err, oAuthClientCredentialsAuthenticationResult) {
+ * authenticator.authenticate(clientCredentialsRequest, function(err, oAuthClientCredentialsAuthenticationResult) {
  *   oAuthClientCredentialsAuthenticationResult.getAccount(function(err, account){
  *     console.log(
  *      oAuthClientCredentialsAuthenticationResult.accessTokenResponse.access_token

--- a/lib/oauth/client-credentials.js
+++ b/lib/oauth/client-credentials.js
@@ -143,8 +143,8 @@ OAuthClientCredentialsAuthenticator.prototype._formatRequestBody = function _for
  * The client secret for the api key for the account that is attempting to authenticate.
  *
  * @param {String} ClientCredentialsRequest.scope
- * Optional scope that can be attached to the request. See {@link ScopeFactoryAuthenticator}
- * for more details.
+ * User-requested scope that will be passed to the scope factory, if configured.
+ * See {@link ScopeFactoryAuthenticator} for more details.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link OAuthClientCredentialsAuthenticationResult}).

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -133,7 +133,7 @@ OAuthPasswordGrantRequestAuthenticator.prototype.authenticate = function authent
         return callback(err);
       }
 
-      self._createAuthResult(application, formData, data, OAuthPasswordGrantAuthenticationResult, callback);
+      self.scopeAuthResult(application, formData, data, OAuthPasswordGrantAuthenticationResult, callback);
     });
   }
 };

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -27,9 +27,9 @@ var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
  * The access token response from the Stormpath REST API.
  *
  */
-function OAuthPasswordGrantAuthenticationResult(application, accessTokenResponse) {
+function OAuthPasswordGrantAuthenticationResult(application,accessTokenResponse){
   if (!(this instanceof OAuthPasswordGrantAuthenticationResult)) {
-    return new OAuthPasswordGrantAuthenticationResult(application, accessTokenResponse);
+    return new OAuthPasswordGrantAuthenticationResult(application,accessTokenResponse);
   }
 
   OAuthPasswordGrantAuthenticationResult.super_.apply(this, arguments);
@@ -123,13 +123,13 @@ OAuthPasswordGrantRequestAuthenticator.prototype.authenticate = function authent
   var application = this.application;
   var self = this;
 
-  if (arguments.length !==2 ) {
+  if(arguments.length !==2 ){
     throw new Error('Must call authenticate with (data,callback)');
-  }else {
+  }else{
     var href = application.href + '/oauth/token';
     formData.grant_type='password';
     application.dataStore.createResource(href, {form:formData}, function(err, data) {
-      if (err) {
+      if(err){
         return callback(err);
       }
 

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -49,6 +49,8 @@ util.inherits(OAuthPasswordGrantAuthenticationResult, JwtAuthenticationResult);
 /**
  * @class
  *
+ * @augments ScopeFactoryAuthenticator
+ *
  * @description
  *
  * Creates an authenticator that can be used to exchange a username and password
@@ -89,6 +91,10 @@ util.inherits(OAuthPasswordGrantRequestAuthenticator, ScopeFactoryAuthenticator)
  *
  * @param {String} passwordGrantRequest.password
  * The password of the account that is attempting to authenticate.
+ *
+ * @param {String} passwordGrantRequest.scope
+ * Optional scope that can be attached to the request. See {@link ScopeFactoryAuthenticator}
+ * for more details.
  *
  * @param {String} [passwordGrantRequest.accountStore]
  * The HREF of an account store to target during the authentication attempt.

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var util = require('util');
+var util = require('../utils');
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
 var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
@@ -128,7 +128,15 @@ OAuthPasswordGrantRequestAuthenticator.prototype.authenticate = function authent
   }else{
     var href = application.href + '/oauth/token';
     formData.grant_type='password';
-    application.dataStore.createResource(href, {form:formData}, function(err, data) {
+
+    var form = util.extend({}, formData);
+
+    // No need to send the scope to the API
+    if (form.scope) {
+      delete form.scope;
+    }
+
+    application.dataStore.createResource(href, {form: form}, function(err, data) {
       if(err){
         return callback(err);
       }

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var util = require('util');
-
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
+var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
 /**
  * @class
@@ -27,9 +27,9 @@ var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
  * The access token response from the Stormpath REST API.
  *
  */
-function OAuthPasswordGrantAuthenticationResult(application,accessTokenResponse){
+function OAuthPasswordGrantAuthenticationResult(application, accessTokenResponse) {
   if (!(this instanceof OAuthPasswordGrantAuthenticationResult)) {
-    return new OAuthPasswordGrantAuthenticationResult(application,accessTokenResponse);
+    return new OAuthPasswordGrantAuthenticationResult(application, accessTokenResponse);
   }
 
   OAuthPasswordGrantAuthenticationResult.super_.apply(this, arguments);
@@ -71,8 +71,12 @@ function OAuthPasswordGrantRequestAuthenticator(application) {
     return new OAuthPasswordGrantRequestAuthenticator(application);
   }
 
+  OAuthPasswordGrantRequestAuthenticator.super_.apply(this, arguments);
+
   this.application = application;
 }
+
+util.inherits(OAuthPasswordGrantRequestAuthenticator, ScopeFactoryAuthenticator);
 
 /**
  * @function
@@ -109,18 +113,21 @@ function OAuthPasswordGrantRequestAuthenticator(application) {
  * });
  *
  */
-OAuthPasswordGrantRequestAuthenticator.prototype.authenticate = function authenticate(data,callback) {
+OAuthPasswordGrantRequestAuthenticator.prototype.authenticate = function authenticate(formData, callback) {
   var application = this.application;
-  if(arguments.length !==2 ){
+  var self = this;
+
+  if (arguments.length !==2 ) {
     throw new Error('Must call authenticate with (data,callback)');
-  }else{
+  }else {
     var href = application.href + '/oauth/token';
-    data.grant_type='password';
-    application.dataStore.createResource(href,{form:data},function(err,data){
-      if(err){
+    formData.grant_type='password';
+    application.dataStore.createResource(href, {form:formData}, function(err, data) {
+      if (err) {
         return callback(err);
       }
-      callback(null,new OAuthPasswordGrantAuthenticationResult(application,data));
+
+      self._createAuthResult(application, formData, data, OAuthPasswordGrantAuthenticationResult, callback);
     });
   }
 };

--- a/lib/oauth/password-grant.js
+++ b/lib/oauth/password-grant.js
@@ -92,9 +92,9 @@ util.inherits(OAuthPasswordGrantRequestAuthenticator, ScopeFactoryAuthenticator)
  * @param {String} passwordGrantRequest.password
  * The password of the account that is attempting to authenticate.
  *
- * @param {String} passwordGrantRequest.scope
- * Optional scope that can be attached to the request. See {@link ScopeFactoryAuthenticator}
- * for more details.
+ * @param {String} [passwordGrantRequest.scope]
+ * User-requested scope that will be passed to the scope factory, if configured.
+ * See {@link ScopeFactoryAuthenticator} for more details.
  *
  * @param {String} [passwordGrantRequest.accountStore]
  * The HREF of an account store to target during the authentication attempt.
@@ -104,12 +104,12 @@ util.inherits(OAuthPasswordGrantRequestAuthenticator, ScopeFactoryAuthenticator)
  *
  * @example
  *
- * var authenticationRequest = {
+ * var passwordGrantRequest = {
  *   username: 'foo@example.com',
  *   password: 'p@ssword!1'
  * };
  *
- * authenticator.authenticate(authenticationRequest, function(err, oAuthPasswordGrantAuthenticationResult) {
+ * authenticator.authenticate(passwordGrantRequest, function(err, oAuthPasswordGrantAuthenticationResult) {
  *   oAuthPasswordGrantAuthenticationResult.getAccount(function(err, account){
  *     console.log(
  *      'The access token for ' + account.email + ' is: ' +

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -6,18 +6,23 @@ var njwt = require('njwt');
 * @class
 *
 * @description
-* Encapsulates the behaviour required by OAuth authenticator classes which allow
-* for adding scope to requests.
+* Encapsulates the behavior required by OAuth authenticator classes for adding
+* scope to access tokens that are created by Stormpath.
 *
 * This class allows you to use scope factory functions to attach scope to JWT objects,
 * thus expanding the result and permitting runtime access control checks, searching,
 * etc.
 *
-* This class should not be constructed manually. Instead, OAuth authenticators should
-* inherit it and use {@link ScopeFactoryAuthenticator#scopeAuthResult `ScopeFactoryAuthenticator.scopeAuthResult()`}
-* in their authenticate methods.
+* This class should not be constructed manually. Instead, these methods are available
+* on the following authenticators:
 *
+* * {@link OAuthClientCredentialsAuthenticator}
+* * {@link OAuthPasswordGrantRequestAuthenticator}
+* * {@link OAuthStormpathSocialAuthenticator}
+* * {@link OAuthStormpathTokenAuthenticator}
 * @example
+* var application; // An application, fetched from Client.getApplication()
+*
 * function groupScopeFactory(authenticationResult, requestedScope, callback) {
 *   authenticationResult.getAccount({expand: 'groups'}, function(err, account) {
 *     if (err) {
@@ -32,11 +37,19 @@ var njwt = require('njwt');
 *   });
 * }
 *
-* var auth = new OAuthStormpathTokenAuthenticator(application);
-* auth.setScopeFactory(groupScopeFactory);
-* auth.setSigningKey(secretKey);
+* var authenticator = new OAuthPasswordGrantRequestAuthenticator(application);
+* authenticator.setScopeFactory(groupScopeFactory);
+* authenticator.setSigningKey(tenantApiKeySecret); // Same secret that was given to the previously used client
 *
-* auth.authenticate({stormpath_token: token, scope: 'admin'}, callback);
+* authenticator.authenticate({
+*   username: 'user@example.com',
+*   password: 'PAs$w0rd',
+* }, function (err, oAuthPasswordGrantAuthenticationResult) {
+*   if (err) {
+*     return console.log(err);
+*   }
+*   console.log('Access token: ', oAuthPasswordGrantAuthenticationResult.accessToken)
+* });
 */
 function ScopeFactoryAuthenticator() {}
 
@@ -44,23 +57,25 @@ function ScopeFactoryAuthenticator() {}
 * @function
 *
 * @description
-* Sets the scope factory to be used when parsing tokens.
+* Sets the scope factory to be used when parsing tokens.  The scope factory is a
+* developer-provided function that allows you to add custom scope to the tokens
+* that Stormpath creates.
 *
 * @param {Function} scopeFactory
 * The scope factory to use when processing authentication results. When it is defined,
-* and the user has added a `scope` field to their request payload, it will be invoked
-* to process the result.
+* it will be invoked with the authentication result.  You should determine which scope
+* to grant, and provide it to the callback.
 *
-* The function must have the signature (authenticationResult, requestedScope, callback).
+* The function must have the signature `(authenticationResult, requestedScope, callback)`.
 *
-* `authenticationResult` is the result returned from the API when calling `authenticator.authenticate()`,
-* and is passed in its entirety, before being processed.
+* * `authenticationResult` is the authentication result from the authenticator's
+* authentication result class.  You can use this to fetch the account that has
+* authenticated.
 *
-* `requestedScope` is the scope the end-user has requested (added to the payload) when authenticating.
-* The function is expected to return a string. If the string is non-empty it will be attached to the
-* resulting JWT's body.
+* * `requestedScope` is the scope that end-user requested, and passed as the `scope`
+* option on the authenticator's `authenticate()` method.
 *
-* The callback will be invoked with (err, resultInstance)
+* * `callback` should be called with `(err, grantedScope)`
 */
 ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;
@@ -70,13 +85,15 @@ ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorS
 * @function
 *
 * @description
-* Sets the signing key used when unpacking and packing JWTs to modify the scope
-* parameter.
+* Sets the signing that is used to sign the new access token.
 *
 * @param {String} signingKey
 * Signing key used to pack and unpack JWTs. It is <b>required</b> if the scope
 * factory is set. If the factory is invoked without a signing key, an error will
 * be passed to the callback.
+*
+* This must be the same Tenant API Key Secret that you used to create the {@link Client}
+* that was used to initiate the authentication attempt.
 */
 ScopeFactoryAuthenticator.prototype.setScopeFactorySigningKey = function setSigningKey(signingKey) {
   this.signingKey = signingKey;
@@ -125,13 +142,13 @@ ScopeFactoryAuthenticator.prototype.scopeAuthResult = function scopeAuthenticato
 
     var responseInstance = new Ctor(application, responseData);
 
-    self.scopeFactory(responseInstance, formData.scope, function(err, addedScope) {
+    self.scopeFactory(responseInstance, formData.scope, function(err, grantedScope) {
       if (err) {
         return callback(err);
       }
 
-      if (addedScope) {
-        token.body.scope = addedScope;
+      if (grantedScope) {
+        token.body.scope = grantedScope;
         token.setSigningKey(self.signingKey);
 
         responseData.access_token = token.compact();

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -5,8 +5,6 @@ var njwt = require('njwt');
 /**
 * @class
 *
-* @private
-*
 * @description
 * Encapsulates the behaviour required by OAuth authenticator classes which allow
 * for adding scope to requests.
@@ -16,8 +14,29 @@ var njwt = require('njwt');
 * etc.
 *
 * This class should not be constructed manually. Instead, OAuth authenticators should
-* inherit it and use {@link ScopeFactoryAuthenticator#_createAuthResult ScopeFactoryAuthenticator._createAuthResult()}
+* inherit it and use {@link ScopeFactoryAuthenticator#scopeAuthResult `ScopeFactoryAuthenticator.scopeAuthResult()`}
 * in their authenticate methods.
+*
+* @example
+* function groupScopeFactory(authenticationResult, requestedScope, callback) {
+*   authenticationResult.getAccount({expand: 'groups'}, function(err, account) {
+*     if (err) {
+*       return callback(err);
+*     }
+*
+*     var grantedScope = account.groups.items.map(function(group) {
+*       return group.name;
+*     }).join(' ');
+*
+*     callback(null, grantedScope);
+*   });
+* }
+*
+* var auth = new OAuthStormpathTokenAuthenticator(application);
+* auth.setScopeFactory(groupScopeFactory);
+* auth.setSigningKey(secretKey);
+*
+* auth.authenticate({stormpath_token: token, scope: 'admin'}, callback);
 */
 function ScopeFactoryAuthenticator(application) {
   if (!(this instanceof ScopeFactoryAuthenticator)) {
@@ -43,27 +62,6 @@ function ScopeFactoryAuthenticator(application) {
 * The function is expected to return a string. If the string is non-empty it will be attached to the
 * resulting JWT's body.
 *
-* @example
-* function groupScopeFactory(authenticationResult, requestedScope, callback) {
-*   authenticationResult.getAccount({expand: 'groups'}, function(err, account) {
-*     if (err) {
-*       return callback(err);
-*     }
-*
-*     var grantedScope = account.groups.items.map(function(group) {
-*       return group.name;
-*     }).join(' ');
-*
-*     callback(null, grantedScope);
-*   });
-* }
-*
-* var auth = new OAuthStormpathTokenAuthenticator(application);
-* auth.setScopeFactory(groupScopeFactory);
-* auth.setSigningKey(secretKey);
-*
-* auth.authenticate({stormpath_token: token, scope: 'admin'}, callback);
-*
 */
 ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;
@@ -77,7 +75,9 @@ ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorS
 * parameter.
 *
 * @param {String} signingKey
-* Signing key used to pack and unpack JWT
+* Signing key used to pack and unpack JWT. It is <b>required</b> if the scope
+* factory is set. If the factory is invoked without a signing key, an error will
+* be passed to the callback.
 */
 ScopeFactoryAuthenticator.prototype.setScopeFactorySigningKey = function setSigningKey(signingKey) {
   this.signingKey = signingKey;
@@ -108,7 +108,7 @@ ScopeFactoryAuthenticator.prototype.setScopeFactorySigningKey = function setSign
 * Callback function, will be called with (err, Ctor), where Ctor is the instance
 * passed as the argument.
 */
-ScopeFactoryAuthenticator.prototype._createAuthResult = function _createAuthenticatorResult(application, formData, responseData, Ctor, callback) {
+ScopeFactoryAuthenticator.prototype.scopeAuthResult = function scopeAuthenticatorResult(application, formData, responseData, Ctor, callback) {
   var self = this;
 
   if (typeof this.scopeFactory === 'undefined') {

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -2,20 +2,112 @@
 
 var njwt = require('njwt');
 
+/**
+* @class
+*
+* @private
+*
+* @description
+* Encapsulates the behaviour required by OAuth authenticator classes which allow
+* for adding scope to requests.
+*
+* This class allows you to use scope factory functions to attach scope to JWT objects,
+* thus expanding the result and permitting runtime access control checks, searching,
+* etc.
+*
+* This class should not be constructed manually. Instead, OAuth authenticators should
+* inherit it and use {@link ScopeFactoryAuthenticator#_createAuthResult ScopeFactoryAuthenticator._createAuthResult()}
+* in their authenticate methods.
+*/
 function ScopeFactoryAuthenticator(application) {
   if (!(this instanceof ScopeFactoryAuthenticator)) {
     return new ScopeFactoryAuthenticator(application);
   }
 }
 
+/**
+* @function
+*
+* @description
+* Sets the scope factory to be used when parsing tokens.
+*
+* @param {Function} scopeFactory
+* The scope factory to use when processing authentication results. When it is defined,
+* and the user has added a `scope` field to their request payload, it will be invoked
+* to process the result.
+*
+* The function must have the signature (authenticationResult, requestedScope, callback).
+* `authenticationResult` is the result returned from the API when calling authenticator.authenticate,
+* and is passed in its entirety, before being processed.
+* `requestedScope` is the scope the end-user has requested (added to the payload) when authenticating.
+* The function is expected to return a string. If the string is non-empty it will be attached to the
+* resulting JWT's body.
+*
+* @example
+* function groupScopeFactory(authenticationResult, requestedScope, callback) {
+*   authenticationResult.getAccount({expand: 'groups'}, function(err, account) {
+*     if (err) {
+*       return callback(err);
+*     }
+*
+*     var grantedScope = account.groups.items.map(function(group) {
+*       return group.name;
+*     }).join(' ');
+*
+*     callback(null, grantedScope);
+*   });
+* }
+*
+* var auth = new OAuthStormpathTokenAuthenticator(application);
+* auth.setScopeFactory(groupScopeFactory);
+* auth.setSigningKey(secretKey);
+*
+* auth.authenticate({stormpath_token: token, scope: 'admin'}, callback);
+*
+*/
 ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;
 };
 
+/**
+* @function
+*
+* @description
+* Sets the signing key used when unpacking and packing JWTs to modify the scope
+* parameter.
+*
+* @param {String} signingKey
+* Signing key used to pack and unpack JWT
+*/
 ScopeFactoryAuthenticator.prototype.setScopeFactorySigningKey = function setSigningKey(signingKey) {
   this.signingKey = signingKey;
 };
 
+/**
+* @function
+*
+* @private
+*
+* @description
+* Constructs results from OAuth authentication responses, optionally adding scope parameters
+* to these results. Determines whether scope should be added and validates the parameters.
+*
+* The function is to be invoked only if the request was successful.
+*
+* @param {Application} application Stormpath application the authentication result attaches to
+*
+* @param {Object} formData Authentication request data
+*
+* @param {Object} responseData The authentication result the API responded with.
+*
+* @param {Constructor} Ctor
+* The constructor for the result instance to wrap the API response with, should
+* inherit from {@link JwtAuthenticationResult}
+*
+* @param {Function} callback
+* Callback function, will be called with (err, Ctor), where Ctor is the instance
+* passed as the argument.
+*/
 ScopeFactoryAuthenticator.prototype._createAuthResult = function _createAuthenticatorResult(application, formData, responseData, Ctor, callback) {
   var self = this;
 

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var njwt = require('njwt');
+
+function ScopeFactoryAuthenticator(application) {
+  if (!(this instanceof ScopeFactoryAuthenticator)) {
+    return new ScopeFactoryAuthenticator(application);
+  }
+}
+
+ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
+  this.scopeFactory = scopeFactory;
+};
+
+ScopeFactoryAuthenticator.prototype.setScopeFactorySigningKey = function setSigningKey(signingKey) {
+  this.signingKey = signingKey;
+};
+
+ScopeFactoryAuthenticator.prototype._createAuthResult = function _createAuthenticatorResult(application, formData, responseData, Ctor, callback) {
+  var self = this;
+
+  if (typeof this.scopeFactory === 'undefined') {
+    return callback(null, new Ctor(application, responseData));
+  }
+
+  if (typeof this.signingKey === 'undefined') {
+    callback(new Error('Signing key required for expanding the authentication result token through scope factories. Please use `setSigningKey` first'));
+  }
+
+  njwt.verify(responseData.access_token, this.signingKey, function(err, token) {
+    self.scopeFactory(token, formData.scope, function(err, addedScope) {
+      if (err) {
+        return callback(err);
+      }
+
+      if (addedScope) {
+        token.body.scope = addedScope;
+      }
+
+      responseData.access_token = njwt.create(token, self.signingKey).compact();
+
+      callback(null, new Ctor(application, responseData));
+    });
+  });
+};
+
+module.exports = ScopeFactoryAuthenticator;

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -38,11 +38,7 @@ var njwt = require('njwt');
 *
 * auth.authenticate({stormpath_token: token, scope: 'admin'}, callback);
 */
-function ScopeFactoryAuthenticator(application) {
-  if (!(this instanceof ScopeFactoryAuthenticator)) {
-    return new ScopeFactoryAuthenticator(application);
-  }
-}
+function ScopeFactoryAuthenticator() {}
 
 /**
 * @function
@@ -56,12 +52,15 @@ function ScopeFactoryAuthenticator(application) {
 * to process the result.
 *
 * The function must have the signature (authenticationResult, requestedScope, callback).
-* `authenticationResult` is the result returned from the API when calling authenticator.authenticate,
+*
+* `authenticationResult` is the result returned from the API when calling `authenticator.authenticate()`,
 * and is passed in its entirety, before being processed.
+*
 * `requestedScope` is the scope the end-user has requested (added to the payload) when authenticating.
 * The function is expected to return a string. If the string is non-empty it will be attached to the
 * resulting JWT's body.
 *
+* The callback will be invoked with (err, resultInstance)
 */
 ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;
@@ -75,7 +74,7 @@ ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorS
 * parameter.
 *
 * @param {String} signingKey
-* Signing key used to pack and unpack JWT. It is <b>required</b> if the scope
+* Signing key used to pack and unpack JWTs. It is <b>required</b> if the scope
 * factory is set. If the factory is invoked without a signing key, an error will
 * be passed to the callback.
 */

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -123,7 +123,9 @@ ScopeFactoryAuthenticator.prototype.scopeAuthResult = function scopeAuthenticato
       return callback(err);
     }
 
-    self.scopeFactory(responseData, formData.scope, function(err, addedScope) {
+    var responseInstance = new Ctor(application, responseData);
+
+    self.scopeFactory(responseInstance, formData.scope, function(err, addedScope) {
       if (err) {
         return callback(err);
       }
@@ -133,9 +135,10 @@ ScopeFactoryAuthenticator.prototype.scopeAuthResult = function scopeAuthenticato
         token.setSigningKey(self.signingKey);
 
         responseData.access_token = token.compact();
+        responseInstance = new Ctor(application, responseData);
       }
 
-      callback(null, new Ctor(application, responseData));
+      callback(null, responseInstance);
     });
   });
 };

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -123,7 +123,7 @@ ScopeFactoryAuthenticator.prototype.scopeAuthResult = function scopeAuthenticato
       return callback(err);
     }
 
-    self.scopeFactory(token, formData.scope, function(err, addedScope) {
+    self.scopeFactory(responseData, formData.scope, function(err, addedScope) {
       if (err) {
         return callback(err);
       }

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -28,6 +28,10 @@ ScopeFactoryAuthenticator.prototype._createAuthResult = function _createAuthenti
   }
 
   njwt.verify(responseData.access_token, this.signingKey, function(err, token) {
+    if (err) {
+      return callback(err);
+    }
+
     self.scopeFactory(token, formData.scope, function(err, addedScope) {
       if (err) {
         return callback(err);

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -9,18 +9,20 @@ var njwt = require('njwt');
 * Encapsulates the behavior required by OAuth authenticator classes for adding
 * scope to access tokens that are created by Stormpath.
 *
-* This class allows you to use scope factory functions to attach scope to JWT objects,
-* thus expanding the result and permitting runtime access control checks, searching,
-* etc.
+* This class allows you to add custom scope to Stormpath tokens by providing scope
+* factory functions.  Adding custom scope is useful if you want to do stateless
+* access control checks with a JWT scope property.
 *
-* This class should not be constructed manually. Instead, these methods are available
-* on the following authenticators:
+* This class should not be constructed manually. Instead, the following classes
+* inherit from this class and can use the scope factory behavior:
 *
 * * {@link OAuthClientCredentialsAuthenticator}
 * * {@link OAuthPasswordGrantRequestAuthenticator}
 * * {@link OAuthStormpathSocialAuthenticator}
 * * {@link OAuthStormpathTokenAuthenticator}
 * @example
+* <caption>Adding a user's groups to the token as scope</caption>
+*
 * var application; // An application, fetched from Client.getApplication()
 *
 * function groupScopeFactory(authenticationResult, requestedScope, callback) {
@@ -37,14 +39,17 @@ var njwt = require('njwt');
 *   });
 * }
 *
-* var authenticator = new OAuthPasswordGrantRequestAuthenticator(application);
-* authenticator.setScopeFactory(groupScopeFactory);
-* authenticator.setSigningKey(tenantApiKeySecret); // Same secret that was given to the previously used client
+* var authenticator = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
 *
-* authenticator.authenticate({
+* authenticator.setScopeFactory(groupScopeFactory);
+* authenticator.setScopeFactorySigningKey(tenantApiKeySecret); // Same secret that was given to the previously used client
+*
+* var passwordGrantRequest = {
 *   username: 'user@example.com',
 *   password: 'PAs$w0rd',
-* }, function (err, oAuthPasswordGrantAuthenticationResult) {
+* }
+ *
+* authenticator.authenticate(passwordGrantRequest, function (err, oAuthPasswordGrantAuthenticationResult) {
 *   if (err) {
 *     return console.log(err);
 *   }
@@ -59,7 +64,7 @@ function ScopeFactoryAuthenticator() {}
 * @description
 * Sets the scope factory to be used when parsing tokens.  The scope factory is a
 * developer-provided function that allows you to add custom scope to the tokens
-* that Stormpath creates.
+* that Stormpath creates.  For an example, see {@link ScopeFactoryAuthenticator}.
 *
 * @param {Function} scopeFactory
 * The scope factory to use when processing authentication results. When it is defined,
@@ -72,10 +77,12 @@ function ScopeFactoryAuthenticator() {}
 * authentication result class.  You can use this to fetch the account that has
 * authenticated.
 *
-* * `requestedScope` is the scope that end-user requested, and passed as the `scope`
-* option on the authenticator's `authenticate()` method.
+* * `requestedScope` is the end-user requested scope that you passed as the
+* `scope` option when calling the authenticator's `authenticate()` method.
 *
-* * `callback` should be called with `(err, grantedScope)`
+* * `callback` should be called with `(err, <String> grantedScope)` after you determine
+* which scope to grant to the user.  The scope will be added to the JWT as the
+* `scope` claim.  The granted scope must be a string value.
 */
 ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -3,134 +3,134 @@
 var njwt = require('njwt');
 
 /**
-* @class
-*
-* @description
-* Encapsulates the behavior required by OAuth authenticator classes for adding
-* scope to access tokens that are created by Stormpath.
-*
-* This class allows you to add custom scope to Stormpath tokens by providing scope
-* factory functions.  Adding custom scope is useful if you want to do stateless
-* access control checks with a JWT scope property.
-*
-* This class should not be constructed manually. Instead, the following classes
-* inherit from this class and can use the scope factory behavior:
-*
-* * {@link OAuthClientCredentialsAuthenticator}
-* * {@link OAuthPasswordGrantRequestAuthenticator}
-* * {@link OAuthStormpathSocialAuthenticator}
-* * {@link OAuthStormpathTokenAuthenticator}
-* @example
-* <caption>Adding a user's groups to the token as scope</caption>
-*
-* var application; // An application, fetched from Client.getApplication()
-*
-* function groupScopeFactory(authenticationResult, requestedScope, callback) {
-*   authenticationResult.getAccount({expand: 'groups'}, function(err, account) {
-*     if (err) {
-*       return callback(err);
-*     }
-*
-*     var grantedScope = account.groups.items.map(function(group) {
-*       return group.name;
-*     }).join(' ');
-*
-*     callback(null, grantedScope);
-*   });
-* }
-*
-* var authenticator = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
-*
-* authenticator.setScopeFactory(groupScopeFactory);
-* authenticator.setScopeFactorySigningKey(tenantApiKeySecret); // Same secret that was given to the previously used client
-*
-* var passwordGrantRequest = {
-*   username: 'user@example.com',
-*   password: 'PAs$w0rd',
-* }
+ * @class
  *
-* authenticator.authenticate(passwordGrantRequest, function (err, oAuthPasswordGrantAuthenticationResult) {
-*   if (err) {
-*     return console.log(err);
-*   }
-*   console.log('Access token: ', oAuthPasswordGrantAuthenticationResult.accessToken)
-* });
-*/
+ * @description
+ * Encapsulates the behavior required by OAuth authenticator classes for adding
+ * scope to access tokens that are created by Stormpath.
+ *
+ * This class allows you to add custom scope to Stormpath tokens by providing scope
+ * factory functions.  Adding custom scope is useful if you want to do stateless
+ * access control checks with a JWT scope property.
+ *
+ * This class should not be constructed manually. Instead, the following classes
+ * inherit from this class and can use the scope factory behavior:
+ *
+ * * {@link OAuthClientCredentialsAuthenticator}
+ * * {@link OAuthPasswordGrantRequestAuthenticator}
+ * * {@link OAuthStormpathSocialAuthenticator}
+ * * {@link OAuthStormpathTokenAuthenticator}
+ * @example
+ * <caption>Adding a user's groups to the token as scope</caption>
+ *
+ * var application; // An application, fetched from Client.getApplication()
+ *
+ * function groupScopeFactory(authenticationResult, requestedScope, callback) {
+ *   authenticationResult.getAccount({expand: 'groups'}, function(err, account) {
+ *     if (err) {
+ *       return callback(err);
+ *     }
+ *
+ *     var grantedScope = account.groups.items.map(function(group) {
+ *       return group.name;
+ *     }).join(' ');
+ *
+ *     callback(null, grantedScope);
+ *   });
+ * }
+ *
+ * var authenticator = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
+ *
+ * authenticator.setScopeFactory(groupScopeFactory);
+ * authenticator.setScopeFactorySigningKey(tenantApiKeySecret); // Same secret that was given to the previously used client
+ *
+ * var passwordGrantRequest = {
+ *   username: 'user@example.com',
+ *   password: 'PAs$w0rd',
+ * }
+ *
+ * authenticator.authenticate(passwordGrantRequest, function (err, oAuthPasswordGrantAuthenticationResult) {
+ *   if (err) {
+ *     return console.log(err);
+ *   }
+ *   console.log('Access token: ', oAuthPasswordGrantAuthenticationResult.accessToken)
+ * });
+ */
 function ScopeFactoryAuthenticator() {}
 
 /**
-* @function
-*
-* @description
-* Sets the scope factory to be used when parsing tokens.  The scope factory is a
-* developer-provided function that allows you to add custom scope to the tokens
-* that Stormpath creates.  For an example, see {@link ScopeFactoryAuthenticator}.
-*
-* @param {Function} scopeFactory
-* The scope factory to use when processing authentication results. When it is defined,
-* it will be invoked with the authentication result.  You should determine which scope
-* to grant, and provide it to the callback.
-*
-* The function must have the signature `(authenticationResult, requestedScope, callback)`.
-*
-* * `authenticationResult` is the authentication result from the authenticator's
-* authentication result class.  You can use this to fetch the account that has
-* authenticated.
-*
-* * `requestedScope` is the end-user requested scope that you passed as the
-* `scope` option when calling the authenticator's `authenticate()` method.
-*
-* * `callback` should be called with `(err, <String> grantedScope)` after you determine
-* which scope to grant to the user.  The scope will be added to the JWT as the
-* `scope` claim.  The granted scope must be a string value.
-*/
+ * @function
+ *
+ * @description
+ * Sets the scope factory to be used when parsing tokens.  The scope factory is a
+ * developer-provided function that allows you to add custom scope to the tokens
+ * that Stormpath creates.  For an example, see {@link ScopeFactoryAuthenticator}.
+ *
+ * @param {Function} scopeFactory
+ * The scope factory to use when processing authentication results. When it is defined,
+ * it will be invoked with the authentication result.  You should determine which scope
+ * to grant, and provide it to the callback.
+ *
+ * The function must have the signature `(authenticationResult, requestedScope, callback)`.
+ *
+ * * `authenticationResult` is the authentication result from the authenticator's
+ * authentication result class.  You can use this to fetch the account that has
+ * authenticated.
+ *
+ * * `requestedScope` is the end-user requested scope that you passed as the
+ * `scope` option when calling the authenticator's `authenticate()` method.
+ *
+ * * `callback` should be called with `(err, <String> grantedScope)` after you determine
+ * which scope to grant to the user.  The scope will be added to the JWT as the
+ * `scope` claim.  The granted scope must be a string value.
+ */
 ScopeFactoryAuthenticator.prototype.setScopeFactory = function setAuthenticatorScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;
 };
 
 /**
-* @function
-*
-* @description
-* Sets the signing that is used to sign the new access token.
-*
-* @param {String} signingKey
-* Signing key used to pack and unpack JWTs. It is <b>required</b> if the scope
-* factory is set. If the factory is invoked without a signing key, an error will
-* be passed to the callback.
-*
-* This must be the same Tenant API Key Secret that you used to create the {@link Client}
-* that was used to initiate the authentication attempt.
-*/
+ * @function
+ *
+ * @description
+ * Sets the signing that is used to sign the new access token.
+ *
+ * @param {String} signingKey
+ * Signing key used to pack and unpack JWTs. It is <b>required</b> if the scope
+ * factory is set. If the factory is invoked without a signing key, an error will
+ * be passed to the callback.
+ *
+ * This must be the same Tenant API Key Secret that you used to create the {@link Client}
+ * that was used to initiate the authentication attempt.
+ */
 ScopeFactoryAuthenticator.prototype.setScopeFactorySigningKey = function setSigningKey(signingKey) {
   this.signingKey = signingKey;
 };
 
 /**
-* @function
-*
-* @private
-*
-* @description
-* Constructs results from OAuth authentication responses, optionally adding scope parameters
-* to these results. Determines whether scope should be added and validates the parameters.
-*
-* The function is to be invoked only if the request was successful.
-*
-* @param {Application} application Stormpath application the authentication result attaches to
-*
-* @param {Object} formData Authentication request data
-*
-* @param {Object} responseData The authentication result the API responded with.
-*
-* @param {Constructor} Ctor
-* The constructor for the result instance to wrap the API response with, should
-* inherit from {@link JwtAuthenticationResult}
-*
-* @param {Function} callback
-* Callback function, will be called with (err, Ctor), where Ctor is the instance
-* passed as the argument.
-*/
+ * @function
+ *
+ * @private
+ *
+ * @description
+ * Constructs results from OAuth authentication responses, optionally adding scope parameters
+ * to these results. Determines whether scope should be added and validates the parameters.
+ *
+ * The function is to be invoked only if the request was successful.
+ *
+ * @param {Application} application Stormpath application the authentication result attaches to
+ *
+ * @param {Object} formData Authentication request data
+ *
+ * @param {Object} responseData The authentication result the API responded with.
+ *
+ * @param {Constructor} Ctor
+ * The constructor for the result instance to wrap the API response with, should
+ * inherit from {@link JwtAuthenticationResult}
+ *
+ * @param {Function} callback
+ * Callback function, will be called with (err, Ctor), where Ctor is the instance
+ * passed as the argument.
+ */
 ScopeFactoryAuthenticator.prototype.scopeAuthResult = function scopeAuthenticatorResult(application, formData, responseData, Ctor, callback) {
   var self = this;
 

--- a/lib/oauth/scope-factory-authenticator.js
+++ b/lib/oauth/scope-factory-authenticator.js
@@ -35,9 +35,10 @@ ScopeFactoryAuthenticator.prototype._createAuthResult = function _createAuthenti
 
       if (addedScope) {
         token.body.scope = addedScope;
-      }
+        token.setSigningKey(self.signingKey);
 
-      responseData.access_token = njwt.create(token, self.signingKey).compact();
+        responseData.access_token = token.compact();
+      }
 
       callback(null, new Ctor(application, responseData));
     });

--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -38,6 +38,8 @@ util.inherits(OAuthStormpathSocialAuthenticationResult, JwtAuthenticationResult)
 /**
  * @class
  *
+ * @augments ScopeFactoryAuthenticator
+ *
  * @description
  *
  * Creates an authenticator that can be used to exchange an authorization code or access token, obtained from
@@ -72,9 +74,10 @@ util.inherits(OAuthStormpathSocialAuthenticator, ScopeFactoryAuthenticator);
  * Exchange an authorization code or access token, provided by a social provier, for a Stormpath Access Token and Refresh token.
  *
  * @param {Object} authenticationRequest
- * An object to encapsulate the request.
+ * An object to encapsulate the request.  One of `accessToken` or `code` must be
+ * provided.
  *
- * @param {String} [authenticationRequest.providerId]
+ * @param {String} authenticationRequest.providerId
  * The identity of the provider that provided the code or access token, e.g. `facebook`, `google`, `github`, `linkedin`.
  *
  * @param {String} [authenticationRequest.accessToken]
@@ -82,6 +85,10 @@ util.inherits(OAuthStormpathSocialAuthenticator, ScopeFactoryAuthenticator);
  *
  * @param {String} [authenticationRequest.code]
  * The authorization code, obtained from the provider.
+ *
+ * @param {String} [authenticationRequest.scope]
+ * User-requested scope that will be passed to the scope factory, if configured.
+ * See {@link ScopeFactoryAuthenticator} for more details.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link OAuthStormpathSocialAuthenticationResult}).

--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -2,6 +2,7 @@
 
 var util = require('util');
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
+var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
 /**
  * @class
@@ -64,6 +65,8 @@ function OAuthStormpathSocialAuthenticator(application) {
 
   this.application = application;
 }
+
+util.inherits(OAuthStormpathSocialAuthenticator, ScopeFactoryAuthenticator);
 
 /**
  * Exchange an authorization code or access token, provided by a social provier, for a Stormpath Access Token and Refresh token.

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -120,6 +120,10 @@ OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(
     token: data.stormpath_token
   };
 
+  if (data.scope) {
+    formData.scope = data.scope;
+  }
+
   var tokenHref = application.href + '/oauth/token';
 
   application.dataStore.createResource(tokenHref, {form: formData}, function(err, tokenData) {

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -85,9 +85,9 @@ util.inherits(OAuthStormpathTokenAuthenticator, ScopeFactoryAuthenticator);
  * @param {String} tokenRequest.stormpath_token
  * The Stormpath Token, from the ID Site or SAML callback.  This is a compacted JWT string.
  *
- * @param {String} tokenRequest.scope
- * Optional scope that can be attached to the request. See {@link ScopeFactoryAuthenticator}
- * for more details.
+ * @param {String} [tokenRequest.scope]
+ * User-requested scope that will be passed to the scope factory, if configured.
+ * See {@link ScopeFactoryAuthenticator} for more details.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link OAuthStormpathTokenAuthenticationResult}).

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -39,6 +39,8 @@ util.inherits(OAuthStormpathTokenAuthenticationResult, JwtAuthenticationResult);
 /**
  * @class
  *
+ * @augments ScopeFactoryAuthenticator
+ *
  * @description
  *
  * Creates an authenticator that can be used to exchange a Stormpath Token for an
@@ -83,6 +85,9 @@ util.inherits(OAuthStormpathTokenAuthenticator, ScopeFactoryAuthenticator);
  * @param {String} tokenRequest.stormpath_token
  * The Stormpath Token, from the ID Site or SAML callback.  This is a compacted JWT string.
  *
+ * @param {String} tokenRequest.scope
+ * Optional scope that can be attached to the request. See {@link ScopeFactoryAuthenticator}
+ * for more details.
  *
  * @param {Function} callback
  * Callback function, will be called with (err, {@link OAuthStormpathTokenAuthenticationResult}).

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var util = require('util');
+var util = require('../utils');
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
 var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
@@ -125,9 +125,7 @@ OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(
     token: data.stormpath_token
   };
 
-  if (data.scope) {
-    formData.scope = data.scope;
-  }
+  var scopeFactoryData = util.extend({}, formData, {scope: data.scope});
 
   var tokenHref = application.href + '/oauth/token';
 
@@ -136,7 +134,7 @@ OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(
       return callback(err);
     }
 
-    self.scopeAuthResult(application, formData, tokenData, OAuthStormpathTokenAuthenticationResult, callback);
+    self.scopeAuthResult(application, scopeFactoryData, tokenData, OAuthStormpathTokenAuthenticationResult, callback);
   });
 };
 

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -2,6 +2,7 @@
 
 var util = require('util');
 var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
+var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
 
 /**
  * @class
@@ -28,10 +29,11 @@ var JwtAuthenticationResult = require('../jwt/jwt-authentication-result');
  * The access token response from the Stormpath REST API.
  *
  */
-function OAuthStormpathTokenAuthenticationResult(application, data){
+function OAuthStormpathTokenAuthenticationResult(application, data) {
   OAuthStormpathTokenAuthenticationResult.super_.apply(this, arguments);
   this.accessTokenResponse = data;
 }
+
 util.inherits(OAuthStormpathTokenAuthenticationResult, JwtAuthenticationResult);
 
 /**
@@ -65,8 +67,12 @@ function OAuthStormpathTokenAuthenticator(application) {
     return new OAuthStormpathTokenAuthenticator(application);
   }
 
+  OAuthStormpathTokenAuthenticator.super_.apply(this, arguments);
+
   this.application = application;
 }
+
+util.inherits(OAuthStormpathTokenAuthenticator, ScopeFactoryAuthenticator);
 
 /**
  * Exchange the Stormpath Token for an Access and Refresh token.
@@ -99,6 +105,7 @@ function OAuthStormpathTokenAuthenticator(application) {
  */
 OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(data, callback) {
   var application = this.application;
+  var self = this;
 
   if (typeof data !== 'object') {
     throw new Error('The \'data\' parameter must be an object.');
@@ -115,12 +122,12 @@ OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(
 
   var tokenHref = application.href + '/oauth/token';
 
-  application.dataStore.createResource(tokenHref, { form: formData }, function(err, tokenData) {
+  application.dataStore.createResource(tokenHref, {form: formData}, function(err, tokenData) {
     if (err) {
       return callback(err);
     }
 
-    callback(null, new OAuthStormpathTokenAuthenticationResult(application, tokenData));
+    self._createAuthResult(application, formData, tokenData, OAuthStormpathTokenAuthenticationResult, callback);
   });
 };
 

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -29,7 +29,7 @@ var ScopeFactoryAuthenticator = require('./scope-factory-authenticator');
  * The access token response from the Stormpath REST API.
  *
  */
-function OAuthStormpathTokenAuthenticationResult(application, data) {
+function OAuthStormpathTokenAuthenticationResult(application, data){
   OAuthStormpathTokenAuthenticationResult.super_.apply(this, arguments);
   this.accessTokenResponse = data;
 }
@@ -131,7 +131,7 @@ OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(
 
   var tokenHref = application.href + '/oauth/token';
 
-  application.dataStore.createResource(tokenHref, {form: formData}, function(err, tokenData) {
+  application.dataStore.createResource(tokenHref, { form: formData }, function(err, tokenData) {
     if (err) {
       return callback(err);
     }

--- a/lib/oauth/stormpath-token.js
+++ b/lib/oauth/stormpath-token.js
@@ -136,7 +136,7 @@ OAuthStormpathTokenAuthenticator.prototype.authenticate = function authenticate(
       return callback(err);
     }
 
-    self._createAuthResult(application, formData, tokenData, OAuthStormpathTokenAuthenticationResult, callback);
+    self.scopeAuthResult(application, formData, tokenData, OAuthStormpathTokenAuthenticationResult, callback);
   });
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -246,6 +246,21 @@ function isValidHref(href, subPath) {
   return true;
 }
 
+function extend(/* target, src1, src2, ... */) {
+  var target = arguments[0];
+  var sources = Array.prototype.slice.call(arguments, 1);
+
+  sources.forEach(function(source) {
+    Object.keys(source).forEach(function(key) {
+      if (source.hasOwnProperty(key)) {
+        target[key] = source[key];
+      }
+    });
+  });
+
+  return target;
+}
+
 module.exports = {
   isConfigLoader: isConfigLoader,
   resolveArgs: resolveArgs,
@@ -261,6 +276,6 @@ module.exports = {
   crypto: crypto,
   uuid: uuid,
   applyMixin: applyMixin,
-  noop: function() {
-  }
+  extend: extend,
+  noop: function () {}
 };

--- a/test/it/jwt_authenticator_it.js
+++ b/test/it/jwt_authenticator_it.js
@@ -207,7 +207,38 @@ describe('JwtAuthenticator',function(){
     });
   });
 
+  describe('JwtAuthenticationResult', function() {
+    var authenticator;
+    var authResult;
 
+    before(function(done) {
+      authenticator = new stormpath.JwtAuthenticator(application);
+      authenticator.authenticate(passwordGrantResponse.accessToken.toString(), function(err, result) {
+        if (err) {
+          return done(err);
+        }
 
+        authResult = result;
+        done();
+      });
+    });
+
+    describe('#getAccount()', function() {
+      it('should support expansion options for the Account query', function(done) {
+        authResult.getAccount({expand: 'groups'}, function(err, account) {
+          if (err) {
+            return done(err);
+          }
+
+          assert.instanceOf(account, require('../../lib/resource/Account'));
+          assert.isDefined(account.groups);
+          assert.isDefined(account.groups.size);
+          assert.isDefined(account.groups.limit);
+          assert.isDefined(account.groups.offset);
+          assert.isDefined(account.groups.items);
+          done();
+        });
+      });
+    });
+  });
 });
-

--- a/test/it/oauth_client_credentials_it.js
+++ b/test/it/oauth_client_credentials_it.js
@@ -10,6 +10,7 @@ var stormpath = require('../../');
 var Account = require('../../lib/resource/Account');
 var AccessToken = require('../../lib/resource/AccessToken');
 var JwtAuthenticator = require('../../lib/jwt/jwt-authenticator');
+var JwtAuthenticationResult = require('../../lib/jwt/jwt-authentication-result');
 
 describe('OAuthClientCredentialsAuthenticator', function() {
   var newAccount;
@@ -190,6 +191,7 @@ describe('OAuthClientCredentialsAuthenticator', function() {
 
       before(function() {
         scopeFactoryFunction = sinon.spy(function(authenticationResult, requestedScope, callback) {
+          assert.instanceOf(authenticationResult, JwtAuthenticationResult);
           callback(null, scope);
         });
 

--- a/test/it/oauth_client_credentials_it.js
+++ b/test/it/oauth_client_credentials_it.js
@@ -324,8 +324,8 @@ describe('OAuthClientCredentialsAuthenticator', function() {
           it('should yield a result containing the scope', function(done) {
             authenticator.authenticate(token, function(err, data) {
               assert.ok(data.expandedJwt);
-              assert.ok(data.expandedJwt.body);
-              assert.equal(data.expandedJwt.body.scope, scope);
+              assert.ok(data.expandedJwt.claims);
+              assert.equal(data.expandedJwt.claims.scope, scope);
               done();
             });
           });

--- a/test/it/oauth_client_credentials_it.js
+++ b/test/it/oauth_client_credentials_it.js
@@ -333,24 +333,23 @@ describe('OAuthClientCredentialsAuthenticator', function() {
       });
 
       describe('errors', function() {
-        var callback;
 
         before(function() {
           auth.setScopeFactorySigningKey();
-          callback = function(err, data) {
-            assert.ok(err);
-            assert.notOk(data);
-          };
         });
 
         after(function() {
           auth.setScopeFactorySigningKey(signingKey);
         });
 
-        it('should call the callback with an error if used with a factory function but without a key', function() {
-          assert.doesNotThrow(function() {
-            auth.authenticate({apiKey: apiKey, scope: scope}, callback);
-          }, Error);
+        it('should call the callback with an error if used with a factory function but without a key', function(done) {
+          var callback = function(err, data) {
+            assert.ok(err);
+            assert.notOk(data);
+            done();
+          };
+
+          auth.authenticate({apiKey: apiKey, scope: scope}, callback);
         });
       });
     });

--- a/test/it/oauth_client_credentials_it.js
+++ b/test/it/oauth_client_credentials_it.js
@@ -259,7 +259,7 @@ describe('OAuthClientCredentialsAuthenticator', function() {
           scopeFactoryFunction.should.have.been.calledThrice;
           /* jshint +W030 */
 
-          var originalToken = scopeFactoryFunction.args[2][0];
+          var originalToken = njwt.verify(scopeFactoryFunction.args[2][0].access_token, auth.signingKey);
           var token = authResponse.accessToken;
 
           assert.deepEqual(originalToken.header, token.header);

--- a/test/it/oauth_client_credentials_it.js
+++ b/test/it/oauth_client_credentials_it.js
@@ -259,7 +259,7 @@ describe('OAuthClientCredentialsAuthenticator', function() {
           scopeFactoryFunction.should.have.been.calledThrice;
           /* jshint +W030 */
 
-          var originalToken = njwt.verify(scopeFactoryFunction.args[2][0].access_token, auth.signingKey);
+          var originalToken = scopeFactoryFunction.args[2][0].accessToken;
           var token = authResponse.accessToken;
 
           assert.deepEqual(originalToken.header, token.header);

--- a/test/it/oauth_password_grant_it.js
+++ b/test/it/oauth_password_grant_it.js
@@ -142,7 +142,7 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
           scopeFactoryFunction.should.have.been.calledThrice;
           /* jshint +W030 */
 
-          var originalToken = scopeFactoryFunction.args[2][0];
+          var originalToken = njwt.verify(scopeFactoryFunction.args[2][0].access_token, auth.signingKey);
           var token = authResponse.accessToken;
 
           assert.deepEqual(originalToken.header, token.header);

--- a/test/it/oauth_password_grant_it.js
+++ b/test/it/oauth_password_grant_it.js
@@ -9,6 +9,7 @@ var njwt = require('njwt');
 var stormpath = require('../../');
 
 var JwtAuthenticator = require('../../lib/jwt/jwt-authenticator');
+var JwtAuthenticationResult = require('../../lib/jwt/jwt-authentication-result');
 
 describe('OAuthPasswordGrantRequestAuthenticator',function(){
 
@@ -74,6 +75,7 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
 
       before(function() {
         scopeFactoryFunction = sinon.spy(function(authenticationResult, requestedScope, callback) {
+          assert.instanceOf(authenticationResult, JwtAuthenticationResult);
           callback(null, scope);
         });
 

--- a/test/it/oauth_password_grant_it.js
+++ b/test/it/oauth_password_grant_it.js
@@ -142,7 +142,7 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
           scopeFactoryFunction.should.have.been.calledThrice;
           /* jshint +W030 */
 
-          var originalToken = njwt.verify(scopeFactoryFunction.args[2][0].access_token, auth.signingKey);
+          var originalToken = scopeFactoryFunction.args[2][0].accessToken;
           var token = authResponse.accessToken;
 
           assert.deepEqual(originalToken.header, token.header);

--- a/test/it/oauth_password_grant_it.js
+++ b/test/it/oauth_password_grant_it.js
@@ -2,8 +2,13 @@
 var common = require('../common');
 var helpers = require('./helpers');
 var assert = common.assert;
+var sinon = common.sinon;
+
+var njwt = require('njwt');
 
 var stormpath = require('../../');
+
+var JwtAuthenticator = require('../../lib/jwt/jwt-authenticator');
 
 describe('OAuthPasswordGrantRequestAuthenticator',function(){
 
@@ -24,6 +29,12 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
     helpers.cleanupApplicationAndStores(application, done);
   });
 
+  describe('inheritance', function() {
+    it('should inherit from ScopeFactoryAuthenticator', function() {
+      assert.equal(stormpath.OAuthPasswordGrantRequestAuthenticator.super_.name, 'ScopeFactoryAuthenticator');
+    });
+  });
+
   it('should be constructable with new operator',function(){
     var authenticator = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
     assert.instanceOf(authenticator,stormpath.OAuthPasswordGrantRequestAuthenticator);
@@ -40,5 +51,190 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
       username: newAccount.username,
       password: newAccount.password
     },common.assertPasswordGrantResponse(done));
+  });
+
+  describe('calling the #authenticate(data, callback) method', function() {
+    var auth;
+    var scope;
+    var requestData;
+
+    before(function() {
+      auth = new stormpath.OAuthPasswordGrantRequestAuthenticator(application);
+      scope = 'test';
+      requestData = {
+        username: newAccount.username,
+        password: newAccount.password,
+        scope: scope
+      };
+    });
+
+    describe('scope factory properties', function() {
+      var scopeFactoryFunction;
+      var signingKey;
+
+      before(function() {
+        scopeFactoryFunction = sinon.spy(function(authenticationResult, requestedScope, callback) {
+          callback(null, scope);
+        });
+
+        signingKey = application.dataStore.requestExecutor.options.client.apiKey.secret;
+
+        auth.setScopeFactory(scopeFactoryFunction);
+        auth.setScopeFactorySigningKey(signingKey);
+      });
+
+      after(function() {
+        // Unset the scope factory props
+        auth.setScopeFactory();
+        auth.setScopeFactorySigningKey();
+      });
+
+      it('should call the scope factory function if the scope is defined, with the correct `requestedScope`', function(done) {
+        auth.authenticate(requestData, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+
+          /* jshint -W030 */
+          scopeFactoryFunction.should.have.been.calledOnce;
+          /* jshint +W030 */
+          scopeFactoryFunction.args[0][1].should.equal(scope);
+          assert.ok(result);
+          done();
+        });
+      });
+
+      it('should append a scope field from the factory to the result token, if the factory result is a truthy string', function(done) {
+        auth.authenticate(requestData, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+
+          /* jshint -W030 */
+          scopeFactoryFunction.should.have.been.calledTwice;
+          /* jshint +W030 */
+
+          // Decoded token
+          assert.ok(result);
+          assert.ok(result.accessToken);
+          assert.ok(result.accessToken.body);
+          assert.equal(result.accessToken.body.scope, scope);
+
+          // Manual decoding check
+          njwt.verify(result.accessTokenResponse.access_token, signingKey, function(err, token) {
+            assert.ok(token);
+            assert.ok(token.body);
+            assert.equal(token.body.scope, scope);
+            done();
+          });
+        });
+      });
+
+      it('should leave all the other fields in the header and body of the JWT untouched', function(done) {
+        var bodyField;
+
+        auth.authenticate(requestData, function(err, authResponse) {
+          if (err) {
+            return done(err);
+          }
+
+          /* jshint -W030 */
+          scopeFactoryFunction.should.have.been.calledThrice;
+          /* jshint +W030 */
+
+          var originalToken = scopeFactoryFunction.args[2][0];
+          var token = authResponse.accessToken;
+
+          assert.deepEqual(originalToken.header, token.header);
+
+          for (bodyField in originalToken.body) {
+            if (originalToken.body.hasOwnProperty(bodyField)) {
+              assert.equal(originalToken.body[bodyField], token.body[bodyField]);
+            }
+          }
+
+          done();
+        });
+      });
+
+      describe('JwtAuthenticator validation', function() {
+        var authenticator;
+        var token;
+
+        before(function(done) {
+          authenticator = new JwtAuthenticator(application);
+          auth.authenticate(requestData, function(err, resp) {
+            if (err) {
+              return done(err);
+            }
+            token = resp.accessTokenResponse.access_token;
+            done();
+          });
+        });
+
+        describe('without local validation', function() {
+          it('should validate the token', function(done) {
+            authenticator.authenticate(token, function(err, data) {
+              assert.notOk(err);
+              assert.ok(data);
+              done();
+            });
+          });
+
+          it('should yield a result containing the scope', function(done) {
+            authenticator.authenticate(token, function(err, data) {
+              assert.ok(data.expandedJwt);
+              assert.ok(data.expandedJwt.claims);
+              assert.equal(data.expandedJwt.claims.scope, scope);
+              done();
+            });
+          });
+        });
+
+        describe('with local validation', function() {
+          before(function() {
+            authenticator.withLocalValidation();
+          });
+
+          it('should validate the token', function(done) {
+            authenticator.authenticate(token, function(err, data) {
+              assert.notOk(err);
+              assert.ok(data);
+              done();
+            });
+          });
+
+          it('should yield a result containing the scope', function(done) {
+            authenticator.authenticate(token, function(err, data) {
+              assert.ok(data.expandedJwt);
+              assert.ok(data.expandedJwt.body);
+              assert.equal(data.expandedJwt.body.scope, scope);
+              done();
+            });
+          });
+        });
+      });
+
+      describe('errors', function() {
+
+        before(function() {
+          auth.setScopeFactorySigningKey();
+        });
+
+        after(function() {
+          auth.setScopeFactorySigningKey(signingKey);
+        });
+
+        it('should call the callback with an error if used with a factory function but without a key', function(done) {
+          var callback = function(err, data) {
+            assert.ok(err);
+            assert.notOk(data);
+            done();
+          };
+
+          auth.authenticate(requestData, callback);
+        });
+      });
+    });
   });
 });

--- a/test/it/oauth_password_grant_it.js
+++ b/test/it/oauth_password_grant_it.js
@@ -207,8 +207,8 @@ describe('OAuthPasswordGrantRequestAuthenticator',function(){
           it('should yield a result containing the scope', function(done) {
             authenticator.authenticate(token, function(err, data) {
               assert.ok(data.expandedJwt);
-              assert.ok(data.expandedJwt.body);
-              assert.equal(data.expandedJwt.body.scope, scope);
+              assert.ok(data.expandedJwt.claims);
+              assert.equal(data.expandedJwt.claims.scope, scope);
               done();
             });
           });

--- a/test/it/oauth_stormpath_socal_it.js
+++ b/test/it/oauth_stormpath_socal_it.js
@@ -59,6 +59,12 @@ describe('OAuthStormpathSocialAuthenticator', function () {
     helpers.cleanupApplicationAndStores(application, done);
   });
 
+  describe('inheritance', function() {
+    it('should inherit from ScopeFactoryAuthenticator', function() {
+      assert.equal(stormpath.OAuthStormpathSocialAuthenticator.super_.name, 'ScopeFactoryAuthenticator');
+    });
+  });
+
   describe('when calling OAuthStormpathSocialAuthenticator(application)', function () {
     var instance;
 

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -252,7 +252,7 @@ describe('OAuthStormpathTokenAuthenticator', function () {
           spy.should.have.been.calledThrice;
           /* jshint +W030 */
 
-          var originalToken = spy.args[2][0];
+          var originalToken = njwt.verify(spy.args[2][0].access_token, auth.signingKey);
           var token = authResponse.accessToken;
 
           assert.deepEqual(originalToken.header, token.header);

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -317,8 +317,8 @@ describe('OAuthStormpathTokenAuthenticator', function () {
           it('should yield a result containing the scope', function(done) {
             jwtAuthenticator.authenticate(token, function(err, data) {
               assert.ok(data.expandedJwt);
-              assert.ok(data.expandedJwt.body);
-              assert.equal(data.expandedJwt.body.scope, scope);
+              assert.ok(data.expandedJwt.claims);
+              assert.equal(data.expandedJwt.claims.scope, scope);
               done();
             });
           });

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -5,6 +5,11 @@ var common = require('../common');
 var helpers = require('./helpers');
 
 var assert = common.assert;
+var sinon = common.sinon;
+
+var njwt = require('njwt');
+
+var JwtAuthenticator = require('../../lib/jwt/jwt-authenticator');
 
 describe('OAuthStormpathTokenAuthenticator', function () {
   var account;
@@ -43,6 +48,12 @@ describe('OAuthStormpathTokenAuthenticator', function () {
 
     it('should return a OAuthStormpathTokenAuthenticator instance', function () {
       assert.instanceOf(instance, stormpath.OAuthStormpathTokenAuthenticator);
+    });
+
+    describe('inheritance', function() {
+      it('should inherit from ScopeFactoryAuthenticator', function() {
+        assert.equal(stormpath.OAuthStormpathTokenAuthenticator.super_.name, 'ScopeFactoryAuthenticator');
+      });
     });
 
     it('should return a new instance', function () {
@@ -156,6 +167,182 @@ describe('OAuthStormpathTokenAuthenticator', function () {
           assert.equal(err.developerMessage, 'token parameter is required; it cannot be null, empty, or blank.');
           assert.notOk(authenticationResult);
           done();
+        });
+      });
+    });
+
+    describe('scope factory properties', function() {
+      var auth;
+      var spy;
+      var scopeFactoryFunction;
+      var scope;
+      var signingKey;
+
+      before(function() {
+        auth = new stormpath.OAuthStormpathTokenAuthenticator(application);
+        spy = sinon.spy();
+        scopeFactoryFunction = function scopeFactoryFunction(authenticationResult, requestedScope, callback) {
+          spy(authenticationResult, requestedScope, callback);
+          callback(null, scope);
+        };
+
+        scope = 'test';
+        signingKey = application.dataStore.requestExecutor.options.client.apiKey.secret;
+
+        auth.setScopeFactory(scopeFactoryFunction);
+        auth.setScopeFactorySigningKey(signingKey);
+      });
+
+      after(function() {
+        // Unset the scope factory props
+        auth.setScopeFactory();
+        auth.setScopeFactorySigningKey();
+      });
+
+      it('should call the scope factory function if the scope is defined, with the correct `requestedScope`', function(done) {
+        auth.authenticate({stormpath_token: validToken, scope: scope}, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+
+          /* jshint -W030 */
+          spy.should.have.been.calledOnce;
+          /* jshint +W030 */
+          spy.args[0][1].should.equal(scope);
+          assert.ok(result);
+          done();
+        });
+      });
+
+      it('should append a scope field from the factory to the result token, if the factory result is a truthy string', function(done) {
+        auth.authenticate({stormpath_token: validToken, scope: scope}, function(err, result) {
+          if (err) {
+            return done(err);
+          }
+
+          /* jshint -W030 */
+          spy.should.have.been.calledTwice;
+          /* jshint +W030 */
+
+          // Decoded token
+          assert.ok(result);
+          assert.ok(result.accessToken);
+          assert.ok(result.accessToken.body);
+          assert.equal(result.accessToken.body.scope, scope);
+
+          // Manual decoding check
+          njwt.verify(result.accessTokenResponse.access_token, signingKey, function(err, token) {
+            assert.ok(token);
+            assert.ok(token.body);
+            assert.equal(token.body.scope, scope);
+            done();
+          });
+        });
+      });
+
+      it('should leave all the other fields in the header and body of the JWT untouched', function(done) {
+        var bodyField;
+
+        auth.authenticate({stormpath_token: validToken, scope: scope}, function(err, authResponse) {
+          if (err) {
+            return done(err);
+          }
+
+          /* jshint -W030 */
+          spy.should.have.been.calledThrice;
+          /* jshint +W030 */
+
+          var originalToken = spy.args[2][0];
+          var token = authResponse.accessToken;
+
+          assert.deepEqual(originalToken.header, token.header);
+
+          for (bodyField in originalToken.body) {
+            if (originalToken.body.hasOwnProperty(bodyField)) {
+              assert.equal(originalToken.body[bodyField], token.body[bodyField]);
+            }
+          }
+
+          done();
+        });
+      });
+
+      describe('JwtAuthenticator validation', function() {
+        var jwtAuthenticator;
+        var token;
+
+        before(function(done) {
+          jwtAuthenticator = new JwtAuthenticator(application);
+          auth.authenticate({stormpath_token: validToken, scope: scope}, function(err, resp) {
+            if (err) {
+              return done(err);
+            }
+            token = resp.accessTokenResponse.access_token;
+            done();
+          });
+        });
+
+        describe('without local validation', function() {
+          it('should validate the token', function(done) {
+            jwtAuthenticator.authenticate(token, function(err, data) {
+              assert.notOk(err);
+              assert.ok(data);
+              done();
+            });
+          });
+
+          it('should yield a result containing the scope', function(done) {
+            jwtAuthenticator.authenticate(token, function(err, data) {
+              assert.ok(data.expandedJwt);
+              assert.ok(data.expandedJwt.claims);
+              assert.equal(data.expandedJwt.claims.scope, scope);
+              done();
+            });
+          });
+        });
+
+        describe('with local validation', function() {
+          before(function() {
+            jwtAuthenticator.withLocalValidation();
+          });
+
+          it('should validate the token', function(done) {
+            jwtAuthenticator.authenticate(token, function(err, data) {
+              assert.notOk(err);
+              assert.ok(data);
+              done();
+            });
+          });
+
+          it('should yield a result containing the scope', function(done) {
+            jwtAuthenticator.authenticate(token, function(err, data) {
+              assert.ok(data.expandedJwt);
+              assert.ok(data.expandedJwt.body);
+              assert.equal(data.expandedJwt.body.scope, scope);
+              done();
+            });
+          });
+        });
+      });
+
+      describe('errors', function() {
+
+        before(function() {
+          auth.setScopeFactorySigningKey();
+        });
+
+        after(function() {
+          auth.setScopeFactorySigningKey(signingKey);
+        });
+
+        it('should call the callback with an error if used with a factory function but without a key', function(done) {
+          var callback = function(err, data) {
+            assert.ok(err);
+            assert.notOk(data);
+            done();
+          };
+
+          auth.authenticate({stormpath_token: validToken, scope: scope}, callback);
         });
       });
     });

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -10,6 +10,7 @@ var sinon = common.sinon;
 var njwt = require('njwt');
 
 var JwtAuthenticator = require('../../lib/jwt/jwt-authenticator');
+var JwtAuthenticationResult = require('../../lib/jwt/jwt-authentication-result');
 
 describe('OAuthStormpathTokenAuthenticator', function () {
   var account;
@@ -182,6 +183,7 @@ describe('OAuthStormpathTokenAuthenticator', function () {
         auth = new stormpath.OAuthStormpathTokenAuthenticator(application);
         spy = sinon.spy();
         scopeFactoryFunction = function scopeFactoryFunction(authenticationResult, requestedScope, callback) {
+          assert.instanceOf(authenticationResult, JwtAuthenticationResult);
           spy(authenticationResult, requestedScope, callback);
           callback(null, scope);
         };

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -40,6 +40,12 @@ describe('OAuthStormpathTokenAuthenticator', function () {
     helpers.cleanupApplicationAndStores(application, done);
   });
 
+  describe('inheritance', function() {
+    it('should inherit from ScopeFactoryAuthenticator', function() {
+      assert.equal(stormpath.OAuthStormpathTokenAuthenticator.super_.name, 'ScopeFactoryAuthenticator');
+    });
+  });
+
   describe('when calling OAuthStormpathTokenAuthenticator(application)', function () {
     var instance;
 

--- a/test/it/oauth_stormpath_token_it.js
+++ b/test/it/oauth_stormpath_token_it.js
@@ -252,7 +252,7 @@ describe('OAuthStormpathTokenAuthenticator', function () {
           spy.should.have.been.calledThrice;
           /* jshint +W030 */
 
-          var originalToken = njwt.verify(spy.args[2][0].access_token, auth.signingKey);
+          var originalToken = spy.args[2][0].accessToken;
           var token = authResponse.accessToken;
 
           assert.deepEqual(originalToken.header, token.header);


### PR DESCRIPTION
Implements the scope factory feature for certain OAuth authenticators. This enables developers to attach functions to their authenticators, with the goal of attaching `scope` properties to their JSON Web Tokens (JWT), and as such their authentication results. These can then be used for various purposes, as described in the attached issue.

Adds tests and class documentation. Modifies some existing classes slightly to satisfy the requirements.

Usage example:

``` js
var stormpath = require('stormpath');
var application; // instantiated somewhere
var apiKey; // fetched beforehand
var stormpathToken; // generated beforehand
var authenticator;
var jwtAuthenticator;

function groupScopeFactory(authenticationResult, requestedScope, callback){
  authenticationResult.getAccount({expand: 'groups'}, function(err, account){
    if (err) {
      return callback(err);
    }

    var groupNames = account.groups.items.map(function (group) {
      return group.name;
    });

    var grantedScope = groupNames.join(' ');

    callback(null, grantedScope);
  });
}

jwtAuthenticator = new stormpath.JwtAuthenticator(application);

authenticator = new stormpath.OAuthStormpathTokenAuthenticator(application);
authenticator.setScopeFactory(groupScopeFactory);
authenticator.setScopeFactorySigningKey(apiKey.secret);

authenticator.authenticate({stormpath_token: stormpathToken, scope: 'admin'}, function(err, authResult) {
  authenticator.authenticate(authResult.accessTokenResponse.access_token, function(err, authConfirm) {
    // Will be defined if the user is a member of at least one group
    console.log(authConfirm.expandedJwt.claims.scope);
  });
});
```

Fixes #556 
