### PR TITLE
Fix issue with .hasOwnProperty in utils.extend()

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -251,6 +251,10 @@ function extend(/* target, src1, src2, ... */) {
   var sources = Array.prototype.slice.call(arguments, 1);
 
   sources.forEach(function(source) {
+    if (!source) {
+      return;
+    }
+
     Object.keys(source).forEach(function(key) {
       if (Object.prototype.hasOwnProperty.call(source, key)) {
         target[key] = source[key];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -252,7 +252,7 @@ function extend(/* target, src1, src2, ... */) {
 
   sources.forEach(function(source) {
     Object.keys(source).forEach(function(key) {
-      if (source.hasOwnProperty(key)) {
+      if (Object.prototype.hasOwnProperty.call(source, key)) {
         target[key] = source[key];
       }
     });

--- a/test/sp.utils_test.js
+++ b/test/sp.utils_test.js
@@ -229,4 +229,83 @@ describe('util', function () {
       assert.isUndefined(Ctor.prototype.explode);
     });
   });
+
+  describe('extend', function() {
+    var objA;
+    var objB;
+    var objC;
+
+    beforeEach(function() {
+      objA = {
+        a: 1
+      };
+      objB = {
+        b: 2
+      };
+      objC = {
+        b: 3,
+        c: 4
+      };
+    });
+
+    it('should merge two objects', function() {
+      var merged = utils.extend({}, objA);
+      assert.notEqual(merged, objA); // Not the same ref
+      assert.deepEqual(merged, objA); // Equal in values
+    });
+
+    it('should merge more objects', function() {
+      var merged = utils.extend({}, objA, objB);
+      assert.deepEqual(merged, {
+        a: 1,
+        b: 2
+      });
+    });
+
+    it('should skip empty values if not the first value', function() {
+      var merged = utils.extend({}, objA, null, objB, null);
+      assert.deepEqual(merged, {
+        a: 1,
+        b: 2
+      });
+    });
+
+    it('should write over the first object', function() {
+      var target = {};
+      var merged = utils.extend(target, objA, objB);
+
+      assert.deepEqual(merged, {
+        a: 1,
+        b: 2
+      });
+
+      assert.equal(merged, target);
+    });
+
+
+    it('should overwrite keys using the later object\'s value', function() {
+      var merged = utils.extend({}, objA, objB, objC);
+
+      assert.deepEqual(merged, {
+        a: 1,
+        b: 3,
+        c: 4
+      });
+    });
+
+    it('should work with objects that have an empty prototype chain', function() {
+      var objX = Object.create(null);
+      objX.x = 7;
+
+      var merge = function() {
+        return utils.extend({}, objA, objX);
+      };
+
+      assert.doesNotThrow(merge);
+      assert.deepEqual(merge(), {
+        a: 1,
+        x: 7
+      });
+    });
+  });
 });


### PR DESCRIPTION
Patches an issue where the `utils.extend` implementation would fail when the object did not have a prototype pointing to `Object`.

Fixes #590 