### PR TITLE
Update tests

### DIFF
--- a/lib/ds/RequestExecutor.js
+++ b/lib/ds/RequestExecutor.js
@@ -30,7 +30,7 @@ function RequestExecutor(options) {
 
   options = options || {};
 
-  this.baseUrl = options.baseUrl || 'https://api.stormpath.com/v1';
+  this.baseUrl = options.baseUrl || options.client && options.client.baseUrl || 'https://api.stormpath.com/v1';
 
   this.requestAuthenticator = authc.getAuthenticator(options);
 

--- a/lib/oauth/stormpath-social.js
+++ b/lib/oauth/stormpath-social.js
@@ -126,8 +126,6 @@ util.inherits(OAuthStormpathSocialAuthenticator, ScopeFactoryAuthenticator);
 OAuthStormpathSocialAuthenticator.prototype.authenticate = function authenticate(authenticationRequest, callback) {
   var application = this.application;
 
-  console.log('authenticationRequest',authenticationRequest);
-
   if (typeof authenticationRequest !== 'object') {
     throw new Error('The \'authenticationRequest\' parameter must be an object.');
   }

--- a/test/it/oauth_stormpath_socal_it.js
+++ b/test/it/oauth_stormpath_socal_it.js
@@ -7,7 +7,6 @@ var helpers = require('./helpers');
 var assert = common.assert;
 
 describe('OAuthStormpathSocialAuthenticator', function () {
-  var account;
   var application;
   var validProviderId;
 
@@ -36,21 +35,7 @@ describe('OAuthStormpathSocialAuthenticator', function () {
           accountStore: {
             href: directory.href
           }
-        }, function (err) {
-          if (err) {
-            return done(err);
-          }
-
-          application.createAccount(helpers.fakeAccount(), function (err, newAccount) {
-            if (err) {
-              return done(err);
-            }
-
-            account = newAccount;
-
-            done();
-          });
-        });
+        }, done);
       });
     });
   });
@@ -178,8 +163,7 @@ describe('OAuthStormpathSocialAuthenticator', function () {
           assert.ok(err);
           assert.equal(err.name, 'ResourceError');
           assert.equal(err.status, 400); // Bad request
-          assert.equal(err.code, 2003); // The specified property value is unsupported.
-          assert.equal(err.developerMessage, 'account providerId is an unsupported value.');
+          assert.equal(err.code, 5201); // No directory found with this id
           assert.notOk(authenticationResult);
           done();
         });
@@ -202,7 +186,6 @@ describe('OAuthStormpathSocialAuthenticator', function () {
           assert.equal(err.name, 'ResourceError');
           assert.equal(err.status, 400); // Bad request
           assert.equal(err.code, 7200); // Stormpath was not able to complete the request to the Social Login site.
-          assert.include(err.developerMessage, 'Stormpath was not able to complete the request to Google');
           assert.notOk(authenticationResult);
           done();
         });
@@ -225,7 +208,6 @@ describe('OAuthStormpathSocialAuthenticator', function () {
           assert.equal(err.name, 'ResourceError');
           assert.equal(err.status, 400); // Bad request
           assert.equal(err.code, 7200); // Stormpath was not able to complete the request to the Social Login site.
-          assert.include(err.developerMessage, 'Stormpath was not able to complete the request to Google');
           assert.notOk(authenticationResult);
           done();
         });

--- a/test/it/saml_idp_url_builder_it.js
+++ b/test/it/saml_idp_url_builder_it.js
@@ -40,7 +40,7 @@ describe('SamlIdpUrlBuilder', function () {
           var parsedUrl = url.parse(resultUrl, true);
 
           assert.ok(parsedUrl);
-          assert.equal(parsedUrl.host, 'api.stormpath.com');
+          assert.equal(parsedUrl.pathname, url.parse(application.href).pathname + '/saml/sso/idpRedirect');
           assert.isDefined(parsedUrl.query.accessToken);
 
           done();

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -67,10 +67,28 @@ describe('Client', function () {
       expect(client._currentTenant).to.be.null;
       /* jshint +W030 */
     });
-    it('should use the public api as the base url',function(){
-      expect(client._dataStore.requestExecutor.baseUrl).to.equal('https://api.stormpath.com/v1');
+    it('should use the public api as the default base url',function(done){
+      // temporarily unset any environment provided url
+      var oldValue = process.env.STORMPATH_CLIENT_BASEURL;
+      delete process.env.STORMPATH_CLIENT_BASEURL;
+      var client = makeTestClient({apiKey: apiKey});
+      client.on('error', function (err) {
+        throw err;
+      });
+
+      client.on('ready', function () {
+        expect(client._dataStore.requestExecutor.baseUrl).to.equal('https://api.stormpath.com/v1');
+        // restore environment value
+        process.env.STORMPATH_CLIENT_BASEURL = oldValue;
+        done();
+      });
+
     });
-    it('should allow me to change the base url',function(done){
+    it('should allow me to change the base url through the constructor',function(done){
+      // temporarily unset any environment provided url
+      var oldValue = process.env.STORMPATH_CLIENT_BASEURL;
+      delete process.env.STORMPATH_CLIENT_BASEURL;
+
       var url = 'http://api.example.com/';
       var client = makeTestClient({apiKey: apiKey, baseUrl: url});
 
@@ -80,6 +98,27 @@ describe('Client', function () {
 
       client.on('ready', function () {
         expect(client._dataStore.requestExecutor.baseUrl).to.equal(url);
+        // restore environment value
+        process.env.STORMPATH_CLIENT_BASEURL = oldValue;
+        done();
+      });
+    });
+
+    it('should allow me to change the base url through the environment',function(done){
+      // temporarily set a new environment provided url, save the old one if it exists
+      var oldValue = process.env.STORMPATH_CLIENT_BASEURL;
+      process.env.STORMPATH_CLIENT_BASEURL = 'https://foo/v1';
+
+      var client = makeTestClient({apiKey: apiKey });
+
+      client.on('error', function (err) {
+        throw err;
+      });
+
+      client.on('ready', function () {
+        expect(client._dataStore.requestExecutor.baseUrl).to.equal('https://foo/v1');
+        // restore environment value
+        process.env.STORMPATH_CLIENT_BASEURL = oldValue;
         done();
       });
     });


### PR DESCRIPTION
* OAuth error messages have changed, we were hard coded to specific strings
* Fixes to allow tests to be run against a different base url, where the base url is defined by the environment