### PR TITLE
Add organizations cache region

### DIFF
--- a/lib/cache/CacheHandler.js
+++ b/lib/cache/CacheHandler.js
@@ -10,7 +10,7 @@ var utils = require('../utils');
 
 var CACHE_REGIONS = ['applications', 'directories', 'accounts', 'groups',
   'groupMemberships', 'tenants', 'accountStoreMappings','apiKeys','idSiteNonces',
-  'customData'];
+  'customData', 'organizations'];
 
 // singleton of DisabledCache wrapped into Cache instance
 var disabledCache = new Cache({store: DisabledCache});


### PR DESCRIPTION
Adds `organiations` to the cache regions.

Fixes https://github.com/stormpath/express-stormpath/pull/538