### PR TITLE
Hotfix/okta get api key reduce function

### DIFF
--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -986,7 +986,7 @@ Application.prototype.getApiKey = function getApiKey(apiKeyId, options, callback
           match = value;
         }
         return match;
-      }).split(':');
+      }, '').split(':');
 
       return cb(null, {
         id: matchedKeyParts[0],

--- a/lib/resource/Application.js
+++ b/lib/resource/Application.js
@@ -986,7 +986,7 @@ Application.prototype.getApiKey = function getApiKey(apiKeyId, options, callback
           match = value;
         }
         return match;
-      }, '').split(':');
+      },'').split(':');
 
       return cb(null, {
         id: matchedKeyParts[0],


### PR DESCRIPTION
Migration from Stormpath to Okta:

A wrong implementation of reduce function when trying to authenticate the user for oauth tokens.

On JS reduce functions the default the InitialValue is the first array value if no value is supplied (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/Reduce?v=control)

As a result, if the first element on Object.keys is the stormpathApiKey_1 or any stormpathApiKey_x then the extracted id and secret is wrong because no value if assigned to first element.

The fix adding an empty string so the reduce function will start with an initialValue and will take all object keys 