### PR TITLE
Document creating social directory

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -682,9 +682,10 @@ Client.prototype.getDirectories = function() {
  * creating a directory, you will likely want to map it to an {@link Application} using
  * {@link Application#createAccountStoreMapping Application.createAccountStoreMapping()}.
  *
- * Directories can be linked to social providers, such as Facebook, Google or Twitter,
- * by specifing a valid provider containing the valid `providerId` and client credentials
- * when creating or modifying the directory. See {@link Provider}.
+ * Directories can be linked to social providers - such as Facebook, Google, Twitter, or
+ * even any other generic OAuth 2.0 provider - by specifing a valid provider containing
+ * the valid `providerId` and client credentials when creating or modifying the directory.
+ * See {@link Provider}.
  *
  * @param {Object} directory
  * The {@link Directory} resource to create.

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -682,6 +682,10 @@ Client.prototype.getDirectories = function() {
  * creating a directory, you will likely want to map it to an {@link Application} using
  * {@link Application#createAccountStoreMapping Application.createAccountStoreMapping()}.
  *
+ * Directories can be linked to social providers, such as Facebook, Google or Twitter,
+ * by specifing a valid provider containing the valid `providerId` and client credentials
+ * when creating or modifying the directory. See {@link Provider}.
+ *
  * @param {Object} directory
  * The {@link Directory} resource to create.
  *
@@ -692,11 +696,26 @@ Client.prototype.getDirectories = function() {
  * Callback function, will be called with (err, {@link Directory}).
  *
  * @example
+ * // Creating a simple directory
  * var newDirectory = {
  *   name: 'Customers'
  * }
  *
  * client.createDirectory(newDirectory, function (err, directory) {
+ *   console.log(directory);
+ * });
+ *
+ * // Creating a social provider directory (e.g. Twitter)
+ * var twitterDirectory = {
+ *   name: 'Twitter Users',
+ *   provider: {
+ *     providerId: 'twitter',
+ *     clientId: 'my-twitter-client-id',
+ *     clientSecret: 'my-twitter-client-secret'
+ *   }
+ * };
+ *
+ * client.createDirectory(twitterDirectory, function (err, directory) {
  *   console.log(directory);
  * });
  */


### PR DESCRIPTION
Document creating a social directory via `Client.createDirectory`, using Twitter as an example.
A real-world example, tested manually, verified via dev console (`api.stormpath`).

Fixes #577 