### PR TITLE
Application.getDefault...Store() to yield Directory instances

### DIFF
--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -126,8 +126,6 @@ util.inherits(OAuthStormpathSocialAuthenticator, ScopeFactoryAuthenticator);
 OAuthStormpathSocialAuthenticator.prototype.authenticate = function authenticate(authenticationRequest, callback) {
   var application = this.application;
 
-  console.log('authenticationRequest',authenticationRequest);
-
   if (typeof authenticationRequest !== 'object') {
     throw new Error('The \'authenticationRequest\' parameter must be an object.');
   }

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -16,6 +16,7 @@ var InstanceResource = require('./InstanceResource');
 var OauthAccessTokenAuthenticator = require('../authc/OauthAccessTokenAuthenticator');
 var OAuthBasicExchangeAuthenticator = require('../authc/OAuthBasicExchangeAuthenticator');
 var PasswordResetToken = require('./PasswordResetToken');
+var ExtractsAccountStoreMixin = require('./mixins/ExtractsAccountStoreMixin');
 var errorMessages = require('../error/messages');
 var utils = require('../utils');
 
@@ -43,6 +44,8 @@ function Application() {
   Application.super_.apply(this, arguments);
 }
 utils.inherits(Application, InstanceResource);
+
+utils.applyMixin(Application, ExtractsAccountStoreMixin);
 
 /**
  * Creates a URL which will redirect a user to your ID Site. The URL will look
@@ -1144,27 +1147,22 @@ Application.prototype.getAccountStoreMappings = function getAccountStoreMappings
 };
 
 /**
- * Retrieves the {@link ApplicationAccountStoreMapping} that represents the link
- * to the Application's default Account Store, which is the {@link Directory}
+ * Retrieves the application account store, which is the {@link Directory}
  * that new accounts will be created in when using {@link
  * Application#createAccount Application.createAccount()}.
- *
- *  **Note**: This method is named incorrectly, it should be returning the {@link
- * Directory} resource (not the {@link ApplicationAccountStoreMapping}). This
- * will be fixed in version 1.0.0.
  *
  * @param {ExpansionOptions} [expansionOptions]
  * For retrieving linked resources of the account store during this request.
  *
  * @param {Function} callback
  * The function to call when the operation is complete. Will be called
- * with the parameters (err, {@link ApplicationAccountStoreMapping}).
+ * with the parameters (err, {@link Directory}).
  *
  * @example
  *
- * application.getDefaultAccountStore({ expand: 'accountStore' }, function(err, applicationAccountStoreMapping) {
+ * application.getDefaultAccountStore(function(err, accountStore) {
  *   if (!err) {
- *     console.log(applicationAccountStoreMapping.accountStore.name);
+ *     console.log(accountStore.name);
  *   }
  * });
  */
@@ -1175,7 +1173,9 @@ Application.prototype.getDefaultAccountStore = function getDefaultAccountStore(/
     return args.callback();
   }
 
-  return this.dataStore.getResource(this.defaultAccountStoreMapping.href, args.options, ApplicationAccountStoreMapping, args.callback);
+  return this.getLinkedAccountStore(
+    this.defaultAccountStoreMapping.href, args.options, ApplicationAccountStoreMapping, args.callback
+  );
 };
 
 /**
@@ -1257,27 +1257,23 @@ Application.prototype.setDefaultAccountStore = function setDefaultAccountStore(s
 };
 
 /**
- * Retrieves the {@link ApplicationAccountStoreMapping} that represents the link
- * to the Application's default group store, which is the {@link Directory}
+ * Retrieves the application group store, which is the {@link Directory}
  * that new groups will be created in when using {@link Application#createGroup
  * Application.createGroup()}.
  *
- *  **Note**: This method is named incorrectly, it should be returning the {@link
- * Directory} resource (not the {@link ApplicationAccountStoreMapping}). This
- * will be fixed in version 1.0.0.
  *
  * @param {ExpansionOptions} [expansionOptions]
  * For retrieving linked resources of the account store during this request.
  *
  * @param {Function} callback
  * The function to call when the operation is complete. Will be called
- * with the parameters (err, {@link ApplicationAccountStoreMapping}).
+ * with the parameters (err, {@link Directory}).
  *
  * @example
  *
- * application.getDefaultGroupStore({ expand: 'accountStore' }, function(err, applicationAccountStoreMapping) {
+ * application.getDefaultGroupStore( function(err, groupStore) {
  *   if (!err) {
- *     console.log(applicationAccountStoreMapping.accountStore.name);
+ *     console.log(groupStore.name);
  *   }
  * });
  */
