### PR TITLE
Collection resource update

### DIFF
--- a/lib/resource/CollectionResource.js
+++ b/lib/resource/CollectionResource.js
@@ -268,28 +268,9 @@ utils.inherits(CollectionResource, Resource);
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
  *   if (!err) {
- *     collection.concat(iterator, donCallback);
+ *     collection.concat(iterator, doneCallback);
  *   }
  * });
- */
-
-/**
- * @name CollectionResource#concatLimit
- *
- * @function
- *
- * @description
- * The same interface as `concat`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#concat concat}.
- *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#concat concat}.
  */
 
 /**
@@ -320,52 +301,31 @@ utils.inherits(CollectionResource, Resource);
  *
  * @param {Function} iterator
  * The function to call, for each resource in the collection. Will be called
- * with `(resource, next)`. The `next(err, test)` function must be called to
+ * with `(resource, next)`. The `next(test)` function must be called to
  * advance to the next resource. Iteration is ended as soon as a truthy value
- * is provided to either `err` or `test`.
+ * is provided to `test`.
  *
  * @param {Function} doneCallback
- * The function to call when iteration has ended. Will be called with `(err,
- * foundResource)`.
+ * The function to call when iteration has ended. Will be called with
+ * `(foundResource)`.
  *
  * @example
  * // Find the first account that likes pizza.
  *
  * function iterator(account, next) {
- *   next(null, account.customData.favoriteFood === 'pizza');
+ *   next(account.customData.favoriteFood === 'pizza');
  * }
  *
- * function doneCallback(err, foundAccount) {
- *   if (!err) {
- *     console.log('Guess who likes pizza??').
- *     console.log(foundAccount.fullName);
- *   }
+ * function doneCallback(foundAccount) {
+ *   console.log('Guess who likes pizza??');
+ *   console.log(foundAccount.email);
  * }
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
  *   if (!err) {
- *     collection.detect(iterator, donCallback);
+ *     collection.detect(iterator, doneCallback);
  *   }
  * });
- */
-
-/**
- * @name CollectionResource#detectLimit
- *
- * @function
- *
- * @description
- * The same interface as `detect`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#detect detect}.
- *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#detect detect}.
  */
 
 /**
@@ -412,7 +372,7 @@ utils.inherits(CollectionResource, Resource);
  *
  * function doneCallback(err) {
  *   if (!err) {
- *     console.log('All accounts have been visited.').
+ *     console.log('All accounts have been visited.');
  *   }
  * }
  *
@@ -469,68 +429,31 @@ utils.inherits(CollectionResource, Resource);
  *
  * @param {Function} iterator
  * The function to call, for each resource in the collection. Will be called
- * with `(resource, next)`. The `next(err, test)` function must be called to
- * advance to the next resource. If an `err` value is passed to next, the
- * iteration will stop and the `doneCallback` will be called with the `err`
- * value.
+ * with `(resource, next)`. The `next(test)` function must be called to
+ * advance to the next resource.
  *
  * @param {Function} doneCallback
- * The function to call when iteration has ended. Will be called with `(err,
- * test)`.
+ * The function to call when iteration has ended. Will be called with
+ * `(test)`.
  *
  * @example
  * // Does everyone like Brie cheese?
  *
  * function iterator(account, next) {
- *   next(null, account.customData.likesBrie === true);
+ *   next(account.customData.likesBrie === true);
  * }
  *
- * function doneCallback(err, test) {
- *   if (!err && test === true) {
+ * function doneCallback(test) {
+ *   if (test === true) {
  *     console.log('Everyone likes Brie??');
  *   }
  * }
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
  *   if (!err) {
- *     collection.every(iterator, donCallback);
+ *     collection.every(iterator, doneCallback);
  *   }
  * });
- */
-
-/**
- * @name CollectionResource#everyLimit
- *
- * @function
- *
- * @description
- * The same interface as `every`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#every every}.
- *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#every every}.
- */
-
-/**
- * @name CollectionResource#everySeries
- *
- * @function
- *
- * @description
- * The same interface as `every`, but the `iterator` will be called in series,
- * not in parallel.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#every every}.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#every every}.
  */
 
 /**
@@ -545,29 +468,24 @@ utils.inherits(CollectionResource, Resource);
  *
  * @param {Function} iterator
  * The function to call for each resource in the collection. Will be called
- * with `(resource, next)`. The `next(err, test)` function must be called in order to
+ * with `(resource, next)`. The `next(test)` function must be called in order to
  * advance to the next resource. The `test` value should be a boolean value that
  * indicates if the resource should be included in the filtered collection.
  *
- * If an `err` value is passed to next, the iteration will stop and the
- * `doneCallback` will be called with the `err` value.
- *
  * @param {Function} doneCallback
  * The function to call when all items have been visited. Will be called with
- * `(err, [filteredResources])`.
+ * `([filteredResources])`.
  *
  * @example
- * // Find all accounts that have the 'paid' plan property, in custom data.
+ * // Find all accounts that have the 'paid' plan property in custom data.
  *
  * function iterator(account, next) {
- *   next(null, account.customData.plan === 'paid');
+ *   next(account.customData.plan === 'paid');
  * }
  *
- * function doneCallback(err, paidAccounts) {
- *   if (!err) {
- *     console.log('All paid accounts:').
- *     console.log(paidAccounts);
- *   }
+ * function doneCallback(paidAccounts) {
+ *   console.log('All paid accounts:');
+ *   console.log(paidAccounts);
  * }
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
@@ -575,25 +493,6 @@ utils.inherits(CollectionResource, Resource);
  *     collection.filter(iterator, doneCallback);
  *   }
  * });
- */
-
-/**
- * @name CollectionResource#filterLimit
- *
- * @function
- *
- * @description
- * The same interface as `filter`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#filter filter}.
- *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#filter filter}.
  */
 
 /**
@@ -641,7 +540,7 @@ utils.inherits(CollectionResource, Resource);
  *
  * function doneCallback(err, emails) {
  *   if (!err) {
- *     console.log('All email addresses in this application:').
+ *     console.log('All email addresses in this application:');
  *     console.log(emails);
  *   }
  * }
@@ -698,8 +597,8 @@ utils.inherits(CollectionResource, Resource);
  * to a new value. The `iterator` will be called in parallel.
  *
  * @param {*} initialValue
- * The initial value that will then be passed to the `iterator` as `result`,
- * this is the value that you will mutate over time as the iterator is called
+ * The initial value that will then be passed to the `iterator` as `result`.
+ * This is the value that you will mutate over time as the iterator is called
  * with every resource in the collection.
  *
  * @param {Function} iterator
@@ -721,7 +620,7 @@ utils.inherits(CollectionResource, Resource);
  *   if (result.indexOf(color) === -1) {
  *     result.push(color);
  *   }
- *   return result;
+ *   return next(null, result);
  * }
  *
  * function doneCallback(err, colors) {
@@ -732,7 +631,7 @@ utils.inherits(CollectionResource, Resource);
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
  *   if (!err) {
- *     collection.reduce([], iterator, donCallback);
+ *     collection.reduce([], iterator, doneCallback);
  *   }
  * });
  */
