### PR TITLE
Add Application.getDirectories

### DIFF
--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -12,6 +12,7 @@ var ApplicationAccountStoreMapping = require('./ApplicationAccountStoreMapping')
 var AuthenticationResult = require('./AuthenticationResult');
 var AuthRequestParser = require('../authc/AuthRequestParser');
 var BasicApiAuthenticator = require('../authc/BasicApiAuthenticator');
+var Directory = require('./Directory');
 var InstanceResource = require('./InstanceResource');
 var OauthAccessTokenAuthenticator = require('../authc/OauthAccessTokenAuthenticator');
 var OAuthBasicExchangeAuthenticator = require('../authc/OAuthBasicExchangeAuthenticator');
@@ -1501,6 +1502,41 @@ Application.prototype.getAccountLinkingPolicy = function getApplicationAccountLi
   var args = utils.resolveArgs(arguments, ['options', 'callback'], true);
 
   return this.dataStore.getResource(this.accountLinkingPolicy.href, args.options, require('./AccountLinkingPolicy'), args.callback);
+};
+
+/**
+ * Retrieves the application's linked {@link Directory} instances.
+ *
+ * @param {Function} callback
+ * The function that will be called when the query is finished, with the parameters
+ * (err, [{@link Directory}]).
+ */
+Application.prototype.getDirectories = function getDirectories(/* callback */) {
+  var self = this;
+  var args = utils.resolveArgs(arguments, ['callback'], true);
+
+  this.getAccountStoreMappings({expand: 'accountStore'}, function(err, collection) {
+    if (err) {
+      return args.callback(err);
+    }
+
+    return collection.map(function(accountStoreMapping, next) {
+      next(null, accountStoreMapping.accountStore);
+    }, function(err, accountStores) {
+      if (err) {
+        return args.callback(err);
+      }
+
+      var directories = accountStores.filter(function(store) {
+        // Determines which are directories by URL matching
+        return store && store.href && store.href.match(/\/directories\//);
+      }).map(function(directoryData) {
+        return new Directory(directoryData, self.dataStore);
+      });
+
+      args.callback(null, directories);
+    });
+  });
 };
 
 module.exports = Application;


### PR DESCRIPTION
Adds `Application.getDirectories(cb)` convenience method, as well as tests for it.

This method is just a shorthand for getting all the Directories from the accountStoreMappings and wrapping them into `Directory` instances.

Fixes #194