### PR TITLE
Delete AccessTokenAuthenticator access token

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -426,6 +426,33 @@ Client.prototype.getResource = function() {
 /**
  * @private
  *
+ * @callback deleteResourceCallback
+ *
+ * @param {Error} err
+ * The error (if there is one).
+ */
+
+/**
+ * Deletes a given resource by href.
+ *
+ * @private
+ *
+ * @param {Object} resource
+ * The resource to be deleted.
+ *
+ * @param {String} resource.href
+ * The URI of the resource.
+ *
+ * @param {getResourceCallback}
+ * The callback that handles the response.
+ */
+Client.prototype.deleteResource = function deleteResource() {
+  return this._dataStore.deleteResource.apply(this._dataStore, arguments);
+};
+
+/**
+ * @private
+ *
  * @callback createResourceCallback
  *
  * @param {Error} err

--- a/lib/oauth/stormpath-access-token-authentication-result.js
+++ b/lib/oauth/stormpath-access-token-authentication-result.js
@@ -99,4 +99,17 @@ StormpathAccessTokenAuthenticationResult.prototype.getApplication = function get
   this.client.getApplication(this.application.href, args.options, require('../resource/Application'), args.callback);
 };
 
+/**
+ * @function
+ *
+ * @description Delete the access token used to authenticate.
+ *
+ * @param {Function} callback
+ * The callback to call after the resource is deleted, with parameters (err, null)
+ */
+StormpathAccessTokenAuthenticationResult.prototype.deleteAccessToken = function deleteAccessToken(/* callback */) {
+  var args = utils.resolveArgs(arguments, ['callback']);
+  this.client.deleteResource({href: this.href}, args.callback);
+};
+
 module.exports = StormpathAccessTokenAuthenticationResult;

--- a/test/sp.client_test.js
+++ b/test/sp.client_test.js
@@ -467,6 +467,50 @@ describe('Client', function () {
     });
   });
 
+  describe('call to delete resource', function () {
+    var sandbox;
+    var client;
+    var deleteResourceStub;
+    var cbSpy;
+    var resource;
+
+    before(function (done) {
+      resource = {href: '/boom!'};
+      sandbox = sinon.sandbox.create();
+      client = makeTestClient({apiKey: apiKey});
+
+      client.on('error', function (err) {
+        throw err;
+      });
+
+      client.on('ready', function () {
+        deleteResourceStub = sandbox.stub(client._dataStore, 'deleteResource', function (resource, cb) {
+          cb();
+        });
+
+        cbSpy = sandbox.spy();
+
+        done();
+      });
+    });
+
+    after(function () {
+      sandbox.restore();
+    });
+
+    it('should call dataStore#deleteResource', function () {
+      client.deleteResource(resource, cbSpy);
+
+      deleteResourceStub.should.have.been
+        .calledWith(resource, cbSpy);
+
+      /* jshint -W030 */
+      deleteResourceStub.should.have.been.calledOnce;
+      cbSpy.should.have.been.calledOnce;
+      /* jshint +W030 */
+    });
+  });
+
   describe('call to get accounts', function() {
     var cbSpy, client, err, sandbox, tenant;
     var getCurrentTenantStub, getTenantAccounts;


### PR DESCRIPTION
Adds ability to direct tokens after running a `StormpathAccessTokenAuthenticator.authenticate` directly, by adding `StormpathAccessTokenAuthenticatorResult.deleteAccessToken`.

To implement this, `Client.deleteResource` was added and documented.

Fixes #603 