### PR TITLE
Account linking

### DIFF
--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -383,6 +383,84 @@ Account.prototype.getApiKeys = function getApiKeys(options, callback) {
 
   return this.dataStore.getResource(this.apiKeys.href, opts, require('./ApiKey'), cb);
 };
+
+/**
+ * Retrieves the collection of accounts that this account is linked to.
+ *
+ * @param {CollectionQueryOptions} collectionQueryOptions
+ * Options for querying, paginating, and expanding the collection. This collection
+ * supports filter searches and the following attribute searches:
+ * `createdAt`, `email`, `givenName`, `middleName`, `modifiedAt`, `surname`,
+ * `status`, `username`.
+ *
+ * @param {Function} callback
+ * The function to call when then the operation is complete. Will be called
+ * with the parameters (err, {@link CollectionResource}). The collection will
+ * be a list of {@link Account} objects.
+ */
+
+Account.prototype.getLinkedAccount = function getLinkedAccounts(/* [options], callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.linkedAccounts.href, args.options, Account, args.callback);
+};
+
+/**
+* Retrieves the collection of account links that are associated with the current
+* account.
+*
+* @param {CollectionQueryOptions} CollectionQueryOptions
+* Options for querying, paginating and expanding the collection. This collection
+* does not support filter searches, but it does support attribute searches by
+* `createdAt`. It allows expansion of the `leftAccount` and `rightAccount` attributes.
+*
+* @param {Function} callback
+* The function to call when the operation is complete. Will be called with
+* the parameters (err, {@link CollectionResource}). The collection will be a
+* list of {@link AccountLink} objects.
+*/
+Account.prototype.getAccountLinks = function getAccountLinks(/* [options], callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.accountLinks.href, args.options, require('./AccountLink'), args.callback);
+};
+
+/**
+ * Creates a link between this account and a given account. If the two accounts
+ * are already linked, this will error.
+ *
+ * @param {Account} linkedAccount Account to link this account to.
+ *
+ * @param {Function} callback
+ * The function to call when the operation is complete. Will be called with the
+ * parameters (err, {@link AccountLink}).
+ *
+ * @example
+ *
+ * var otherAccount = {
+ *   href: 'validhref'
+ * };
+ *
+ * account.createAccountLink(otherAccount, function (err, link) {
+ *   if (!err) {
+ *     console.log('Accounts linked');
+ *   }
+ * });
+ */
+Account.prototype.createAccountLink = function linkToAccount(/* linkedAccount, callback */) {
+  var args = utils.resolveArgs(arguments, ['linkedAccount', 'callback']);
+  var accountLink = {
+    leftAccount: {
+      href: this.href
+    },
+    rightAccount: {
+      href: args.linkedAccount.href
+    }
+  };
+
+  return this.dataStore.createResource('/accountLinks', {}, accountLink, require('./accountLink'), args.callback);
+};
+
 /**
  * Save changes to this account.
  *

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -398,8 +398,7 @@ Account.prototype.getApiKeys = function getApiKeys(options, callback) {
  * with the parameters (err, {@link CollectionResource}). The collection will
  * be a list of {@link Account} objects.
  */
-
-Account.prototype.getLinkedAccount = function getLinkedAccounts(/* [options], callback */) {
+Account.prototype.getLinkedAccounts = function getLinkedAccounts(/* [options], callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   return this.dataStore.getResource(this.linkedAccounts.href, args.options, Account, args.callback);
@@ -458,7 +457,7 @@ Account.prototype.createAccountLink = function linkToAccount(/* linkedAccount, c
     }
   };
 
-  return this.dataStore.createResource('/accountLinks', {}, accountLink, require('./accountLink'), args.callback);
+  return this.dataStore.createResource('/accountLinks', null, accountLink, require('./AccountLink'), args.callback);
 };
 
 /**

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -430,6 +430,9 @@ Account.prototype.getAccountLinks = function getAccountLinks(/* [options], callb
  *
  * @param {Account} linkedAccount Account to link this account to.
  *
+ * @param {ExpansionOptions} [options]
+ * Options to expand the returned {@link AccountLink} resource.
+ *
  * @param {Function} callback
  * The function to call when the operation is complete. Will be called with the
  * parameters (err, {@link AccountLink}).
@@ -437,17 +440,17 @@ Account.prototype.getAccountLinks = function getAccountLinks(/* [options], callb
  * @example
  *
  * var otherAccount = {
- *   href: 'validhref'
+ *   href: 'https://api.stormpath.com/v1/accounts/1oS9pRJ8we097h882rhWyb'
  * };
  *
- * account.createAccountLink(otherAccount, function (err, link) {
+ * account.createAccountLink(otherAccount, function (err, accountLink) {
  *   if (!err) {
- *     console.log('Accounts linked');
+ *     console.log('Account Link Created', accountLink);
  *   }
  * });
  */
 Account.prototype.createAccountLink = function linkToAccount(/* linkedAccount, callback */) {
-  var args = utils.resolveArgs(arguments, ['linkedAccount', 'callback']);
+  var args = utils.resolveArgs(arguments, ['linkedAccount', 'options', 'callback']);
   var accountLink = {
     leftAccount: {
       href: this.href
@@ -457,7 +460,7 @@ Account.prototype.createAccountLink = function linkToAccount(/* linkedAccount, c
     }
   };
 
-  return this.dataStore.createResource('/accountLinks', null, accountLink, require('./AccountLink'), args.callback);
+  return this.dataStore.createResource('/accountLinks', args.options, accountLink, require('./AccountLink'), args.callback);
 };
 
 /**

--- a/lib/resource/AccountLink.js
+++ b/lib/resource/AccountLink.js
@@ -66,5 +66,7 @@ AccountLink.prototype.getLeftAccount = function getLeftAccount(/* [options], cal
 AccountLink.prototype.getRightAccount = function getRightAccount(/* [options], callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
-  return this.dataStore.getResource(this.rightAccout.href, args.options, require('./Account'), args.callback);
+  return this.dataStore.getResource(this.rightAccount.href, args.options, require('./Account'), args.callback);
 };
+
+module.exports = AccountLink;

--- a/lib/resource/AccountLink.js
+++ b/lib/resource/AccountLink.js
@@ -20,6 +20,7 @@ var InstanceResource = require('./InstanceResource');
  *
  * - {@link Account#getAccountLinks Account.getAccountLinks()}
  * - {@link Account#createAccountLink Account.createAccountLink()}
+ * - {@link Tenant#createAccountLink Tenant.createAccountLink()}
  *
  * @augments {InstanceResource}
  *

--- a/lib/resource/AccountLink.js
+++ b/lib/resource/AccountLink.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var utils = require('../utils');
+var InstanceResource = require('./InstanceResource');
+
+/**
+ * @class AccountLink
+ *
+ * @description
+ *
+ * Encapsulates an AccountLink resource. For full documentation of this resource,
+ * please see
+ * [REST API Reference: AccountLink](https://docs.stormpath.com/rest/product-guide/latest/reference.html#account-link).
+ *
+ * For information about automatically generating account links, please see
+ * {@link https://docs.stormpath.com/rest/product-guide/latest/accnt_mgmt.html#account-linking-automatic Automatic Account Linking}.
+ *
+ * This class should not be manually constructed. It should be obtained from one
+ * of these methods:
+ *
+ * - {@link Account#getAccountLinks Account.getAccountLinks()}
+ * - {@link Account#createAccountLink Account.createAccountLink()}
+ *
+ * @augments {InstanceResource}
+ *
+ * @param {Object} accountLinkResource
+ *
+ * The JSON representation of this resource.
+ */
+function AccountLink() {
+  AccountLink.super_.apply(this, arguments);
+}
+
+utils.inherits(AccountLink, InstanceResource);
+
+/**
+* Retrieves the "left" account of this account link. The "left" and "right"
+* designations are purely arbitrary and imply no hierarchy or priority between
+* the two.
+*
+* @param {ExpansionOptions} [options]
+* For retrieving linked resources of the query result.
+*
+* @param {Function} callback
+* The function to call when the operation is complete. Will be called with
+* the parameters (err, {@link Account}).
+*/
+AccountLink.prototype.getLeftAccount = function getLeftAccount(/* [options], callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.leftAccount.href, args.options, require('./Account'), args.callback);
+};
+
+/**
+* Retrieves the "right" account of this account link. The "left" and "right"
+* designations are purely arbitrary and imply no hierarchy or priority between
+* the two.
+*
+* @param {ExpansionOptions} [options]
+* For retrieving linked resources of the query result.
+*
+* @param {Function} callback
+* The function to call when the operation is complete. Will be called with
+* the parameters (err, {@link Account}).
+*/
+AccountLink.prototype.getRightAccount = function getRightAccount(/* [options], callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.rightAccout.href, args.options, require('./Account'), args.callback);
+};

--- a/lib/resource/AccountLinkingPolicy.js
+++ b/lib/resource/AccountLinkingPolicy.js
@@ -51,6 +51,6 @@ AccountLinkingPolicy.prototype.getTenant = function getTenant(/* [options,] call
 };
 
 // Removes the inherited delete method. This resource cannot be deleted manually!
-delete AccountLinkingPolicy.prototype.delete;
+AccountLinkingPolicy.prototype.delete = undefined;
 
 module.exports = AccountLinkingPolicy;

--- a/lib/resource/AccountLinkingPolicy.js
+++ b/lib/resource/AccountLinkingPolicy.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var utils = require('../utils');
+var InstanceResource = require('./InstanceResource');
+
+/**
+ * @class AccountLinkingPolicy
+ *
+ * @description
+ *
+ * Encapsulates an AccountLinkingPolicy resource. For full documentation of this resource,
+ * please see
+ * [REST API Reference: Account LinkingPolicy](https://docs.stormpath.com/rest/product-guide/latest/reference.html#account-linking-policy).
+ *
+ * This class should not be manually constructed. It should be obtained from one
+ * of these methods:
+ *
+ * - {@link Application#getAccountLinkingPolicy Application.getAccountLinkingPolicy()}
+ * - {@link Organization#getAccountLinkingPolicy Organization.getAccountLinkingPolicy()}
+ *
+ * Furthermore, an Account Linking Policy cannot be created or deleted from the SDK. Instead, it is
+ * automatically created for all {@link Application} and {@link Organization} resources,
+ * but can then be modified.
+ *
+ * @augments {InstanceResource}
+ *
+ * @param {Object} AccountLinkingPolicyResource
+ *
+ * The JSON representation of this resource.
+ *
+ */
+function AccountLinkingPolicy() {
+  AccountLinkingPolicy.super_.apply(this, arguments);
+}
+
+utils.inherits(AccountLinkingPolicy, InstanceResource);
+
+/**
+* Retrieves this account linking policy's associated tenant.
+*
+* @param {ExpansionOptions} options
+* Options for retrieving linked resources of the {@link Tenant} during this request.
+*
+* @param {Function} callback
+* The callback that will be called with the parameters (err, {@link Tenant}).
+*/
+AccountLinkingPolicy.prototype.getTenant = function getTenant(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.tenant.href, args.options, require('./Tenant'), args.callback);
+};
+
+// Removes the inherited delete method. This resource cannot be deleted manually!
+delete AccountLinkingPolicy.prototype.delete;
+
+module.exports = AccountLinkingPolicy;

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -1469,4 +1469,22 @@ Application.prototype.getCustomData = function getCustomData(/* [options,] callb
   return this.dataStore.getResource(this.customData.href, args.options, require('./CustomData'), args.callback);
 };
 
+/**
+* Retrieves the application's {@link AccountLinkingPolicy}, which determines if
+* and how accounts in its default account store are linked, so that {@link AccountLink}
+* instances are automatically created between two accounts that would match this policy.
+*
+* @param {ExpansionOptions} options
+* Options for expanding the account linking policy. Can be expanded on `tenant`.
+*
+* @param {Function} callback
+* The function that will be called when the query is finished, with the parameters
+* (err, {@link AccountLinkingPolicy}).
+*/
+Application.prototype.getAccountLinkingPolicy = function getApplicationAccountLinkingPolicy(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.accountLinkingPolicy.href, args.options, require('./AccountLinkingPolicy'), args.callback);
+};
+
 module.exports = Application;

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -615,4 +615,22 @@ Organization.prototype.setDefaultGroupStore = function setDefaultGroupStore(stor
   }
 };
 
+/**
+* Retrieves the organization's {@link AccountLinkingPolicy}, which determines if
+* and how accounts in its default account store are linked, so that {@link AccountLink}
+* instances are automatically created between two accounts that would match this policy.
+*
+* @param {ExpansionOptions} options
+* Options for expanding the account linking policy. Can be expanded on `tenant`.
+*
+* @param {Function} callback
+* The function that will be called when the query is finished, with the parameters
+* (err, {@link AccountLinkingPolicy}).
+*/
+Organization.prototype.getAccountLinkingPolicy = function getOrganizationAccountLinkingPolicy(/* [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+
+  return this.dataStore.getResource(this.accountLinkingPolicy.href, args.options, require('./AccountLinkingPolicy'), args.callback);
+};
+
 module.exports = Organization;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -280,4 +280,58 @@ Tenant.prototype.getSmtpServers = function getSmtpServers(/* [options,] callback
   return this.dataStore.getResource(this.smtpServers.href, args.options, require('./SmtpServer'), args.callback);
 };
 
+/**
+ * Creates a link between two given accounts. If the two accounts are already
+ * linked, this will error. The designations "left" and "right" are purely
+ * arbitrary and imply no hierarchy or ordering between the accounts.
+ *
+ * @param {Account} leftAccount
+ * One of the accounts to create a link between.
+ *
+ * @param {Account} rightAccount
+ * Other one of the accounts to create a link between.
+ *
+ * @param {ExpansionOptions} options
+ * Options to expand the returned {@link AccountLink} resource.
+ *
+ * @param {Function} callback
+ * The function to call when the operation is complete. Will be called with the
+ * parameters (err, {@link AccountLink}).
+ *
+ * @example
+ *
+ * var leftAccount = {
+ *  href: 'href1'
+ * };
+ *
+ * var rightAccount = {
+ *  href: 'href2'
+ * };
+ *
+ * tenant.createAccountLink(leftAccount, rightAccount, function (err, link) {
+ *   if (!err) {
+ *     console.log('Accounts linked');
+ *   }
+ * });
+ */
+Tenant.prototype.createAccountLink = function createAccountLink(/* leftAccount, rightAccount, [options,] callback */) {
+  var args = utils.resolveArgs(arguments, ['leftAccount', 'rightAccount', 'options', 'callback']);
+
+  if (args.options && !args.callback) {
+    args.callback = args.options;
+    args.options = null;
+  }
+
+  var accountLink = {
+    leftAccount: {
+      href: args.leftAccount.href
+    },
+    rightAccount: {
+      href: args.rightAccount.href
+    }
+  };
+
+  return this.dataStore.createResource('/accountLinks', args.options, accountLink, require('./AccountLink'), args.callback);
+};
+
 module.exports = Tenant;

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -291,7 +291,7 @@ Tenant.prototype.getSmtpServers = function getSmtpServers(/* [options,] callback
  * @param {Account} rightAccount
  * Other one of the accounts to create a link between.
  *
- * @param {ExpansionOptions} options
+ * @param {ExpansionOptions} [options]
  * Options to expand the returned {@link AccountLink} resource.
  *
  * @param {Function} callback
@@ -301,26 +301,21 @@ Tenant.prototype.getSmtpServers = function getSmtpServers(/* [options,] callback
  * @example
  *
  * var leftAccount = {
- *  href: 'href1'
+ *  href: 'https://api.stormpath.com/v1/accounts/1oS9pRJ8we097h882rhWyb'
  * };
  *
  * var rightAccount = {
- *  href: 'href2'
+ *  href: 'https://api.stormpath.com/v1/accounts/xbohsiHoGq0qRGW4c0hqd'
  * };
  *
- * tenant.createAccountLink(leftAccount, rightAccount, function (err, link) {
+ * tenant.createAccountLink(leftAccount, rightAccount, function (err, accountLink) {
  *   if (!err) {
- *     console.log('Accounts linked');
+ *     console.log('Account Link Created', accountLink);
  *   }
  * });
  */
 Tenant.prototype.createAccountLink = function createAccountLink(/* leftAccount, rightAccount, [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['leftAccount', 'rightAccount', 'options', 'callback']);
-
-  if (args.options && !args.callback) {
-    args.callback = args.options;
-    args.options = null;
-  }
 
   var accountLink = {
     leftAccount: {

--- a/lib/resource/Tenant.js
+++ b/lib/resource/Tenant.js
@@ -14,6 +14,7 @@ var utils = require('../utils');
  *
  * This class should not be manually constructed. It should be obtained from one of these methods:
  * - {@link Client#getCurrentTenant Client.getCurrentTenant()}
+ * - {@link AccountLinkingPolicy#getTenant AccountLinkingPolicy.getTenant()}
  *
  * For convenience, some of these methods also exist on an instance of {@link Client},
  * where they are bound to the current tenant, as identified by the API Key Pair

--- a/test/it/account_it.js
+++ b/test/it/account_it.js
@@ -8,6 +8,7 @@ var assert = common.assert;
 var AccessToken = require('../../lib/resource/AccessToken');
 var RefreshToken = require('../../lib/resource/RefreshToken');
 var Account = require('../../lib/resource/Account');
+var AccountLink = require('../../lib/resource/AccountLink');
 var CustomData = require('../../lib/resource/CustomData');
 
 var AccountAccessTokenFixture = require('../fixtures/account-token');
@@ -194,6 +195,75 @@ describe('Account', function() {
 
         it('should have the new property persisted', function() {
           assert.equal(customDataAfterGet[propertyName], propertyValue);
+        });
+      });
+    });
+  });
+
+  describe('account linking', function() {
+    var secondaryFixture;
+
+    before(function(done) {
+      secondaryFixture = new AccountAccessTokenFixture();
+      secondaryFixture.before(function() {
+        assert.equal(secondaryFixture.creationResult[0], null); // did not error
+        assert(secondaryFixture.account instanceof Account);
+        done();
+      });
+
+    });
+
+    after(function(done) {
+      secondaryFixture.after(done);
+    });
+
+    // Note: order of these tests matters, we need to create a link first!
+    describe('createAccountLink()', function() {
+      it('should create a link with a given second account', function(done) {
+        fixture.account.createAccountLink(secondaryFixture.account, function(err, link) {
+          if (err) {
+            return done(err);
+          }
+
+          assert(link instanceof AccountLink);
+          done();
+        });
+      });
+
+      it('should return an error if that link already exists', function(done) {
+        fixture.account.createAccountLink(secondaryFixture.account, function(err, link) {
+          assert.ok(err);
+          assert.notOk(link);
+          assert.equal(err.status, 409);
+          assert.equal(err.code, 7500);
+          assert.equal(err.userMessage, 'These accounts are already linked.');
+          done();
+        });
+      });
+    });
+
+    describe('getAccountLinks', function() {
+      it('should return a collection of account links', function(done) {
+        fixture.account.getAccountLinks(function(err, collection) {
+          if (err) {
+            return done(err);
+          }
+
+          assert(collection.items[0] instanceof AccountLink);
+          done();
+        });
+      });
+    });
+
+    describe('getLinkedAccounts()', function() {
+      it('should return a collection of linked accounts', function(done) {
+        fixture.account.getLinkedAccounts(function(err, collection) {
+          if (err) {
+            return done(err);
+          }
+
+          assert(collection.items[0] instanceof Account);
+          done();
         });
       });
     });

--- a/test/sp.resource.accountLink_test.js
+++ b/test/sp.resource.accountLink_test.js
@@ -1,0 +1,118 @@
+var common = require('./common');
+var assert = common.assert;
+var sinon = common.sinon;
+
+var Account = require('../lib/resource/Account');
+var AccountLink = require('../lib/resource/AccountLink');
+var DataStore = require('../lib/ds/DataStore');
+
+describe('Resources: ', function() {
+  describe('AccountLink resource class', function() {
+    var dataStore;
+
+    before(function () {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
+
+    describe('Constructor', function() {
+      it('should inherit from InstanceResource', function() {
+        AccountLink.super_.name.should.equal('InstanceResource');
+      });
+    });
+
+    describe('methods', function() {
+      var sandbox;
+      var opts;
+      var accountLinkData;
+      var accountLink;
+      var getResourceStub;
+      var cbSpy;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+
+        opts = {
+          boom: 'of course'
+        };
+
+        accountLinkData = {
+          href: 'boom!',
+          createdAt: '',
+          modifiedAt: '',
+          leftAccount: {
+            href: 'leftBoom!'
+          },
+          rightAccount: {
+            href: 'rightBoom!'
+          }
+        };
+
+        accountLink = new AccountLink(accountLinkData, dataStore);
+
+        getResourceStub = sandbox.stub(dataStore, 'getResource', function(href, options, ctor, cb) {
+          cb();
+        });
+
+        cbSpy = sandbox.spy();
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      describe('#getLeftAccount()', function() {
+        before(function() {
+          accountLink.getLeftAccount(cbSpy);
+          accountLink.getLeftAccount(opts, cbSpy);
+        });
+
+        it('should get the leftAccount resource', function() {
+          /* jshint -W030 */
+          getResourceStub.should.have.been.calledTwice;
+          cbSpy.should.have.been.calledTwice;
+          /* jshint +W030 */
+
+          getResourceStub.should.have.been.calledWith(
+            'leftBoom!',
+            null,
+            Account,
+            cbSpy
+          );
+
+          getResourceStub.should.have.been.calledWith(
+            'leftBoom!',
+            opts,
+            Account,
+            cbSpy
+          );
+        });
+      });
+
+      describe('#getRightAccount()', function() {
+        before(function() {
+          accountLink.getRightAccount(cbSpy);
+          accountLink.getRightAccount(opts, cbSpy);
+        });
+
+        it('should get the rightAccount resource', function() {
+          assert.equal(getResourceStub.callCount, 4);
+          assert.equal(cbSpy.callCount, 4);
+
+          getResourceStub.should.have.been.calledWith(
+            'rightBoom!',
+            null,
+            Account,
+            cbSpy
+          );
+
+          getResourceStub.should.have.been.calledWith(
+            'rightBoom!',
+            opts,
+            Account,
+            cbSpy
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/sp.resource.accountLinkingPolicy_test.js
+++ b/test/sp.resource.accountLinkingPolicy_test.js
@@ -1,0 +1,97 @@
+var common = require('./common');
+var assert = common.assert;
+var sinon = common.sinon;
+
+var AccountLinkingPolicy = require('../lib/resource/AccountLinkingPolicy');
+var Tenant = require('../lib/resource/Tenant');
+var DataStore = require('../lib/ds/DataStore');
+
+describe('Resources: ', function() {
+  describe('AccountLinkingPolicy resource class', function() {
+    var dataStore;
+
+    before(function() {
+      dataStore = new DataStore({client: {apiKey: {id: 1, secret: 2}}});
+    });
+
+    describe('Constructor', function() {
+      it('should inherit from InstanceResource', function() {
+        AccountLinkingPolicy.super_.name.should.equal('InstanceResource');
+      });
+
+      it('should *not* inherit the delete method', function() {
+        var alp = new AccountLinkingPolicy({href: 'boom!'}, dataStore);
+        assert.isUndefined(alp.delete);
+      });
+    });
+
+    describe('methods', function() {
+      var sandbox;
+      var opts;
+      var alpData;
+      var alp;
+      var getResourceStub;
+      var cbSpy;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+
+        opts = {
+          boom: 'of course'
+        };
+
+        alpData = {
+          href: 'boom!',
+          createdAt: '',
+          modifiedAt: '',
+          status: 'ENABLED',
+          automaticProvisioning: 'ENABLED',
+          matchingProperty: 'email',
+          tenant: {
+            href: 'boom!'
+          }
+        };
+
+        alp = new AccountLinkingPolicy(alpData, dataStore);
+
+        getResourceStub = sandbox.stub(dataStore, 'getResource', function(href, options, ctor, cb) {
+          cb();
+        });
+
+        cbSpy = sandbox.spy();
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      describe('#getTenant()', function() {
+        before(function() {
+          alp.getTenant(cbSpy);
+          alp.getTenant(opts, cbSpy);
+        });
+
+        it('should get the leftAccount resource', function() {
+          /* jshint -W030 */
+          getResourceStub.should.have.been.calledTwice;
+          cbSpy.should.have.been.calledTwice;
+          /* jshint +W030 */
+
+          getResourceStub.should.have.been.calledWith(
+            'boom!',
+            null,
+            Tenant,
+            cbSpy
+          );
+
+          getResourceStub.should.have.been.calledWith(
+            'boom!',
+            opts,
+            Tenant,
+            cbSpy
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/sp.resource.account_test.js
+++ b/test/sp.resource.account_test.js
@@ -7,6 +7,7 @@ var uuid = common.uuid;
 var assert = common.assert;
 var Group = require('../lib/resource/Group');
 var Account = require('../lib/resource/Account');
+var AccountLink = require('../lib/resource/AccountLink');
 var ApiKey = require('../lib/resource/ApiKey');
 var DataStore = require('../lib/ds/DataStore');
 var CustomData = require('../lib/resource/CustomData');
@@ -496,6 +497,129 @@ describe('Resources: ', function () {
       });
       it('should return ApiKey instances',function(){
         assert.instanceOf(result[1].items[0],ApiKey);
+      });
+    });
+
+    describe('get linked accounts', function() {
+      var sandbox;
+      var account;
+      var opts;
+      var getResourceStub;
+      var cbSpy;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+        account = new Account({linkedAccounts: {href: 'boom!'}}, dataStore);
+        getResourceStub = sandbox.stub(dataStore, 'getResource',
+          function(href, options, ctor, cb) {
+            cb();
+          });
+
+        opts = {q: 'boom!'};
+
+        cbSpy = sandbox.spy();
+
+        account.getLinkedAccounts(cbSpy);
+        account.getLinkedAccounts(opts, cbSpy);
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      it('should try to get the resources', function() {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        getResourceStub.should.have.been.calledWith('boom!', null, Account, cbSpy);
+        getResourceStub.should.have.been.calledWith('boom!', opts, Account, cbSpy);
+      });
+    });
+
+    describe('get account links', function() {
+      var sandbox;
+      var account;
+      var opts;
+      var getResourceStub;
+      var cbSpy;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+        account = new Account({accountLinks: {href: 'boom!'}}, dataStore);
+        getResourceStub = sandbox.stub(dataStore, 'getResource',
+          function(href, options, ctor, cb) {
+            cb();
+          });
+
+        opts = {q: 'boom!'};
+
+        cbSpy = sandbox.spy();
+
+        account.getAccountLinks(cbSpy);
+        account.getAccountLinks(opts, cbSpy);
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      it('should try to get the resources', function() {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        getResourceStub.should.have.been.calledWith('boom!', null, AccountLink, cbSpy);
+        getResourceStub.should.have.been.calledWith('boom!', opts, AccountLink, cbSpy);
+      });
+    });
+
+    describe('create account links', function() {
+      var sandbox;
+      var account;
+      var otherAccount;
+      var createResourceStub;
+      var cbSpy;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+        account = new Account({href: 'boom!'}, dataStore);
+        otherAccount = new Account({href: 'baam!'});
+
+        createResourceStub = sandbox.stub(dataStore, 'createResource',
+          function(href, options, data, ctor, cb) {
+            cb();
+          });
+
+        cbSpy = sandbox.spy();
+
+        account.createAccountLink(otherAccount, cbSpy);
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      it('should try to create the resource', function() {
+        /* jshint -W030 */
+        createResourceStub.should.have.been.calledOnce;
+        cbSpy.should.have.been.calledOnce;
+        /* jshint +W030 */
+
+        assert.equal(createResourceStub.args[0][0], '/accountLinks');
+        assert.equal(createResourceStub.args[0][1], null);
+        assert.deepEqual(createResourceStub.args[0][2], {
+          leftAccount: {
+            href: 'boom!'
+          },
+          rightAccount: {
+            href: 'baam!'
+          }
+        });
+        assert.equal(createResourceStub.args[0][3], AccountLink);
+        assert.equal(createResourceStub.args[0][4], cbSpy);
       });
     });
 

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -18,6 +18,7 @@ var AccountStoreMapping = require('../lib/resource/AccountStoreMapping');
 var ApiKey = require('../lib/resource/ApiKey');
 var DataStore = require('../lib/ds/DataStore');
 var PasswordResetToken = require('../lib/resource/PasswordResetToken');
+var AccountLinkingPolicy = require('../lib/resource/AccountLinkingPolicy');
 var nJwt = require('njwt');
 var nJwtProperties = require('njwt/properties');
 var uuid = require('node-uuid');
@@ -1256,6 +1257,55 @@ describe('Resources: ', function () {
         asm.accountStore.href.should.be.equal(storeObj.href);
         asm.application.href.should.be.equal(app.href);
         cbSpy.should.have.been.calledOnce;
+      });
+    });
+
+    describe('get account linking policy', function() {
+      var sandbox;
+      var application;
+      var getResourceStub;
+      var cbSpy;
+      var app;
+      var opts;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+        app = {
+          accountLinkingPolicy: {
+            href: 'boom!'
+          }
+        };
+        opts = {
+          expand: 'boom!'
+        };
+        application = new Application(app, dataStore);
+        getResourceStub = sandbox.stub(dataStore, 'getResource', function(href, options, ctor, cb) {
+          cb();
+        });
+        cbSpy = sandbox.spy();
+
+        // call without optional param
+        application.getAccountLinkingPolicy(cbSpy);
+        // call with optional param
+        application.getAccountLinkingPolicy(opts, cbSpy);
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      it('should should get the account linking policy', function() {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        // call without optional param
+        getResourceStub.should.have.been
+          .calledWith(app.accountLinkingPolicy.href, null, AccountLinkingPolicy, cbSpy);
+        // call with optional param
+        getResourceStub.should.have.been
+          .calledWith(app.accountLinkingPolicy.href, opts, AccountLinkingPolicy, cbSpy);
       });
     });
 

--- a/test/sp.resource.organization_test.js
+++ b/test/sp.resource.organization_test.js
@@ -4,6 +4,7 @@ var sinon = require('sinon');
 var assert = require('chai').assert;
 
 var Organization = require('../lib/resource/Organization');
+var AccountLinkingPolicy = require('../lib/resource/AccountLinkingPolicy');
 
 var sandbox = sinon.sandbox.create();
 
@@ -67,6 +68,9 @@ describe('resource/Organization.js', function () {
         },
         accountStoreMappings: {
           href: 'c1913f98-e4f7-424c-a259-f48c8359e327'
+        },
+        accountLinkingPolicy: {
+          href: '78675b49-93aa-48d2-aa03-18ebd9dba54f'
         }
       };
 
@@ -753,6 +757,33 @@ describe('resource/Organization.js', function () {
 
       it('should return the value from dataStore.getResource', function () {
         returnValue.should.equal(getResourceReturn);
+      });
+    });
+
+    describe('.getAccountLinkingPolicy(opts, callback)', function() {
+      var opts;
+
+      beforeEach(function() {
+        opts = {
+          expand: 'tenant'
+        };
+
+        organization.getAccountLinkingPolicy(callbackSpy);
+        organization.getAccountLinkingPolicy(opts, callbackSpy);
+        console.log('Called these two jokers');
+      });
+
+      it('should pass the callback, and the options if present, to dataStore.getResource', function() {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        callbackSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        getResourceStub.should.have.been
+          .calledWith(organization.accountLinkingPolicy.href, null, AccountLinkingPolicy, callbackSpy);
+
+        getResourceStub.should.have.been
+          .calledWith(organization.accountLinkingPolicy.href, opts, AccountLinkingPolicy, callbackSpy);
       });
     });
 

--- a/test/sp.resource.tenant_test.js
+++ b/test/sp.resource.tenant_test.js
@@ -4,6 +4,7 @@ var sinon = common.sinon;
 var uuid = require('node-uuid');
 
 var Account = require('../lib/resource/Account');
+var AccountLink = require('../lib/resource/AccountLink');
 var Tenant = require('../lib/resource/Tenant');
 var Application = require('../lib/resource/Application');
 var Directory = require('../lib/resource/Directory');
@@ -383,6 +384,66 @@ describe('Resources: ', function () {
 
         getResourceStub.should.have.been.calledWith('boom!', null, IdSiteModel, cbSpy);
         getResourceStub.should.have.been.calledWith('boom!', opts, IdSiteModel, cbSpy);
+      });
+    });
+
+    describe('create account link', function () {
+      var sandbox;
+      var tenant;
+      var createResourceStub;
+      var cbSpy;
+      var opts;
+      var createAccLinkPath;
+      var leftAccount;
+      var rightAccount;
+
+      before(function () {
+        createAccLinkPath = '/accountLinks';
+        sandbox = sinon.sandbox.create();
+        opts = {};
+        tenant = new Tenant({}, dataStore);
+        createResourceStub = sandbox.stub(dataStore, 'createResource',
+          function (href, options, ctor, app, cb) {
+            cb();
+          });
+        cbSpy = sandbox.spy();
+
+        leftAccount = {
+          href: 'leftBoom!'
+        };
+
+        rightAccount = {
+          href: 'rightBoom!'
+        };
+
+        tenant.createAccountLink(leftAccount, rightAccount, cbSpy);
+        tenant.createAccountLink(leftAccount, rightAccount, opts, cbSpy);
+      });
+      after(function () {
+        sandbox.restore();
+      });
+
+      it('should create application', function () {
+        /* jshint -W030 */
+        createResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        var expectedLink = {
+          leftAccount: {
+            href: 'leftBoom!'
+          },
+          rightAccount: {
+            href: 'rightBoom!'
+          }
+        };
+
+        // call without optional param
+        createResourceStub.should.have.been
+          .calledWith(createAccLinkPath, null, expectedLink, AccountLink, cbSpy);
+        // call with optional param
+        createResourceStub.should.have.been
+          .calledWith(createAccLinkPath, opts, expectedLink, AccountLink, cbSpy);
       });
     });
   });


### PR DESCRIPTION
Adds support for manual account linking by adding new a new `AccountLink` resource type, as well as new methods on the `Account` object. Includes documentation, unit and integration tests.

Example:

```javascript
var account, secondAccount;

function showLinkedAccounts(link) {
   link.getLeftAccount(function(err, leftAccount) {
      if (err) {
         throw err;
      }

      console.log(leftAccount);
      link.getRightAccount(function(err, rightAccount) {
        if (err) {
          throw err;
        }

        console.log(rightAccount);
      });
   });
};

account.createAccountLink(secondAccount, function(err, link) {
  if (err) {
    throw err;
  }

  console.log('Done linking accounts:', link);

  account.getAccountLinks(function(err, accountLink) {
     if (err) {
        throw err;
     }
     console.log(collection.items[0].href === link.href); // true

     account.getLinkedAccounts(function(err, accounts) {
       console.log(accounts.items[0].href === secondAccount.href); // true
       showLinkedAccounts(link);
     });
  });
});
```

Additionally, it adds support (and tests) for the `AccountLinkingPolicy` on `Application` and `Organization` resources. This policy manages automatic merging of accounts in the application/organization. Likewise adds tests and documentation.

Example:
```javascript
var application;

// Same principle with an Organization resource
application.getAccountLinkingPolicy(function(err, accLinkPolicy) {
  if (err) {
    throw err;  
  }

  console.log(accLinkPolicy);
  accLinkPolicy.getTenant(function(err, tenant) {
    if (err) {
      throw err;
    }

    console.log(tenant);
  });
});
```

Fixes #559 
Fixes #560 