### PR TITLE
Okta

### DIFF
--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -651,9 +651,7 @@ Account.prototype.toOktaUser = function toOktaUser(configuration) {
           oktaUser.profile.customData = JSON.stringify(value);
         } else {
           extend(oktaUser.profile, Object.keys(value).reduce(function(result, key) {
-            if(value[key]) {
-              result[key] = value[key];
-            }
+            result[key] = value[key];
             return result;
           }, {}));
         }

--- a/lib/resource/Account.js
+++ b/lib/resource/Account.js
@@ -650,7 +650,12 @@ Account.prototype.toOktaUser = function toOktaUser(configuration) {
         if (configuration.customDataStrategy === 'serialize') {
           oktaUser.profile.customData = JSON.stringify(value);
         } else {
-          extend(oktaUser.profile, dot.dot(value));
+          extend(oktaUser.profile, Object.keys(value).reduce(function(result, key) {
+            if(value[key]) {
+              result[key] = value[key];
+            }
+            return result;
+          }, {}));
         }
         break;
       default:


### PR DESCRIPTION
Allows user to save arrays or any other objects as account customData.
When i tried to save array ["a", "b","c"] as customData.values
dot.dot produced 
"values.0": "a",
"values.1": "b",
"values.2": "c"
As its not valid fields set for okta, it raises 400 error with related message.