### PR TITLE
Simplify test to avoid Jwt Expired

### DIFF
--- a/test/it/oauth_authenticator_it.js
+++ b/test/it/oauth_authenticator_it.js
@@ -212,25 +212,12 @@ describe('OAuthAuthenticator',function(){
   });
 
   it('should reject expired tokens',function(done){
-    new stormpath.OAuthPasswordGrantRequestAuthenticator(application2)
-      .authenticate({
-        username: newAccount.username,
-        password: newAccount.password
-      },function(err,passwordGrantResponse){
-        if(err){
-          done(err);
-        }else{
-          setTimeout(function(){
-            new stormpath.OAuthAuthenticator(application2)
-              .authenticate({
-                headers: {
-                  authorization: 'Bearer ' + passwordGrantResponse.accessToken.toString()
-                }
-              },assertUnauthenticatedResponse(done));
-          },5000);
-        }
-      });
-
+    var authenticator = stormpath.OAuthAuthenticator(application);
+    authenticator.authenticate({
+      headers: {
+        Authorization: 'Bearer ' + expiredToken
+      }
+    }, assertUnauthenticatedResponse(done));
   });
 
   describe('with local authentication',function(){


### PR DESCRIPTION
Simplified the existing test as to avoid the persistent `Jwt Expired` error we keep getting when running the tests (even though everything is fine). 

After some testing, this looks like it fixes the issue, and this now matches the local authorisation tests that verify the same thing.