@@ -771,25 +670,24 @@ utils.inherits(CollectionResource, Resource);
  *
  * @param {Function} doneCallback
  * Same interface as {@link CollectionResource#filter filter}.
- */
-
-/**
- * @name CollectionResource#rejectLimit
  *
- * @function
+ * @example
+ * // Find all accounts that don't have the 'paid' plan property in custom data.
  *
- * @description
- * The same interface as `reject`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
+ * function iterator(account, next) {
+ *   next(account.customData.plan === 'paid');
+ * }
  *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#reject reject}.
+ * function doneCallback(paidAccounts) {
+ *   console.log('All unpaid accounts:');
+ *   console.log(paidAccounts);
+ * }
  *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#reject reject}.
+ * application.getAccounts({ expand: 'customData' }, function (err, collection) {
+ *   if (!err) {
+ *     collection.reject(iterator, doneCallback);
+ *   }
+ * });
  */
 
 /**
@@ -820,68 +718,31 @@ utils.inherits(CollectionResource, Resource);
  *
  * @param {Function} iterator
  * The function to call for each resource in the collection. Will be called
- * with `(resource, next)`. The `next(err, test)` function must be called to
- * advance to the next resource. If an `err` value is passed to next, the
- * iteration will stop and the `doneCallback` will be called with the `err`
- * value.
+ * with `(resource, next)`. The `next(test)` function must be called to
+ * advance to the next resource.
  *
  * @param {Function} doneCallback
- * The function to call when iteration has ended. Will be called with `(err,
- * test)`.
+ * The function to call when iteration has ended. Will be called with
+ * `(test)`.
  *
  * @example
  * // Does anyone like Brie cheese?
  *
  * function iterator(account, next) {
- *   next(null, account.customData.likesBrie === true);
+ *   next(account.customData.likesBrie === true);
  * }
  *
  * function doneCallback(err, test) {
- *   if (!err && test === true) {
+ *   if (test === true) {
  *     console.log('Some people like Brie.');
  *   }
  * }
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
  *   if (!err) {
- *     collection.some(iterator, donCallback);
+ *     collection.some(iterator, doneCallback);
  *   }
  * });
- */
-
-/**
- * @name CollectionResource#someLimit
- *
- * @function
- *
- * @description
- * The same interface as `some`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#some some}.
- *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#some some}.
- */
-
-/**
- * @name CollectionResource#someSeries
- *
- * @function
- *
- * @description
- * The same interface as `some`, but the `iterator` will be called in series,
- * not in parallel.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#some some}.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#some some}.
  */
 
 /**
@@ -920,44 +781,9 @@ utils.inherits(CollectionResource, Resource);
  *
  * application.getAccounts({ expand: 'customData' }, function (err, collection) {
  *   if (!err) {
- *     collection.sortBy(iterator, donCallback);
+ *     collection.sortBy(iterator, doneCallback);
  *   }
  * });
- */
-
-/**
- * @name CollectionResource#sortByLimit
- *
- * @function
- *
- * @description
- * The same interface as `sortBy`, but with a 2nd parameter that can be used to
- * limit the number of parallel workers.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#sortBy sortBy}.
- *
- * @param {Number} limit
- * The maximum number of parallel iterator workers.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#sortBy sortBy}.
- */
-
-/**
- * @name CollectionResource#sortBySeries
- *
- * @function
- *
- * @description
- * The same interface as `sortBy`, but the `iterator` will be called in series,
- * not in parallel.
- *
- * @param {Function} iterator
- * Same interface as {@link CollectionResource#sortBy sortBy}.
- *
- * @param {Function} doneCallback
- * Same interface as {@link CollectionResource#sortBy sortBy}.
  */
 (function extendCollectionResourceWithAsyncMethods(){
 


### PR DESCRIPTION
Fixed broken collection resource method examples and removed docs for the methods that don't exist (collection.concatLimit(), collection.detectLimit(), collection.everyLimit(), collection.everySeries(), collection.filterLimit(),collection.mapLimit(), collection.rejectLimit(), collection.someLimit(), collection.someSeries(),collection.sortByLimit(), collection.sortBySeries()). 

One thing to note, there are still some methods remaining that don't work as expected (all of the limit() methods, like collection.eachLimit() and collection.mapLimit()). The docs say they're supposed to be exactly like their parent methods but with an iterator, so for ex, eachLimit should look like this: 

```
    function iterator(account, next) {
      console.log('Found account for ' + account.givenName + ' (' + account.email + ')');
      next();
    }

    function doneCallback(err) {
      if (!err) {
        console.log('All accounts have been visited.');
      }
    }

    application.getAccounts({ email: 'foo@example.com' }, function (err, collection) {
      if (!err) {
        collection.eachLimit(iterator, 2, doneCallback);
      }
    });
```

When I run this, though, it doesn't make it into any of the functions (iterator or doneCallback). Please take a look and let me know if they should be fixed here. 