### PR TITLE
Fix/crypto deprecation

### DIFF
--- a/lib/resource/ApiKey.js
+++ b/lib/resource/ApiKey.js
@@ -47,7 +47,9 @@ ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {
   var encryptedSecret = new Buffer(this.secret,'base64');
   var iv = encryptedSecret.slice(0,16);
   var rawEncryptedValue = encryptedSecret.slice(16);
-  crypto.pbkdf2(password,new Buffer(salt,'base64'),iterations,(keyLengthBits/8), 'sha1',function(err,key){
+  var saltBuf = new Buffer(salt,'base64');
+  var keyLength = keyLengthBits / 8;
+  var cryptoCallback = function(err, key){
     if(err){
       return callback(err);
     }
@@ -61,7 +63,14 @@ ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {
       return callback(e);
     }
     callback(null,decrypted);
-  });
+  };
+
+  try {
+    crypto.pbkdf2(password,saltBuf,iterations,keyLength,'sha1',cryptoCallback);
+  } catch (e) {
+    // Node 0.10.0 support - It does not take the digest parameter, and throws
+    crypto.pbkdf2(password,saltBuf,iterations,keyLength,cryptoCallback);
+  }
 };
 
 ApiKey.prototype._setApiKeyMetaData = function _setApiKeyMetaData(obj){

--- a/lib/resource/ApiKey.js
+++ b/lib/resource/ApiKey.js
@@ -47,7 +47,7 @@ ApiKey.prototype._getDecryptedSecret = function _getDecryptedSecret(callback) {
   var encryptedSecret = new Buffer(this.secret,'base64');
   var iv = encryptedSecret.slice(0,16);
   var rawEncryptedValue = encryptedSecret.slice(16);
-  crypto.pbkdf2(password,new Buffer(salt,'base64'),iterations,(keyLengthBits/8),function(err,key){
+  crypto.pbkdf2(password,new Buffer(salt,'base64'),iterations,(keyLengthBits/8), 'sha1',function(err,key){
     if(err){
       return callback(err);
     }


### PR DESCRIPTION
Updates `crypto.pbkdf2` call to use an explicit digest, to prevent a Node v6+ deprecation warning. It uses `sha1`, which used to be the default value in previous versions, so behaviour will remain unchanged.

Added a special `try-catch` to support Node `0.10.*`, because its version of `crypto` does not support the `digest` parameter at all. It can freely be removed once we dump `0.10.*`.

Fixes #541 