### PR TITLE
Fixes for recent expansions fix

### DIFF
--- a/lib/resource/AccountCreationPolicy.js
+++ b/lib/resource/AccountCreationPolicy.js
@@ -1,3 +1,6 @@
+var InstanceResource = require('./InstanceResource');
+var utils = require('../utils');
+
 /**
  * @class AccountCreationPolicy
  *
@@ -27,3 +30,12 @@
  * The function to call when the save operation is complete. Will be called
  * with the parameters (err, updatedResource).
  */
+
+
+function AccountCreationPolicy() {
+  AccountCreationPolicy.super_.apply(this, arguments);
+}
+
+utils.inherits(AccountCreationPolicy, InstanceResource);
+
+module.exports = AccountCreationPolicy;

--- a/lib/resource/ResourceFactory.js
+++ b/lib/resource/ResourceFactory.js
@@ -6,6 +6,9 @@ var CustomData = require('./CustomData');
 var InstanceResource = require('./InstanceResource');
 var utils = require('../utils');
 
+var fs = require('fs');
+var path = require('path');
+
 /**
 * @private
 *
@@ -21,7 +24,7 @@ function getPathForResourceName(resourceName) {
   var normalizedFieldName = resourceName.charAt(0).toUpperCase() +
     resourceName.substr(1);
 
-  return './' + normalizedFieldName;
+  return path.join(__dirname , normalizedFieldName + '.js');
 }
 
 /**
@@ -51,8 +54,7 @@ function expandResource(expandedFields, resource, query, dataStore) {
 
   expandedFields.forEach(function(fieldName) {
     var path = getPathForResourceName(fieldName);
-
-    if (typeof resource[fieldName] !== 'undefined') {
+    if (typeof resource[fieldName] !== 'undefined' && fs.existsSync(path) ) {
       resource[fieldName] = instantiate(require(path), resource[fieldName], query, dataStore);
     }
   });


### PR DESCRIPTION
This commit fixes these problems:

* If a defined resource exists (it exists as a file in lib/resource/) but doesn’t export a constructor function, then `instantiate()` will fail.
* If a resource cannot be found in lib/resource, we get exceptions.

The tests in this library are not catching these exceptions.  I found these while running the express-stormpath tests, while linked to the master head of this library.

@Tweety-FER can you please review?  You should be able to reproduce the problems by running the tests in our [express-stormpath](https://github.com/stormpath/express-stormpath) library, while you have it linked to the master head of this library.