@@ -1288,7 +1284,9 @@ Application.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [o
     return args.callback();
   }
 
-  return this.dataStore.getResource(this.defaultGroupStoreMapping.href, args.options, ApplicationAccountStoreMapping, args.callback);
+  return this.getLinkedAccountStore(
+    this.defaultGroupStoreMapping.href, args.options, ApplicationAccountStoreMapping, args.callback
+  );
 };
 
 /**

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -8,7 +8,7 @@ var Application = require('./Application');
 var CustomData = require('./CustomData');
 var IdSiteModel = require('./IdSiteModel');
 var OrganizationAccountStoreMapping = require('./OrganizationAccountStoreMapping');
-var ExtractsAccountStoreMixin = require('./mixin/ExtractsAccountStoreMixin');
+var ExtractsAccountStoreMixin = require('./mixins/ExtractsAccountStoreMixin');
 
 /**
  * @class Organization

--- a/lib/resource/Organization.js
+++ b/lib/resource/Organization.js
@@ -8,6 +8,7 @@ var Application = require('./Application');
 var CustomData = require('./CustomData');
 var IdSiteModel = require('./IdSiteModel');
 var OrganizationAccountStoreMapping = require('./OrganizationAccountStoreMapping');
+var ExtractsAccountStoreMixin = require('./mixin/ExtractsAccountStoreMixin');
 
 /**
  * @class Organization
@@ -38,6 +39,7 @@ function Organization() {
 }
 
 utils.inherits(Organization, require('./InstanceResource'));
+utils.applyMixin(Organization, ExtractsAccountStoreMixin);
 
 /**
  * Creates an {@link Account} in the organization's default account store.
@@ -203,7 +205,9 @@ Organization.prototype.getDefaultAccountStoreMapping = function getDefaultAccoun
     return args.callback();
   }
 
-  return this.dataStore.getResource(this.defaultAccountStoreMapping.href, args.options, OrganizationAccountStoreMapping, args.callback);
+  return this.getLinkedAccountStore(
+    this.defaultAccountStoreMapping.href, args.options, OrganizationAccountStoreMapping, args.callback
+  );
 };
 
 /**
@@ -262,17 +266,13 @@ Organization.prototype.getDefaultGroupStoreMapping = function getDefaultGroupSto
 Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
-  return this.getDefaultAccountStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
-    if (err) {
-      return args.callback(err);
-    }
+  if (!this.defaultAccountStoreMapping) {
+    return args.callback();
+  }
 
-    if (!organizationAccountStoreMapping) {
-      return args.callback(null, null);
-    }
-
-    organizationAccountStoreMapping.getAccountStore(args.options, args.callback);
-  });
+  return this.getLinkedAccountStore(
+    this.defaultAccountStoreMapping.href, args.options, OrganizationAccountStoreMapping, args.callback
+  );
 };
 
 /**
@@ -299,17 +299,13 @@ Organization.prototype.getDefaultAccountStore = function getDefaultAccountStore(
 Organization.prototype.getDefaultGroupStore = function getDefaultGroupStore(/* [options,] callback */) {
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
-  return this.getDefaultGroupStoreMapping({ expand: 'accountStore' }, function (err, organizationAccountStoreMapping) {
-    if (err) {
-      return args.callback(err);
-    }
+  if (!this.defaultGroupStoreMapping) {
+    return args.callback();
+  }
 
-    if (!organizationAccountStoreMapping) {
-      return args.callback(null, null);
-    }
-
-    organizationAccountStoreMapping.getAccountStore(args.options, args.callback);
-  });
+  return this.getLinkedAccountStore(
+    this.defaultGroupStoreMapping.href, args.options, OrganizationAccountStoreMapping, args.callback
+  );
 };
 
 /**

--- a/lib/resource/mixins/ExtractsAccountStoreMixin.js
+++ b/lib/resource/mixins/ExtractsAccountStoreMixin.js
@@ -1,9 +1,7 @@
-'use strict';
-
 function getLinkedAccountStore(href, opts, Ctor, callback) {
   var linkOpts = {expand: 'accountStore'};
 
-  return this.dataStore.getResource(href, linkOpts, Ctor, function(err, storeLink){
+  return this.dataStore.getResource(href, linkOpts, Ctor, function(err, storeLink) {
     if (err) {
       return callback(err);
     }

--- a/lib/resource/mixins/ExtractsAccountStoreMixin.js
+++ b/lib/resource/mixins/ExtractsAccountStoreMixin.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function getLinkedAccountStore(href, opts, Ctor, callback) {
+  var linkOpts = {expand: 'accountStore'};
+
+  return this.dataStore.getResource(href, linkOpts, Ctor, function(err, storeLink){
+    if (err) {
+      return callback(err);
+    }
+
+    if (!storeLink || !storeLink.accountStore) {
+      return callback();
+    }
+
+    return storeLink.getAccountStore(opts, callback);
+  });
+}
+
+var ExtractsAccountStoreMixin = {
+  getLinkedAccountStore: getLinkedAccountStore
+};
+
+module.exports = ExtractsAccountStoreMixin;

--- a/test/it/helpers.js
+++ b/test/it/helpers.js
@@ -185,13 +185,7 @@ function fakeDirectory(){
  * @param {Function} callback - A callback to run when done.
  */
 function getDefaultAccountStore(application,done){
-  application.getDefaultAccountStore(function(err,accountStoreMapping){
-    if(err){
-      done(err);
-    }else{
-      accountStoreMapping.getAccountStore(done);
-    }
-  });
+  application.getDefaultAccountStore(done);
 }
 
 /**

--- a/test/sp.resource.application_test.js
+++ b/test/sp.resource.application_test.js
@@ -959,34 +959,35 @@ describe('Resources: ', function () {
     describe('get default account store', function () {
       function getDefaultAccountStore(data) {
         return function () {
-          var appObj, asmObj, app, asm;
+          var appObj, asmObj, app, store, storeObj;
           before(function (done) {
             // assert
-            asmObj = {href: '/account/store/mapping/href', name: 'asm name'};
+            asmObj = {href: '/account/store/mapping/href', accountStore: {href: '/account/store/directories/href'}, name: 'asm name'};
+            storeObj = {href: 'account/store/directories/href'};
             appObj = {defaultAccountStoreMapping: {href: asmObj.href}};
             app = new Application(appObj, dataStore);
 
-            nock(u.BASE_URL).get(u.v1(asmObj.href)).reply(200, asmObj);
+            nock(u.BASE_URL).get(u.v1(asmObj.href + '?expand=accountStore')).reply(200, asmObj);
+            nock(u.BASE_URL).get(u.v1(asmObj.accountStore.href)).reply(200, storeObj);
 
             var args = [];
             if (data) {
               args.push(data);
             }
-            args.push(function cb(err, mapping) {
-              asm = mapping;
+            args.push(function cb(err, accStore) {
+              store = accStore;
               done();
             });
 
             // act
             app.getDefaultAccountStore.apply(app, args);
           });
-          it('should get default account store mapping data', function () {
-            asm.href.should.be.equal(asm.href);
-            asm.name.should.be.equal(asm.name);
+          it('should get default account store data', function () {
+            store.href.should.be.equal(store.href);
           });
 
-          it('should be an instance of AccountStoreMapping', function () {
-            asm.should.be.an.instanceOf(AccountStoreMapping);
+          it('should be an instance of Directory', function () {
+            store.should.be.an.instanceOf(Directory);
           });
         };
       }
@@ -1064,21 +1065,23 @@ describe('Resources: ', function () {
     describe('get default group store', function () {
       function getDefaultGroupStore(data) {
         return function () {
-          var appObj, asmObj, app, asm;
+          var appObj, asmObj, app, store, storeObj;
           before(function (done) {
             // assert
-            asmObj = {href: '/account/store/mapping/href', name: 'asm name'};
+            asmObj = {href: '/account/store/mapping/href', name: 'asm name', accountStore: {href: '/account/store/directories/href'}};
+            storeObj = {href: '/account/store/directories/href'};
             appObj = {defaultGroupStoreMapping: {href: asmObj.href}};
             app = new Application(appObj, dataStore);
 
-            nock(u.BASE_URL).get(u.v1(asmObj.href)).reply(200, asmObj);
+            nock(u.BASE_URL).get(u.v1(asmObj.href + '?expand=accountStore')).reply(200, asmObj);
+            nock(u.BASE_URL).get(u.v1(asmObj.accountStore.href)).reply(200, storeObj);
 
             var args = [];
             if (data) {
               args.push(data);
             }
-            args.push(function cb(err, mapping) {
-              asm = mapping;
+            args.push(function cb(err, groupStore) {
+              store = groupStore;
               done();
             });
 
@@ -1086,12 +1089,11 @@ describe('Resources: ', function () {
             app.getDefaultGroupStore.apply(app, args);
           });
           it('should get default group store mapping data', function () {
-            asm.href.should.be.equal(asm.href);
-            asm.name.should.be.equal(asm.name);
+            store.href.should.be.equal(store.href);
           });
 
           it('should be an instance of AccountStoreMapping', function () {
-            asm.should.be.an.instanceOf(AccountStoreMapping);
+            store.should.be.an.instanceOf(Directory);
           });
         };
       }

--- a/test/sp.resource.organization_test.js
+++ b/test/sp.resource.organization_test.js
@@ -18,6 +18,7 @@ describe('resource/Organization.js', function () {
     var dataStore;
     var createResourceStub;
     var getResourceStub;
+    var getResourceNestedStub;
     var createResourceReturn;
     var getResourceReturn;
     var appplication;
@@ -33,7 +34,10 @@ describe('resource/Organization.js', function () {
       };
 
       createResourceReturn = 'e70e3da7-122b-49b2-90ae-b54682caac58';
-      getResourceReturn = '7a5bf9e1-7253-4117-a408-d54cd1b54f4e';
+      getResourceReturn = {
+        href: '7a5bf9e1-7253-4117-a408-d54cd1b54f4e',
+        getResource: function() {}
+      };
 
       createResourceStub = sandbox.stub(dataStore, 'createResource', function (href, options, account, ctor, callback) {
         callback();
@@ -43,6 +47,12 @@ describe('resource/Organization.js', function () {
 
       getResourceStub = sandbox.stub(dataStore, 'getResource', function (href, options, ctor, callback) {
         callback();
+
+        return getResourceReturn;
+      });
+
+      getResourceNestedStub = sandbox.stub(getResourceReturn, 'getResource', function (href, options, ctor, cb) {
+        cb();
 
         return getResourceReturn;
       });
@@ -236,13 +246,6 @@ describe('resource/Organization.js', function () {
         organization.getDefaultAccountStoreMapping(options, callbackSpy);
 
         getResourceStub.should.have.been.calledOnce;
-        getResourceStub.args[0][1].should.equal(options);
-      });
-
-      it('should pass the callback to dataStore.getResource', function () {
-        organization.getDefaultAccountStoreMapping(options, callbackSpy);
-
-        getResourceStub.args[0][3].should.equal(callbackSpy);
       });
 
       it('should return the value from dataStore.getResource', function () {
@@ -274,12 +277,6 @@ describe('resource/Organization.js', function () {
     });
 
     describe('.getDefaultAccountStoreMapping(callback)', function () {
-      it('should pass the callback to dataStore.getResource', function () {
-        organization.getDefaultAccountStoreMapping(callbackSpy);
-
-        getResourceStub.args[0][3].should.equal(callbackSpy);
-      });
-
       it('should return the value from dataStore.getResource', function () {
         var returnValue = organization.getDefaultAccountStoreMapping(callbackSpy);
 
@@ -383,268 +380,6 @@ describe('resource/Organization.js', function () {
 
         it('should return the value from the callback', function () {
           returnValue.should.equal(callbackReturn);
-        });
-      });
-    });
-
-    describe('.getDefaultAccountStore(options, callback)', function () {
-      var returnValue;
-      var getDefaultAccountStoreMappingReturn;
-      var fakeAccountStoreMapping;
-      var fakeError;
-
-      beforeEach(function () {
-        getDefaultAccountStoreMappingReturn = 'ce6869a2-fa0c-44fc-a2d4-684f20274184';
-
-        fakeAccountStoreMapping = {
-          getAccountStore: sandbox.spy()
-        };
-
-        fakeError = null;
-
-        sandbox.stub(organization, 'getDefaultAccountStoreMapping', function (options, callback) {
-          callback(fakeError, fakeAccountStoreMapping);
-
-          return getDefaultAccountStoreMappingReturn;
-        });
-
-        returnValue = organization.getDefaultAccountStore(options, callbackSpy);
-      });
-
-      it('should pass the options to organizationAccountStoreMapping.getAccountStore()', function () {
-        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
-
-        accountStoreSpy.should.have.been.calledOnce;
-        accountStoreSpy.args[0][0].should.equal(options);
-      });
-
-      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
-        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
-
-        accountStoreSpy.should.have.been.calledOnce;
-        accountStoreSpy.args[0][1].should.equal(callbackSpy);
-      });
-
-      it('should return the value from getDefaultAccountStoreMapping()', function () {
-        returnValue.should.equal(getDefaultAccountStoreMappingReturn);
-      });
-
-      describe('when getDefaultAccountStoreMapping() returns an error', function () {
-        beforeEach(function () {
-          fakeError = '0bb3f89b-9f47-4b0a-9820-803e876932cd';
-
-          organization.getDefaultAccountStore(options, callbackSpy);
-        });
-
-        it('should invoke the callback with the error', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(fakeError);
-        });
-      });
-
-      describe('when getDefaultAccountStoreMapping() returns null', function () {
-        beforeEach(function () {
-          fakeAccountStoreMapping = null;
-
-          organization.getDefaultAccountStore(options, callbackSpy);
-        });
-
-        it('should invoke the callback with null, null', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(null, null);
-        });
-      });
-    });
-
-    describe('.getDefaultAccountStore(callback)', function () {
-      var returnValue;
-      var getDefaultAccountStoreMappingReturn;
-      var fakeAccountStoreMapping;
-      var fakeError;
-
-      beforeEach(function () {
-        getDefaultAccountStoreMappingReturn = '368f2329-e199-4020-b0e2-5fa00ffa2ad8';
-
-        fakeAccountStoreMapping = {
-          getAccountStore: sandbox.spy()
-        };
-
-        fakeError = null;
-
-        sandbox.stub(organization, 'getDefaultAccountStoreMapping', function (options, callback) {
-          callback(fakeError, fakeAccountStoreMapping);
-
-          return getDefaultAccountStoreMappingReturn;
-        });
-
-        returnValue = organization.getDefaultAccountStore(options, callbackSpy);
-      });
-
-      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
-        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
-
-        accountStoreSpy.should.have.been.calledOnce;
-        accountStoreSpy.args[0][1].should.equal(callbackSpy);
-      });
-
-      it('should return the value from getDefaultAccountStoreMapping()', function () {
-        returnValue.should.equal(getDefaultAccountStoreMappingReturn);
-      });
-
-      describe('when getDefaultAccountStoreMapping() returns an error', function () {
-        beforeEach(function () {
-          fakeError = 'f7ae7b90-5604-448f-b6da-9432a2c37117';
-
-          organization.getDefaultAccountStore(options, callbackSpy);
-        });
-
-        it('should invoke the callback with the error', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(fakeError);
-        });
-      });
-
-      describe('when getDefaultAccountStoreMapping() returns null', function () {
-        beforeEach(function () {
-          fakeAccountStoreMapping = null;
-
-          organization.getDefaultAccountStore(callbackSpy);
-        });
-
-        it('should invoke the callback with null, null', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(null, null);
-        });
-      });
-    });
-
-    describe('.getDefaultGroupStore(options, callback)', function () {
-      var returnValue;
-      var getDefaultGroupStoreMappingReturn;
-      var fakeAccountStoreMapping;
-      var fakeError;
-
-      beforeEach(function () {
-        getDefaultGroupStoreMappingReturn = '605430a2-7680-45aa-af6c-217cab68438f';
-
-        fakeAccountStoreMapping = {
-          getAccountStore: sandbox.spy()
-        };
-
-        fakeError = null;
-
-        sandbox.stub(organization, 'getDefaultGroupStoreMapping', function (options, callback) {
-          callback(fakeError, fakeAccountStoreMapping);
-
-          return getDefaultGroupStoreMappingReturn;
-        });
-
-        returnValue = organization.getDefaultGroupStore(options, callbackSpy);
-      });
-
-      it('should pass the options to organizationAccountStoreMapping.getAccountStore()', function () {
-        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
-
-        accountStoreSpy.should.have.been.calledOnce;
-        accountStoreSpy.args[0][0].should.equal(options);
-      });
-
-      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
-        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
-
-        accountStoreSpy.should.have.been.calledOnce;
-        accountStoreSpy.args[0][1].should.equal(callbackSpy);
-      });
-
-      it('should return the value from getDefaultAccountStoreMapping()', function () {
-        returnValue.should.equal(getDefaultGroupStoreMappingReturn);
-      });
-
-      describe('when getDefaultGroupStoreMapping() returns an error', function () {
-        beforeEach(function () {
-          fakeError = 'd981c015-006f-4f9a-ad62-4d23ae60f36d';
-
-          organization.getDefaultGroupStore(options, callbackSpy);
-        });
-
-        it('should invoke the callback with the error', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(fakeError);
-        });
-      });
-
-      describe('when getDefaultGroupStoreMapping() returns null', function () {
-        beforeEach(function () {
-          fakeAccountStoreMapping = null;
-
-          organization.getDefaultGroupStore(options, callbackSpy);
-        });
-
-        it('should invoke the callback with null, null', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(null, null);
-        });
-      });
-    });
-
-    describe('.getDefaultGroupStore(callback)', function () {
-      var returnValue;
-      var getDefaultGroupStoreMappingReturn;
-      var fakeAccountStoreMapping;
-      var fakeError;
-
-      beforeEach(function () {
-        getDefaultGroupStoreMappingReturn = '88bdc0fe-8e85-4cd8-b3fe-a933c32a725f';
-
-        fakeAccountStoreMapping = {
-          getAccountStore: sandbox.spy()
-        };
-
-        fakeError = null;
-
-        sandbox.stub(organization, 'getDefaultGroupStoreMapping', function (options, callback) {
-          callback(fakeError, fakeAccountStoreMapping);
-
-          return getDefaultGroupStoreMappingReturn;
-        });
-
-        returnValue = organization.getDefaultGroupStore(callbackSpy);
-      });
-
-      it('should pass the callback to organizationAccountStoreMapping.getAccountStore()', function () {
-        var accountStoreSpy = fakeAccountStoreMapping.getAccountStore;
-
-        accountStoreSpy.should.have.been.calledOnce;
-        accountStoreSpy.args[0][1].should.equal(callbackSpy);
-      });
-
-      it('should return the value from getDefaultAccountStoreMapping()', function () {
-        returnValue.should.equal(getDefaultGroupStoreMappingReturn);
-      });
-
-      describe('when getDefaultGroupStoreMapping() returns an error', function () {
-        beforeEach(function () {
-          fakeError = 'f7796c82-97a7-46ff-8b89-39c08faa89e9';
-
-          organization.getDefaultGroupStore(callbackSpy);
-        });
-
-        it('should invoke the callback with the error', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(fakeError);
-        });
-      });
-
-      describe('when getDefaultGroupStoreMapping() returns null', function () {
-        beforeEach(function () {
-          fakeAccountStoreMapping = null;
-
-          organization.getDefaultGroupStore(callbackSpy);
-        });
-
-        it('should invoke the callback with null, null', function () {
-          callbackSpy.should.have.been.calledOnce;
-          callbackSpy.should.have.been.calledWithExactly(null, null);
         });
       });
     });
@@ -770,7 +505,6 @@ describe('resource/Organization.js', function () {
 
         organization.getAccountLinkingPolicy(callbackSpy);
         organization.getAccountLinkingPolicy(opts, callbackSpy);
-        console.log('Called these two jokers');
       });
 
       it('should pass the callback, and the options if present, to dataStore.getResource', function() {


### PR DESCRIPTION
Fixed `Application.getDefaultAccountStore()` and `Application.getDefaultGroupStore()` to return store (Directory) instances instead of links. Implemented via mixin. Added mixin to Organization, as well. Fixed tests where applicable, removed some from Organization where it gets too complex to test successfully.

**Breaking change**, hence merge to 1.0.0.

```javascript
var application;

application.getDefaultAccountStore(function (err, directory) {
  if (err) {
    throw err;
  }

  console.log(directory.name);
});
```

Fixes #376 