### PR TITLE
Update resources regarding save() and delete()

### DIFF
--- a/lib/ds/DataStore.js
+++ b/lib/ds/DataStore.js
@@ -6,6 +6,7 @@ var _ = require('underscore');
 var ApiKey = require('../resource/ApiKey');
 var ApiKeyEncryptedOptions = require('../authc/ApiKeyEncryptedOptions');
 var CacheHandler = require('../cache/CacheHandler');
+var Resource = require('../resource/Resource');
 var InstanceResource = require('../resource/InstanceResource');
 var NonceStore = require('./NonceStore');
 var RequestExecutor = require('./RequestExecutor');
@@ -105,7 +106,7 @@ DataStore.prototype._wrapGetResourceResponse =
  * @param {Object} query [optional=undefined]
  * Key/value pairs to use as query parameters to `href`.
  *
- * @param {Function} instanceCtor [optional=InstanceResource]
+ * @param {Function} instanceCtor [optional=Resource]
  * The Constructor function to invoke for any Instance Resource returned by the server.
  * If the resource returned by the server is a single resource, this function is used to
  * construct the resource. If the resource returned by the server is a collection,
@@ -342,7 +343,7 @@ DataStore.prototype.exec = function executeRequest(callback){
  * @param {Object} data
  * The resource (name/value pairs) to send to the server.
  *
- * @param {Function} instanceCtor [optional=InstanceResource]
+ * @param {Function} instanceCtor [optional=Resource]
  * The Constructor function to invoke for any Instance Resource returned by the server.
  * If the resource returned by the server is a single resource, this function is used to
  * construct the resource. If the resource returned by the server is a collection,
@@ -365,8 +366,8 @@ DataStore.prototype.createResource = function createResource(/* parentHref, [que
   var query = (args.length > 0) ? args.pop() : null;
   callback = callback || noop;
 
-  if (!utils.isAssignableFrom(InstanceResource, ctor)) {
-    throw new Error("If specifying a constructor function, it must be for class equal to or a subclass of InstanceResource.");
+  if (!utils.isAssignableFrom(Resource, ctor)) {
+    throw new Error("If specifying a constructor function, it must be for class equal to or a subclass of Resource.");
   }
 
   var request = { uri: parentHref, method: 'POST' };

--- a/lib/resource/AccessToken.js
+++ b/lib/resource/AccessToken.js
@@ -1,9 +1,13 @@
 'use strict';
 
 var utils = require('../utils');
+var DeletableMixin = require('./mixins/DeletableMixin');
 
 /**
  * @class AccessToken
+ *
+ * @augments Resource
+ * @mixes DeletableMixin
  *
  * @description
  *
@@ -33,18 +37,22 @@ function AccessToken() {
   AccessToken.super_.apply(this, arguments);
 }
 
-// TODO: implement getAccount(), getRefreshToken()
+// TODO: implement getRefreshToken()
 
-utils.inherits(AccessToken, require('./InstanceResource'));
-
-module.exports = AccessToken;
+utils.inherits(AccessToken, require('./Resource'));
+utils.applyMixin(AccessToken, DeletableMixin);
 
 /**
- * Deletes this resource from the API.
- *
- * @method AccessToken.delete
- *
- * @param {Function} callback
- * The function to call when the delete operation is complete. Will be called
- * with the parameter (err).
- */
+* Gets and returns the account associated with this access token.
+*
+* @param {ExpansionOptions=} opts Options for expanding the fetched Account
+*
+* @param {Function} callback The function to call after the operation is finished.
+* It is called with (err, {@link Account}).
+*/
+AccessToken.prototype.getAccount = function getAccount(/* [opts,] callback */) {
+  var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
+  return this.dataStore.getResource(this.account.href, args.options, require('./Account'), args.callback);
+};
+
+module.exports = AccessToken;

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -30,6 +30,7 @@ var utils = require('../utils');
  * - {@link Organization#getAccounts Organization.getAccounts()}
  * - {@link Phone#getAccount Phone.getAccount()}
  * - {@link Factor#getAccount Factor.getAccount()}
+ * - {@link AccessToken#getAccount AccessToken.getAccount()}
  *
  * @augments {DirectoryChildResource}
  *

--- a/lib/resource/AccountCreationPolicy.js
+++ b/lib/resource/AccountCreationPolicy.js
@@ -1,8 +1,12 @@
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/SaveableMixin');
 var utils = require('../utils');
 
 /**
  * @class AccountCreationPolicy
+ *
+ * @augments Resource
+ * @mixes SaveableMixin
  *
  * @description
  * Encapsulates the account creation policy of a {@link Directory}. For full documentation of the this resource, please see
@@ -19,23 +23,11 @@ var utils = require('../utils');
  * The JSON representation of this resource, retrieved the Stormpath REST API.
  */
 
-/**
- * @method AccountCreationPolicy.save
- *
- * @description
- *
- * Save changes to this resource.
- *
- * @param {Function} callback
- * The function to call when the save operation is complete. Will be called
- * with the parameters (err, updatedResource).
- */
-
-
 function AccountCreationPolicy() {
   AccountCreationPolicy.super_.apply(this, arguments);
 }
 
-utils.inherits(AccountCreationPolicy, InstanceResource);
+utils.inherits(AccountCreationPolicy, Resource);
+utils.applyMixin(AccountCreationPolicy, SaveableMixin);
 
 module.exports = AccountCreationPolicy;

--- a/lib/resource/AccountStoreMapping.js
+++ b/lib/resource/AccountStoreMapping.js
@@ -6,6 +6,8 @@ var InstanceResource = require('./InstanceResource');
 /**
  * @class AccountStoreMapping
  *
+ * @augments InstanceResource
+ *
  * @description
  *
  * Encapsulates an Account Store Mapping Resource, and is a base class for

--- a/lib/resource/AuthenticationResult.js
+++ b/lib/resource/AuthenticationResult.js
@@ -2,7 +2,7 @@
 
 var nJwt = require('njwt');
 
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
 var utils = require('../utils');
 
 /**
@@ -27,7 +27,7 @@ function AuthenticationResult() {
   Object.defineProperty(this, 'ttl', { enumerable:false, writable:true, value: 3600 });
 }
 
-utils.inherits(AuthenticationResult, InstanceResource);
+utils.inherits(AuthenticationResult, Resource);
 
 /**
  * Retrieves the account resource of the user that has been authenticated.

--- a/lib/resource/Challenge.js
+++ b/lib/resource/Challenge.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/SaveableMixin');
 var FactorCtor = require('./FactorInstantiator').Constructor;
 var utils = require('../utils');
 
@@ -20,7 +21,7 @@ var utils = require('../utils');
  * - {@link SmsFactor#createChallenge SmsFactor.createChallenge()}
  * - {@link GoogleAuthenticatorFactor#createChallenge GoogleAuthenticatorFactor.createChallenge()}
  *
- * @augments {InstanceResource}
+ * @augments {Resource}
  *
  * @param {Object} challengeResource
  *
@@ -30,7 +31,8 @@ function Challenge() {
   Challenge.super_.apply(this, arguments);
 }
 
-utils.inherits(Challenge, InstanceResource);
+utils.inherits(Challenge, Resource);
+utils.applyMixin(Challenge, SaveableMixin);
 
 /**
  * Retrieves the factor instance ({@link SmsFactor} or {@link GoogleAuthenticatorFactor})

--- a/lib/resource/CustomData.js
+++ b/lib/resource/CustomData.js
@@ -115,6 +115,8 @@ CustomData.prototype.remove = function removeCustomDataField(fieldName){
 /**
  * Save changes to this custom data resource.
  *
+ * @override
+ *
  * @param {Function} callback
  * The function to call when the save operation is complete. Will be called
  * with the parameters (err, updatedCustomDataResource).

--- a/lib/resource/FactorInstantiator.js
+++ b/lib/resource/FactorInstantiator.js
@@ -4,7 +4,7 @@ var utils = require('../utils');
 var Factor = require('./Factor');
 var SmsFactor = require('./SmsFactor');
 var GoogleAuthenticatorFactor = require('./GoogleAuthenticatorFactor');
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
 
 /**
 * Retrieves the constructor for a correct {@link Factor} instance ({@link SmsFactor} or
@@ -45,10 +45,10 @@ function getFactorConstructor(/* factor */) {
 * The constructor for {@link Factor} instances ({@link SmsFactor} or
 * {@link GoogleAuthenticatorFactor}). It parses the data to construct the
 * correct constructor, and calls it with the data. It is used for polymorphic
-* factor instantiation. It augments {@link InstanceResource} to adhere to the
+* factor instantiation. It augments {@link Resource} to adhere to the
 * interface used for instantiation in {@link ResourceFactory}.
 *
-* @augments InstanceResource
+* @augments Resource
 */
 function FactorInstantiator() {
   var Ctor = getFactorConstructor.apply(this, arguments);
@@ -62,7 +62,7 @@ function FactorInstantiator() {
   return new (Ctor.bind.apply(Ctor, argsWithContext))();
 }
 
-utils.inherits(FactorInstantiator, InstanceResource);
+utils.inherits(FactorInstantiator, Resource);
 
 module.exports = {
   Constructor: FactorInstantiator,

--- a/lib/resource/Field.js
+++ b/lib/resource/Field.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/SaveableMixin');
 var utils = require('../utils');
 
 /**
  * @class Field
+ *
+ * @augments Resource
+ * @mixes SaveableMixin
  *
  * @description
  * Encapsulates an account field, as part of a {@link Schema}.
@@ -18,16 +22,6 @@ function Field(){
 }
 
 utils.inherits(Field, Resource);
-
-/**
- * Save changes to this resource.
- *
- * @param {Function} callback
- * The function to call when the save operation is complete. Will be called
- * with the parameters (err, updatedResource).
- */
-Field.prototype.save = function save(callback) {
-  this.dataStore.saveResource(this, callback);
-};
+utils.applyMixin(Field, SaveableMixin);
 
 module.exports = Field;

--- a/lib/resource/InstanceResource.js
+++ b/lib/resource/InstanceResource.js
@@ -4,12 +4,16 @@ var async = require('async');
 
 var Resource = require('./Resource');
 var SaveableMixin = require('./mixins/SaveableMixin');
+var DeletableMixin = require('./mixins/DeletableMixin');
 var utils = require('../utils');
 
 /**
  * @class InstanceResource
  *
  * Low-level resource wrapper for Stormpath resource objects.
+ *
+ * @mixes SaveableMixin
+ * @mixes DeletableMixin
  */
 function InstanceResource() {
   InstanceResource.super_.apply(this, arguments);
@@ -17,6 +21,7 @@ function InstanceResource() {
 
 utils.inherits(InstanceResource, Resource);
 utils.applyMixin(InstanceResource, SaveableMixin);
+utils.applyMixin(InstanceResource, DeletableMixin);
 
 /**
  * @private
@@ -75,17 +80,6 @@ InstanceResource.prototype.get = function getResource() {
   }
 
   this.dataStore.getResource(val.href, query, ctor, callback);
-};
-
-/**
- * Deletes this resource from the API.
- *
- * @param {Function} callback
- * The function to call when the delete operation is complete. Will be called
- * with the parameter (err).
- */
-InstanceResource.prototype.delete = function deleteResource(callback) {
-  this.dataStore.deleteResource(this, callback);
 };
 
 /**

--- a/lib/resource/OAuthPolicy.js
+++ b/lib/resource/OAuthPolicy.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var utils = require('../utils');
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/SaveableMixin');
 
 /**
  * @class OAuthPolicy
+ *
+ * @augments Resource
+ * @mixes SaveableMixin
  *
  * @description
  *
@@ -29,19 +33,7 @@ function OAuthPolicy() {
   OAuthPolicy.super_.apply(this, arguments);
 }
 
-utils.inherits(OAuthPolicy, InstanceResource);
+utils.inherits(OAuthPolicy, Resource);
+utils.applyMixin(OAuthPolicy, SaveableMixin);
 
 module.exports = OAuthPolicy;
-
-
-/**
- * @method OAuthPolicy.save
- *
- * @description
- *
- * Save changes to this resource.
- *
- * @param {Function} callback
- * The function to call when the save operation is complete. Will be called
- * with the parameters (err, updatedResource).
- */

--- a/lib/resource/PasswordResetToken.js
+++ b/lib/resource/PasswordResetToken.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/SaveableMixin');
 var utils = require('../utils');
 
 /**
@@ -27,7 +28,9 @@ var utils = require('../utils');
 function PasswordResetToken() {
   PasswordResetToken.super_.apply(this, arguments);
 }
-utils.inherits(PasswordResetToken, InstanceResource);
+
+utils.inherits(PasswordResetToken, Resource);
+utils.applyMixin(PasswordResetToken, SaveableMixin);
 
 module.exports = PasswordResetToken;
 

--- a/lib/resource/ProviderData.js
+++ b/lib/resource/ProviderData.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/SaveableMixin');
 var utils = require('../utils');
 
 /**
@@ -13,7 +14,7 @@ var utils = require('../utils');
  * This class should not be manually constructed. It should be obtained from one of these methods:
  * - {@link Account#getProviderData Account.getProviderData()}.
  *
- * @augments {InstanceResource}
+ * @augments {Resource}
  *
  * @param {Object} providerDataResource
  * The JSON representation of this resource, retrieved the Stormpath REST API.
@@ -22,6 +23,7 @@ function ProviderData() {
   ProviderData.super_.apply(this, arguments);
 }
 
-utils.inherits(ProviderData, InstanceResource);
+utils.inherits(ProviderData, Resource);
+utils.applyMixin(ProviderData, SaveableMixin);
 
 module.exports = ProviderData;

--- a/lib/resource/RefreshToken.js
+++ b/lib/resource/RefreshToken.js
@@ -1,9 +1,13 @@
 'use strict';
 
 var utils = require('../utils');
+var DeletableMixin = require('./mixins/DeletableMixin');
 
 /**
  * @class RefreshToken
+ *
+ * @augments Resource
+ * @mixes DeletableMixin
  *
  * @description
  *
@@ -30,7 +34,8 @@ function RefreshToken() {
   RefreshToken.super_.apply(this, arguments);
 }
 
-utils.inherits(RefreshToken, require('./InstanceResource'));
+utils.inherits(RefreshToken, require('./Resource'));
+utils.applyMixin(RefreshToken, DeletableMixin);
 
 module.exports = RefreshToken;
 
@@ -43,4 +48,3 @@ module.exports = RefreshToken;
  * The function to call when the delete operation is complete. Will be called
  * with the parameter (err).
  */
-

--- a/lib/resource/Resource.js
+++ b/lib/resource/Resource.js
@@ -2,6 +2,20 @@
 
 var utils = require('../utils');
 
+/**
+* @class
+*
+* @description
+* A bare-bones base representation of a resource in the Node Stormpath SDK.
+* All resource instances must be based on this class (or a class that augments
+* it).
+*
+* @param {Object=} data
+* JavaScript object representing the resource's raw data
+*
+* @param {DataStore} dataStore
+* The application's {@link DataStore}
+*/
 function Resource(data, dataStore) {
   // require moved here intentionally because of
   // issue related to

--- a/lib/resource/ResourceFactory.js
+++ b/lib/resource/ResourceFactory.js
@@ -3,7 +3,7 @@
 /* jshint -W003 */
 var CollectionResource = require('./CollectionResource');
 var CustomData = require('./CustomData');
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
 var utils = require('../utils');
 
 var fs = require('fs');
@@ -78,7 +78,7 @@ function expandResource(expandedFields, resource, query, dataStore) {
  * @returns a new Resource memory instance
  */
 function instantiate(InstanceConstructor, data, query, dataStore) {
-  var Ctor = utils.valueOf(InstanceConstructor, InstanceResource);
+  var Ctor = utils.valueOf(InstanceConstructor, Resource);
 
   if (utils.isAssignableFrom(CollectionResource, Ctor)) {
     throw new Error('InstanceConstructor argument cannot be a CollectionResource.');

--- a/lib/resource/SamlAttributeStatementMappingRules.js
+++ b/lib/resource/SamlAttributeStatementMappingRules.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var utils = require('../utils');
-var InstanceResource = require('./InstanceResource');
+var Resource = require('./Resource');
+var SaveableMixin = require('./mixins/Saveable');
 
 /**
  * @class SamlAttributeStatementMappingRules
+ *
+ * @augments Resource
+ * @mixes SaveableMixin
  *
  * @description
  *
@@ -32,18 +36,7 @@ function SamlAttributeStatementMappingRules() {
   SamlAttributeStatementMappingRules.super_.apply(this, arguments);
 }
 
-utils.inherits(SamlAttributeStatementMappingRules, InstanceResource);
+utils.inherits(SamlAttributeStatementMappingRules, Resource);
+utils.applyMixin(SamlAttributeStatementMappingRules, SaveableMixin);
 
 module.exports = SamlAttributeStatementMappingRules;
-
-/**
- * @method SamlAttributeStatementMappingRules.save
- *
- * @description
- *
- * Save changes to this resource.
- *
- * @param {Function} callback
- * The function to call when the save operation is complete. Will be called
- * with the parameters (err, updatedResource).
- */

--- a/lib/resource/mixins/DeletableMixin.js
+++ b/lib/resource/mixins/DeletableMixin.js
@@ -1,0 +1,22 @@
+function deleteResource(callback) {
+  this.dataStore.deleteResource(this, callback);
+}
+
+/**
+* Provides methods used for deleting resources. It is not meant to be used
+* directly, and should instead be applied to resource classes.
+*
+* @mixin
+*/
+var DeletableMixin = {
+  /**
+   * Deletes a resource from the API.
+   *
+   * @param {Function} callback
+   * The function to call when the delete operation is complete. Will be called
+   * with the parameter (err).
+   */
+  delete: deleteResource
+};
+
+module.exports = DeletableMixin;

--- a/lib/resource/mixins/SaveableMixin.js
+++ b/lib/resource/mixins/SaveableMixin.js
@@ -14,13 +14,7 @@ function applyCustomDataUpdatesIfNecessary(cb){
   return cb();
 }
 
-/**
- * Save changes to this resource.
- *
- * @param {Function} callback
- * The function to call when the save operation is complete. Will be called
- * with the parameters (err, updatedResource).
- */
+
 function saveResource(callback) {
   var self = this;
   self._applyCustomDataUpdatesIfNecessary(function () {
@@ -28,8 +22,21 @@ function saveResource(callback) {
   });
 }
 
+/**
+* Provides methods used for saving resources. It is not meant to be used
+* directly, and should instead be applied to resource classes.
+*
+* @mixin
+*/
 var SaveableMixin = {
   _applyCustomDataUpdatesIfNecessary: applyCustomDataUpdatesIfNecessary,
+  /**
+   * Save changes to this resource.
+   *
+   * @param {Function} callback
+   * The function to call when the save operation is complete. Will be called
+   * with the parameters (err, updatedResource).
+   */
   save: saveResource
 };
 

--- a/test/sp.ds.datastore_test.js
+++ b/test/sp.ds.datastore_test.js
@@ -346,7 +346,7 @@ describe('ds:', function () {
 
         it('should throw error', function () {
           callToCreateResourceWithInvalidResouceCtor
-            .should.throw(/constructor function.*InstanceResource/i);
+            .should.throw(/constructor function.*Resource/i);
         });
       });
 

--- a/test/sp.resource.accessToken_test.js
+++ b/test/sp.resource.accessToken_test.js
@@ -1,0 +1,83 @@
+/* jshint -W030 */
+var common = require('./common');
+var sinon = common.sinon;
+var assert = common.assert;
+var DataStore = require('../lib/ds/DataStore');
+var AccessToken = require('../lib/resource/AccessToken');
+var Account = require('../lib/resource/Account');
+
+describe('Resources: ', function() {
+  var dataStore;
+
+  before(function() {
+    dataStore = new DataStore({
+      client: {
+        apiKey: {
+          id: 1,
+          secret: '6b2c3912-4779-49c1-81e7-23c204f43d2d'
+        }
+      }
+    });
+  });
+
+  describe('AccessToken resource', function() {
+    describe('structure and inheritance', function() {
+      it('should inherit from Resource', function() {
+        assert.ok(AccessToken.super_);
+        assert.equal(AccessToken.super_.name, 'Resource');
+      });
+
+      it('should have a defined delete method', function() {
+        var accessToken = new AccessToken({}, dataStore);
+
+        assert.ok(accessToken.delete);
+        assert.isFunction(accessToken.delete);
+      });
+    });
+
+    describe('.getAccount()', function() {
+      var sandbox;
+      var getResourceStub;
+      var cbSpy;
+      var opts;
+      var data;
+      var accessToken;
+
+      before(function() {
+        sandbox = sinon.sandbox.create();
+        getResourceStub = sinon.stub(dataStore, 'getResource', function(href, opts, ctor, cb) {
+          return cb();
+        });
+
+        cbSpy = sinon.spy();
+
+        opts = {q: 'boomExpand!'};
+
+        data = {
+          account: {
+            href: 'boom!'
+          }
+        };
+
+        accessToken = new AccessToken(data, dataStore);
+
+        accessToken.getAccount(cbSpy);
+        accessToken.getAccount(opts, cbSpy);
+      });
+
+      after(function() {
+        sandbox.restore();
+      });
+
+      it('should get the account', function() {
+        /* jshint -W030 */
+        getResourceStub.should.have.been.calledTwice;
+        cbSpy.should.have.been.calledTwice;
+        /* jshint +W030 */
+
+        getResourceStub.should.have.been.calledWith('boom!', null, Account, cbSpy);
+        getResourceStub.should.have.been.calledWith('boom!', opts, Account, cbSpy);
+      });
+    });
+  });
+});

--- a/test/sp.resource.factorInstantiator_test.js
+++ b/test/sp.resource.factorInstantiator_test.js
@@ -4,7 +4,7 @@ var common = require('./common');
 var assert = common.assert;
 var sinon = common.sinon;
 
-var InstanceResource = require('../lib/resource/InstanceResource');
+var Resource = require('../lib/resource/Resource');
 var FactorInstantiator = require('../lib/resource/FactorInstantiator');
 var FactorConstructor = FactorInstantiator.Constructor;
 var Factor = require('../lib/resource/Factor');
@@ -22,8 +22,8 @@ describe('FactorInstantiator#Constructor', function() {
     sandbox.restore();
   });
 
-  it('should inherit from InstanceResource', function() {
-    assert.equal(FactorConstructor.super_, InstanceResource);
+  it('should inherit from Resource', function() {
+    assert.equal(FactorConstructor.super_, Resource);
   });
 
   it('should construct an SmsFactor if type is SMS', function() {


### PR DESCRIPTION
Finishes extraction of `.save()` and `.delete()` resource actions into mixins. Provides JSDoc documentation regarding these and their use. Applies them both to the `InstanceResource`,
while some other resources were made to inherit `Resource` and apply only one of these mixins
(or even neither).

This is only the initial pass, one more comparison with the API and the API docs is neccessary.

Fixes #539 