### PR TITLE
Scope factories on OAuthAuthenticator

### DIFF
--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -34,10 +34,48 @@ function OAuthAuthenticator(application) {
   this.application = application;
 }
 
+/**
+* @function
+*
+* @description
+*
+* Sets a scope factory to be used in the authentication flow, provided the grant
+* type supports scopes and scope factories. The scope factory is a
+* developer-provided function that allows you to add custom scope to the tokens
+* that Stormpath creates.
+*
+* @param {Function} scopeFactory
+* The scope factory to use when processing authentication results. When it is defined,
+* it will be invoked with the authentication result.  You should determine which scope
+* to grant, and provide it to the callback.
+*
+* The function must have the signature `(authenticationResult, requestedScope, callback)`.
+*
+* See
+* {@link ScopeFactoryAuthenticator#setScopeFactory ScopeFactoryAuthenticator.setScopeFactory}
+* for more details.
+*/
 OAuthAuthenticator.prototype.setScopeFactory = function setScopeFactory(scopeFactory) {
   this.scopeFactory = scopeFactory;
 };
 
+/**
+* @function
+*
+* @description
+*
+* Sets the signing key used by the scope factory to sign new access tokens.
+* Only used in the scope factory flow. See
+* {@link ScopeFactoryAuthenticator#setScopeFactorySigningKey ScopeFactoryAuthenticator.setScopeFactorySigningKey}.
+*
+* @param {String} signingKey
+* Signing key used to pack and unpack JWTs. It is <b>required</b> if the scope
+* factory is set. If the factory is invoked without a signing key, an error will
+* be passed to the callback.
+*
+* This must be the same Tenant API Key Secret that you used to create the {@link Client}
+* that was used to initiate the authentication attempt.
+*/
 OAuthAuthenticator.prototype.setScopeFactorySigningKey = function setScopeFactorySigningKey(key) {
   this.signingKey = key;
 };
@@ -87,14 +125,6 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
   }
 
   if (this.scopeFactory && (authenticator instanceof ScopeFactoryAuthenticator)) {
-    if (!this.signingKey) {
-      callback(new ApiAuthRequestError({
-        userMessage: 'Invalid Request',
-        developerMessage: 'Scope factory cannot be used without a signing key',
-        statusCode: 400
-      }));
-    }
-
     authenticator.setScopeFactory(this.scopeFactory);
     authenticator.setScopeFactorySigningKey(this.signingKey);
   }

--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -33,6 +33,14 @@ function OAuthAuthenticator(application) {
   this.application = application;
 }
 
+OAuthAuthenticator.prototype.setScopeFactory = function setScopeFactory(scopeFactory) {
+  this.scopeFactory = scopeFactory;
+};
+
+OAuthAuthenticator.prototype.setScopeFactorySigningKey = function setScopeFactorySigningKey(key) {
+  this.signingKey = key;
+};
+
 OAuthAuthenticator.prototype.localValidation = false;
 
 OAuthAuthenticator.prototype.withLocalValidation = function withLocalValidation() {
@@ -75,6 +83,19 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
       case 'stormpath_social':
         authenticator = new OAuthStormpathSocialAuthenticator(this.application);
     }
+  }
+
+  if (this.scopeFactory) {
+    if (!this.signingKey) {
+      callback(new ApiAuthRequestError({
+        userMessage: 'Invalid Request',
+        developerMessage: 'Scope factory cannot be used without a signing key',
+        statusCode: 400
+      }));
+    }
+
+    authenticator.setScopeFactory(this.scopeFactory);
+    authenticator.setScopeFactorySigningKey(this.signingKey);
   }
 
   if (authenticator) {

--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -85,7 +85,7 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
     }
   }
 
-  if (this.scopeFactory) {
+  if (this.scopeFactory && typeof authenticator.setScopeFactory === 'function') {
     if (!this.signingKey) {
       callback(new ApiAuthRequestError({
         userMessage: 'Invalid Request',

--- a/lib/oauth/authenticator.js
+++ b/lib/oauth/authenticator.js
@@ -2,6 +2,7 @@
 
 var ApiAuthRequestError = require('../error/ApiAuthRequestError');
 var JwtAuthenticator = require('../jwt/jwt-authenticator');
+var ScopeFactoryAuthenticator = require('../oauth/scope-factory-authenticator');
 var OAuthPasswordGrantRequestAuthenticator = require('../oauth/password-grant').authenticator;
 var OAuthRefreshTokenGrantRequestAuthenticator = require('../oauth/refresh-grant').authenticator;
 var OAuthIdSiteTokenGrantAuthenticator = require('../oauth/id-site-grant').authenticator;
@@ -85,7 +86,7 @@ OAuthAuthenticator.prototype.authenticate = function authenticate(req, callback)
     }
   }
 
-  if (this.scopeFactory && typeof authenticator.setScopeFactory === 'function') {
+  if (this.scopeFactory && (authenticator instanceof ScopeFactoryAuthenticator)) {
     if (!this.signingKey) {
       callback(new ApiAuthRequestError({
         userMessage: 'Invalid Request',


### PR DESCRIPTION
Adds support for setting the scope factory flow properties *directly* on `OAuthAuthenticator` instances. The set properties will automatically be passed onto the specific authenticator instance, if it supports scope factories.

This simplifies the scope factory flow in the Express SDK (without requiring additional hacks).

Example (modified from real-world Express SDK use case):
```javascript
var nJwt = require('njwt');
var req; // Request with client_credentials grant type and 'admin' scope
var authenticator = new stormpath.OAuthAuthenticator(application);

if (config.web.scopeFactory) {
  // Scope factory just returns the requisite scope and appends 'x2' to it
  authenticator.setScopeFactory(config.web.scopeFactory);
  authenticator.setScopeFactorySigningKey(config.client.apiKey.secret);
}

authenticator.authenticate(req, function (err, authResult) {
  if (err) {
     throw err;
  }

  nJwt.verify(authResult.access_token, config.client.apiKey.secret, function (err, token) {
    if (err) {
      throw err;
    }

    console.log(token.body.scope === 'adminx2'); // true
  });
});
```