### PR TITLE
Incompatible request and uuid versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "njwt": "^0.4.0",
     "properties-parser": "~0.3.1",
     "redis": "~2.6.2",
-    "request": "~2.74.0",
+    "request": "~2.81.0",
     "stormpath-config": "stormpath/stormpath-node-config#okta",
     "underscore": "~1.5.2",
     "underscore.string": "~3.2.3",


### PR DESCRIPTION
In the package.json, you are requiring request 2.74 which depends on a very old/outdated version of uuid (it incorporates it as ```require('node-uuid')```) and is not compatible with the uuid 3.0.0 that you have listed.

The easiest thing (I think) is to bump the request version up to something current (i.e. 2.81.0) and since the APIs are relatively self-contained, I think that this is a pretty low risk change and helps make it work for people (like myself) who are using npm's package-lock versioning.

One related note, I tried to run the tests on the okta branch and they failed (definitely unrelated to the change I'm proposing here). Just thought you might like to know that as well.