### PR TITLE
Update collection methods

### DIFF
--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -1225,10 +1225,16 @@ Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(s
       return callback(err);
     }
 
-    res.detectSeries(function(asm, cb){cb(asm.accountStore.href === store.href);}, onAsmFound);
+    res.detectSeries(function(asm, cb){
+      cb(null, asm.accountStore.href === store.href);
+    }, onAsmFound);
   });
 
-  function onAsmFound(asm) {
+  function onAsmFound(err, asm) {
+    if (err) {
+      throw err;
+    }
+
     if (asm) {
       asm.isDefaultAccountStore = true;
       return asm.save(clearCache);
@@ -1337,10 +1343,14 @@ Application.prototype.setDefaultGroupStore = function setDefaultGroupStore(store
     if (err) {
       return callback(err);
     }
-    res.detectSeries(function(asm, cb){cb(asm.accountStore.href === store.href);}, onAsmFound);
+    res.detectSeries(function(asm, cb){cb(null, asm.accountStore.href === store.href);}, onAsmFound);
   });
 
-  function onAsmFound(asm) {
+  function onAsmFound(err, asm) {
+    if (err) {
+      throw err;
+    }
+
     if (asm) {
       asm.isDefaultGroupStore = true;
       return asm.save(updateApp);

--- a/lib/resource/CollectionResource.js
+++ b/lib/resource/CollectionResource.js
@@ -1001,8 +1001,8 @@ utils.inherits(CollectionResource, Resource);
     };
 
     this.wrapCallback = function(callback ){
-      return function(err, result){
-        callback(err, result);
+      return function(err){
+        callback(err, res);
       };
     };
   }
@@ -1020,8 +1020,8 @@ utils.inherits(CollectionResource, Resource);
     };
 
     this.wrapCallback = function(callback ){
-      return function(err, result){
-        callback(err, result);
+      return function(err){
+        callback(err, res);
       };
     };
   }
@@ -1040,8 +1040,8 @@ utils.inherits(CollectionResource, Resource);
     };
 
     this.wrapCallback = function(callback ){
-      return function(err, result){
-        callback(err, result);
+      return function(err){
+        callback(err, res);
       };
     };
   }

--- a/lib/resource/CollectionResource.js
+++ b/lib/resource/CollectionResource.js
@@ -114,6 +114,7 @@ function wrapAsyncCallToAllPages(coll, func, args, callbackWrapper){
             [task.collection.items],
             !!callbackWrapper.wrapPageArgs ? callbackWrapper.wrapPageArgs(args) : args,
             callbackWrapper.wrapPageCallback(parallel_cb.bind(this, null)));
+
         func.apply(this, callArgs);
       },
       function(parallel_cb){
@@ -125,7 +126,6 @@ function wrapAsyncCallToAllPages(coll, func, args, callbackWrapper){
           if (err || !nextPage){
             return parallel_cb(err);
           }
-
           q.push({collection: nextPage});
           parallel_cb();
         });
@@ -993,16 +993,16 @@ utils.inherits(CollectionResource, Resource);
     this.isDone = false;
 
     this.wrapPageCallback = function wrapPageCallback(cb){
-      return function funcCallback(result){
-        that.isDone = !result;
+      return function funcCallback(err, result){
+        that.isDone = err || !result;
         res = res && result;
-        cb(result);
+        cb(err, result);
       };
     };
 
     this.wrapCallback = function(callback ){
-      return function(){
-        callback(res);
+      return function(err, result){
+        callback(err, result);
       };
     };
   }
@@ -1012,16 +1012,16 @@ utils.inherits(CollectionResource, Resource);
     this.isDone = false;
     var that = this;
     this.wrapPageCallback = function wrapPageCallback(cb){
-      return function funcCallback(result){
+      return function funcCallback(err, result){
         that.isDone = !!result;
         res = res || result;
-        cb(result);
+        cb(err, result);
       };
     };
 
     this.wrapCallback = function(callback ){
-      return function(){
-        callback(res);
+      return function(err, result){
+        callback(err, result);
       };
     };
   }
@@ -1032,16 +1032,16 @@ utils.inherits(CollectionResource, Resource);
     this.isDone = false;
 
     this.wrapPageCallback = function wrapPageCallback(cb){
-      return function funcCallback(result){
+      return function funcCallback(err, result){
         that.isDone = !!result;
         res = res || result;
-        cb(res);
+        cb(err, res);
       };
     };
 
     this.wrapCallback = function(callback ){
-      return function(){
-        callback(res);
+      return function(err, result){
+        callback(err, result);
       };
     };
   }
@@ -1137,16 +1137,15 @@ utils.inherits(CollectionResource, Resource);
     };
   }
 
-  var W1 = function(){ return new CallbackWrapper(1);};
   var W2 = function(){ return new CallbackWrapper(2);};
 
   var methods = {
     each: {wrapper: W2}, eachSeries: {wrapper: W2}, eachLimit: {wrapper: W2},
     forEach: {wrapper: W2}, forEachSeries: {wrapper: W2}, forEachLimit: {wrapper: W2},
     map: {wrapper: W2}, mapSeries: {wrapper: W2}, mapLimit:{wrapper: W2},
-    filter: {wrapper: W1}, filterSeries: {wrapper: W1},
-    select: {wrapper: W1}, selectSeries: {wrapper: W1},
-    reject: {wrapper: W1}, rejectSeries: {wrapper: W1},
+    filter: {wrapper: W2}, filterSeries: {wrapper: W2},
+    select: {wrapper: W2}, selectSeries: {wrapper: W2},
+    reject: {wrapper: W2}, rejectSeries: {wrapper: W2},
     reduce: {wrapper: Reduce}, inject: {wrapper: Reduce}, foldl: {wrapper: Reduce},
     reduceRight: {wrapper: ReduceRight, method: 'eachSeries'},
     foldr: {wrapper: ReduceRight, method: 'eachSeries'},

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test": "grunt"
   },
   "dependencies": {
-    "async": "~1.5.2",
+    "async": "^2.1.2",
     "deep-extend": "^0.4.1",
     "jwt-simple": "~0.4.0",
     "memcached": "~2.2.2",

--- a/test/it/application_it.js
+++ b/test/it/application_it.js
@@ -156,27 +156,28 @@ describe('Application',function(){
   describe('setDefaultAccountStore',function () {
 
     describe('with a href string property',function(){
-      var result;
+      var error;
+
       before(function(done){
         app.setDefaultAccountStore(directory.href,function(err){
-          result = err;
+          error = err;
           done();
         });
       });
       it('should not err',function(){
-        assert.equal(result,null);
+        assert.notOk(error);
       });
     });
     describe('with a directory object',function(){
-      var result;
+      var error;
       before(function(done){
         app.setDefaultAccountStore(directory,function(err){
-          result = err;
+          error = err;
           done();
         });
       });
       it('should not err',function(){
-        assert.equal(result,null);
+        assert.notOk(error);
       });
     });
   });


### PR DESCRIPTION
Update the `async` library to `2.1.x` and update the code and tests to reflect this.

The most important changes are that some methods that previously took `next` functions and `callback`s that only had an arity of one now have an arity of 2. For example, `filter` can now be called as:

```javascript
collection.filter(function(item, next) {
  if (item.id < 0) {
     return next(err);
  }

  next(null, item.id % 2 === 0);
}, function(err, filtered) {
  if (!err) {
    console.log('Filtered:', filtered);
  }
});
```

The following methods (method aliases given in brackets) are affected:

- `filter` (`select`)
- `reject`
- `detect`
- `some` (`any`)
- `every` (`all`)

Fixes #569 

Makes these PRs redundant:
- #499
- #505 